### PR TITLE
feat(pptm-clientid): Add client_id to pptm.js call

### DIFF
--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -8,6 +8,7 @@ import { type Component } from 'zoid/src/component/component';
 import { info, warn, track, error, flush as flushLogs } from 'beaver-logger/client';
 import { getDomain } from 'cross-domain-utils/src';
 
+import { pptm } from '../external';
 import { config } from '../config';
 import { SOURCE, ENV, FPTI, FUNDING, BUTTON_LABEL, BUTTON_COLOR,
     BUTTON_SIZE, BUTTON_SHAPE, BUTTON_LAYOUT, COUNTRY } from '../constants';
@@ -29,6 +30,8 @@ import { containerTemplate, componentTemplate } from './template';
 import { validateButtonLocale, validateButtonStyle } from './validate';
 import { setupButtonChild } from './child';
 import { normalizeProps } from './props';
+
+pptm.listenForLoadWithNoContent();
 
 function isCreditDualEligible(props) : boolean {
 
@@ -523,7 +526,6 @@ export let Button : Component<ButtonOptions> = create({
             noop:      true,
             decorate(original) : Function {
                 return function decorateOnRender() : mixed {
-
                     let { browser = 'unrecognized', version = 'unrecognized' } = getBrowser();
                     info(`button_render_browser_${ browser }_${ version }`);
 
@@ -537,6 +539,8 @@ export let Button : Component<ButtonOptions> = create({
                     info(`button_render_branding_${ style.branding || 'default' }`);
                     info(`button_render_fundingicons_${ style.fundingicons || 'default' }`);
                     info(`button_render_tagline_${ style.tagline || 'default' }`);
+
+                    pptm.reloadPptmScript(this.props.client[this.props.env]);
 
                     track({
                         [ FPTI.KEY.STATE ]:              FPTI.STATE.LOAD,

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -863,12 +863,7 @@ export let config = {
     },
 
     get pptmUrl() : string {
-
-        let paypalUrl = config.env === ENV.LOCAL
-            ? config.paypalUrls[ENV.STAGE]
-            : config.paypalUrl;
-
-        return `${ paypalUrl }${ config.pptmUri }`;
+        return `${ config.paypalUrls[config.env] }${ config.pptmUri }`;
     },
 
     get authApiUrl() : string {

--- a/src/external/index.js
+++ b/src/external/index.js
@@ -1,3 +1,4 @@
 /* @flow */
 
 export * from './pptm';
+export * from './pptm-factory';

--- a/src/external/pptm-factory.js
+++ b/src/external/pptm-factory.js
@@ -1,0 +1,164 @@
+/* @flow */
+
+import { track, info } from 'beaver-logger/client';
+
+import { config } from '../config';
+import { FPTI, PPTM_ID } from '../constants';
+import { stringifyError, extendUrl, loadScript, getElement, isPayPalDomain } from '../lib';
+
+
+function shouldCreateInitialPptmScript() : boolean {
+    const id = window.location.hostname;
+
+    if (!id) {
+        return false;
+    }
+
+    if (isPayPalDomain()) {
+        return false;
+    }
+
+    const existingScript = getElement(PPTM_ID);
+    const alreadyDownloaded = Boolean(existingScript);
+
+    if (alreadyDownloaded) {
+        info('pptm_tried_loading_twice');
+        return false;
+    }
+
+    return true;
+}
+
+function removePptm() {
+    const script = getElement(PPTM_ID);
+
+    if (script) {
+        // $FlowFixMe
+        script.parentNode.removeChild(script);
+    }
+}
+
+export function pptmFactory() : Object {
+    let noContentFoundInContainer = false;
+    let callback = `__pptmLoadedWithNoContent`;
+    let listener;
+
+    let obj = {
+        /*
+        In the button component, we set up a global window[callback] that will be called in pptm `onload` attribute.
+        Button.render calls `reloadPptmScript`, which checks if window[callback] has been called yet (meaning, it checks
+        if pptm.js was loaded before Button.render was called). If so, we'll check to see if we should reload PPTM
+        now that we might have a client ID from the Button.render method.
+        If pptm.js hasn't loaded yet, then we'll set up a listener to the same logic above to defer it until
+        pptm.js actually loads.
+        */
+        reloadPptmScript(clientId : ?string) {
+            const tryCreatePptmScript = () => {
+                if (obj.shouldReloadPptmScript(clientId)) {
+                    obj.removePptm();
+                    obj.createPptmScript(clientId);
+                } else {
+                    // Defer until later, since reloadPptmScript might have been called
+                    // before pptm loaded, so we'll still want to hook into the script load.
+                    listener = tryCreatePptmScript;
+                }
+            };
+
+            tryCreatePptmScript();
+        },
+        listenForLoadWithNoContent() {
+            window[callback] = () => {
+                noContentFoundInContainer = true;
+
+                if (listener) {
+                    listener();
+                    listener = undefined;
+                }
+            };
+        },
+        get callback() : string {
+            return callback;
+        },
+        get noContentFoundInContainer() : boolean {
+            return noContentFoundInContainer;
+        },
+        createPptmScript: (clientId : ?string) => {
+            track({
+                [ FPTI.KEY.STATE ]:      FPTI.STATE.PPTM,
+                [ FPTI.KEY.TRANSITION ]: FPTI.TRANSITION.PPTM_LOAD
+            });
+        
+            let params = {
+                t:         'xo',
+                id:        window.location.hostname,
+                mrid:      config.merchantID,
+                client_id: '',
+                v:         config.version,
+                source:    'checkoutjs'
+            };
+        
+            if (clientId) {
+                params.client_id = clientId;
+            } else {
+                delete params.client_id;
+            }
+        
+            const fullUrl = extendUrl(config.pptmUrl, params);
+        
+            loadScript(fullUrl, 0, {
+                async:  true,
+                id:     PPTM_ID,
+                onload: `(function() {
+                    if (window.paypalDDL && window.paypalDDL[0] && window.paypalDDL[0].event === 'snippetRun') {
+                    } else {
+                        window['${ callback }']();
+                    }
+                })()`
+            }).then(() => {
+                track({
+                    [ FPTI.KEY.STATE ]:      FPTI.STATE.PPTM,
+                    [ FPTI.KEY.TRANSITION ]: FPTI.TRANSITION.PPTM_LOADED
+                });
+            }).catch(err => {
+                info('pptm_script_error', { error: stringifyError(err) });
+            });
+        },
+        shouldCreateInitialPptmScript,
+        /*
+        During Button render if a client ID was provided, we'll want to refresh the
+        pptm script to try to pull down a container by that value.
+        We'll only do this if we're not on the PayPal domain, or if
+        a merchant ID wasn't already provided (since container look-up can
+        also happen by merchant ID). Note that this will only happen
+        if there was no content found in the container that was pulled down
+        in the `setup` script. This is important because we don't want
+        to pull down multiple containers that actually contain content,
+        otherwise we'll be firing duplicate tags.
+        */
+        shouldReloadPptmScript(clientId : ?string) : boolean {
+            if (noContentFoundInContainer === false) {
+                return false;
+            }
+
+            if (isPayPalDomain()) {
+                return false;
+            }
+        
+            // If a merchant ID was already provided, then that meant we initially
+            // loaded the pptm script with that value as the main container
+            // look-up value, so in this case we don't want to reload pptm.
+            if (config.merchantID) {
+                return false;
+            }
+        
+            if (clientId) {
+                return true;
+            }
+        
+            return false;
+        },
+        removePptm
+    };
+
+    return obj;
+}

--- a/src/external/pptm-factory.js
+++ b/src/external/pptm-factory.js
@@ -107,14 +107,15 @@ export function pptmFactory() : Object {
         
             loadScript(fullUrl, 0, {
                 async:  true,
-                id:     PPTM_ID,
-                onload: `(function() {
-                    if (window.paypalDDL && window.paypalDDL[0] && window.paypalDDL[0].event === 'snippetRun') {
-                    } else {
-                        window['${ callback }']();
-                    }
-                })()`
+                id:     PPTM_ID
             }).then(() => {
+                // If the snippet is empty, then fire the callback.
+                // We assume non-empty pptm.js bundles with init the paypalDDL and push an event called
+                // `snippetRun` to it.
+                if (!(window.paypalDDL && window.paypalDDL[0] && window.paypalDDL[0].event === 'snippetRun')) {
+                    window[callback]();
+                }
+
                 track({
                     [ FPTI.KEY.STATE ]:      FPTI.STATE.PPTM,
                     [ FPTI.KEY.TRANSITION ]: FPTI.TRANSITION.PPTM_LOADED

--- a/src/external/pptm.js
+++ b/src/external/pptm.js
@@ -1,42 +1,5 @@
 /* @flow */
 
-import { track, info } from 'beaver-logger/client';
+import { pptmFactory } from './pptm-factory';
 
-import { config } from '../config';
-import { FPTI, PPTM_ID } from '../constants';
-import { stringifyError, extendUrl, loadScript, getElement } from '../lib';
-
-export function createPptmScript() {
-    const id = window.location.hostname;
-
-    if (!id) {
-        return;
-    }
-
-    const alreadyDownloaded = Boolean(getElement(PPTM_ID));
-
-    if (alreadyDownloaded) {
-        info('pptm_tried_loading_twice');
-        return;
-    }
-
-    track({
-        [ FPTI.KEY.STATE ]:      FPTI.STATE.PPTM,
-        [ FPTI.KEY.TRANSITION ]: FPTI.TRANSITION.PPTM_LOAD
-    });
-
-    const fullUrl = extendUrl(config.pptmUrl, {
-        t:    'xo',
-        id:   window.location.hostname,
-        mrid: config.merchantID
-    });
-
-    loadScript(fullUrl, 0, { async: true, id: PPTM_ID }).then(() => {
-        track({
-            [ FPTI.KEY.STATE ]:      FPTI.STATE.PPTM,
-            [ FPTI.KEY.TRANSITION ]: FPTI.TRANSITION.PPTM_LOADED
-        });
-    }).catch(err => {
-        info('pptm_script_error', { error: stringifyError(err) });
-    });
-}
+export const pptm = pptmFactory();

--- a/src/setup.js
+++ b/src/setup.js
@@ -9,9 +9,9 @@ import { initLogger, checkForCommonErrors, setLogLevel, stringifyError,
     stringifyErrorMessage, getResourceLoadTime, isPayPalDomain, isEligible,
     getDomainSetting, once, openMetaFrame, precacheRememberedFunding,
     getCurrentScript } from './lib';
-import { createPptmScript } from './external';
 import { Button } from './button';
 import { Checkout } from './checkout';
+import { pptm } from './external';
 
 function domainToEnv(domain : string) : ?string {
     for (let env of Object.keys(config.paypalUrls)) {
@@ -151,8 +151,8 @@ export let init = once(({ precacheRemembered }) => {
 
     initLogger();
 
-    if (!isPayPalDomain()) {
-        createPptmScript();
+    if (pptm.shouldCreateInitialPptmScript()) {
+        pptm.createPptmScript();
     }
 
     if (precacheRemembered) {

--- a/test/tests/external/index.js
+++ b/test/tests/external/index.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+import './pptm';

--- a/test/tests/external/pptm.js
+++ b/test/tests/external/pptm.js
@@ -1,0 +1,181 @@
+/* @flow */
+/* eslint max-lines: 0 */
+import { config } from '../../../src/config';
+import { PPTM_ID } from '../../../src/constants';
+import { createTestContainer, destroyTestContainer, destroyElement } from '../common';
+
+describe(`external pptm`, () => {
+    let oldMockDomain;
+    let oldMerchantId;
+
+    beforeEach(() => {
+        // We're using these 2 values in the tests below, so we'll keep a hold
+        // of them and reset them after each test run so we don't affect any other
+        // test suites.
+        oldMockDomain = window.mockDomain;
+        oldMerchantId = config.merchantID;
+
+        // `setup` in called in the main test index file, which creates the PPTM script.
+        // However, before each test we'll go ahead and get rid of it (and then in the
+        // `after` block, we'll re-create it in order to go back to our initial state so other
+        // tests continue with the same expected state).
+        destroyElement(PPTM_ID);
+        createTestContainer();
+    });
+
+    afterEach(() => {
+        destroyTestContainer();
+
+        window.mockDomain = oldMockDomain;
+        config.merchantID = oldMerchantId;
+    });
+
+    after(() => {
+        const pptm = require('../../../src/external/pptm').pptm;
+        // Go back to our initial state
+        pptm.createPptmScript();
+    });
+
+    const checkPptmLoad = done => {
+        const scripts = Array.prototype.slice.call(document.getElementsByTagName('script'), 0).filter(script => {
+            return script.id === PPTM_ID;
+        });
+
+        if (scripts.length === 0) {
+            return done(new Error('Expected pptm script to be loaded'));
+        }
+
+        if (scripts.length > 1) {
+            return done(new Error(`Expected pptm script to be loaded only once, but it was loaded ${ scripts.length } times`));
+        }
+
+        let el = scripts[0];
+
+        if (!el.async) {
+            return done(new Error('Expected pptm script to be async'));
+        }
+
+        let expectedUrl = `pptm.js?client_id=foo&id=${ window.location.hostname }&source=checkoutjs&t=xo&v=test_minor`;
+
+        if (el.src.indexOf(expectedUrl) === -1) {
+            return done(new Error(`Expected pptm script to contain ${ expectedUrl } but found ${ el.src }`));
+        }
+
+        return done();
+    };
+
+    it('should re-load the pptm script during button render with async prop and correct url when a client ID is present (render called *after* initial pptm is loaded)', done => {
+        const pptm = require('../../../src/external/pptm').pptm;
+        // Mock this side-effect from `setup` being called.
+        pptm.createPptmScript();
+
+        // Mock the serverside callback to retry creating the script.
+        window[pptm.callback]();
+
+        window.paypal.Button.render({
+            env:    'test',
+            client: {
+                test: 'foo'
+            },
+            test: {
+                onRender() : void {
+                    return checkPptmLoad(done);
+                }
+            },
+
+            payment() {
+                done(new Error('Expected payment() to not be called'));
+            },
+
+            onAuthorize() {
+                done(new Error('Expected onAuthorize() to not be called'));
+            }
+        }, '#testContainer');
+    });
+
+    it('should re-load the pptm script during button render with async prop and correct url when a client ID is present (render called *before* initial pptm is loaded)', done => {
+        const pptm = require('../../../src/external/pptm').pptm;
+        // Mock this side-effect from `setup` being called.
+        pptm.createPptmScript();
+
+        window.paypal.Button.render({
+            env:    'test',
+            client: {
+                test: 'foo'
+            },
+
+            payment() {
+                done(new Error('Expected payment() to not be called'));
+            },
+
+            onAuthorize() {
+                done(new Error('Expected onAuthorize() to not be called'));
+            }
+        }, '#testContainer');
+
+        // Mock the serverside callback to retry creating the script.
+        window[pptm.callback]();
+
+        return checkPptmLoad(done);
+    });
+
+    it('should not load pptm.js script tag from button render when inside a PayPal domain', done => {
+        const pptm = require('../../../src/external/pptm').pptm;
+        window.mockDomain = 'mock://www.paypal.com';
+
+        // Mock the serverside callback to retry creating the script.
+        window[pptm.callback]();
+
+        window.paypal.Button.render({
+            test: {
+                onRender() : void {
+                    let el = document.getElementById(PPTM_ID);
+
+                    if (el) {
+                        return done(new Error(`Expected pptm script to not be loaded, window.location.hostname = ${ window.location.hostname }, window.mockDomain = ${ window.mockDomain }`));
+                    }
+
+                    return done();
+                }
+            },
+
+            payment() {
+                done(new Error('Expected payment() to not be called'));
+            },
+
+            onAuthorize() {
+                done(new Error('Expected onAuthorize() to not be called'));
+            }
+        }, '#testContainer');
+    });
+
+    it('should not re-load pptm.js script tag from button render if config.merchantID was already provided (since `setup` would have created pptm with the mrid param)', done => {
+        const pptm = require('../../../src/external/pptm').pptm;
+        config.merchantID = 'foo';
+
+        // Mock the serverside callback to retry creating the script.
+        window[pptm.callback]();
+
+        window.paypal.Button.render({
+            test: {
+                onRender() : void {
+                    let el = document.getElementById(PPTM_ID);
+
+                    if (el) {
+                        return done(new Error(`Expected pptm script to not be loaded, config.merchantID = ${ config.merchantID }`));
+                    }
+
+                    return done();
+                }
+            },
+
+            payment() {
+                done(new Error('Expected payment() to not be called'));
+            },
+
+            onAuthorize() {
+                done(new Error('Expected onAuthorize() to not be called'));
+            }
+        }, '#testContainer');
+    });
+});

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -6,3 +6,4 @@ import './legacy';
 import './checkout';
 import './button';
 import './api';
+import './external';

--- a/test/tests/setup/pptm.js
+++ b/test/tests/setup/pptm.js
@@ -19,7 +19,7 @@ describe('paypal pptm script setup', () => {
                     return reject(new Error('Expected pptm script to be async'));
                 }
 
-                let expectedUrl = 'pptm.js?id=' + window.location.hostname + '&t=xo';
+                let expectedUrl = 'pptm.js?id=' + window.location.hostname + '&source=checkoutjs&t=xo&v=test_minor';
 
                 if (el.src.indexOf(expectedUrl) === -1) {
                     return reject(new Error('Expected pptm script to contain ' + expectedUrl + ' but found ' + el.src));


### PR DESCRIPTION
# Background
Currently checkout.js sends the URL or mrid to pull down pptm.js. However, as part of ramping for some new MUSE features, we want to increase coverage by using client_id if it's available.

# Problem
client_id is only available during button render.

# Solution
Retain current behavior of how pptm.js is pulled down, but if the pptm.js bundle is empty, reload it during button render if a client_id is available (for those merchants who do a client-side integration instead of serverside).

**Design**

We do this by setting up a window function (`window. __pptmLoadedWithNoContent`) in the button component that will be called when pptm.js is pulled down in its `onload` handler. The handler will check if pptm.js is empty (by checking if an internal pptm event called `snippetRun` was pushed to the `paypalDDL` event queue), and if so, it will remove the empty pptm.js bundle and try to pull it down again, but this time by client_id (only if the merchant supplied a client_id during button render). If pptm.js is pulled down, then all good. If it's empty again, then nothing more happens. Note: due to the async nature of button render vs when pptm.js is loaded, there was some complexity with how the window listener is setup, but most of the complexity is abstracted away into the `pptm.reloadPptmScript` method. This is to ensure that timing of button render and script loading behaves the same regardless of the order they're called.
