### PR TITLE
upgrading beaver-logger, new settings for button js

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "babel-eslint": "^6.0.4",
-    "beaver-logger": "^1.0.11",
+    "beaver-logger": "^2",
     "es6-promise": "^3.1.2",
     "es6-promise-min": "^2.0.1",
     "post-robot": "^4.0.0",

--- a/src/components/button/component.js
+++ b/src/components/button/component.js
@@ -175,7 +175,7 @@ export let Button = xcomponent.create({
 
                     small: {
                         width: 148,
-                        height: 40
+                        height: 48
                     },
 
                     medium: {
@@ -196,7 +196,7 @@ export let Button = xcomponent.create({
         buttonStyle: {
             type: 'object',
             required: false,
-            queryParam: false,
+            queryParam: true,
             def() {
                 return {
                     color: 'gold',
@@ -212,6 +212,6 @@ export let Button = xcomponent.create({
 
     dimensions: {
         width: 146,
-        height: 40
+        height: 48
     }
 });

--- a/src/components/common.js
+++ b/src/components/common.js
@@ -22,6 +22,14 @@ export function validateProps(props) {
     if (!props.onAuthorize) {
         throw new Error(`Must specify onAuthorize callback`);
     }
+    
+    if (props.buttonStyle && props.buttonStyle.size) {
+        var buttonSize = props.buttonStyle.size;
+        
+        if (config.buttonSizes.indexOf(buttonSize) < 0) {
+            props.buttonStyle.size = 'medium';
+        }
+    }
 
     let env = props.env || config.env;
 

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -30,6 +30,8 @@ export let config = {
 
     stage: 'msmaster',
 
+    buttonSizes: ['tiny', 'small', 'medium'],
+
     SUPPORTED_AGENTS: {
         Chrome: 27,
         IE: 9,


### PR DESCRIPTION
-- new sizes for buttonjs (some cutoff whenever we rendered buttons with multiple lines)
-- setting button parameters in as query params for server side rendering. 
-- default button size is medium if none specified to prevent cutoffs. 
