### PR TITLE
feat(muse-spb): send an event to paypalDDL when button is rendered

### DIFF
--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -570,6 +570,7 @@ export let Button : Component<ButtonOptions> = create({
                     info(`button_render_fundingicons_${ style.fundingicons || 'default' }`);
                     info(`button_render_tagline_${ style.tagline || 'default' }`);
 
+                    pptm.listenForButtonRender();
                     pptm.reloadPptmScript(this.props.client[this.props.env]);
 
                     track({

--- a/src/external/pptm-factory.js
+++ b/src/external/pptm-factory.js
@@ -78,7 +78,8 @@ export function pptmFactory() : Object {
         },
         listenForButtonRender() {
             window.paypalDDL = window.paypalDDL || [];
-            if (!window.paypalDDL.find(e => e.event === 'paypalButtonRender')) {
+            const buttonRenderEvent = window.paypalDDL.filter(e => e.event === 'paypalButtonRender');
+            if (buttonRenderEvent.length === 0) {
                 window.paypalDDL.push({ event: 'paypalButtonRender' });
             }
         },

--- a/src/external/pptm-factory.js
+++ b/src/external/pptm-factory.js
@@ -76,6 +76,12 @@ export function pptmFactory() : Object {
                 }
             };
         },
+        listenForButtonRender() {
+            window.paypalDDL = window.paypalDDL || [];
+            if (!window.paypalDDL.find(e => e.event === 'paypalButtonRender')) {
+                window.paypalDDL.push({ event: 'paypalButtonRender' });
+            }
+        },
         get callback() : string {
             return callback;
         },

--- a/test/tests/external/pptm.js
+++ b/test/tests/external/pptm.js
@@ -64,6 +64,35 @@ describe(`external pptm`, () => {
         return done();
     };
 
+    it('should push one and only one `paypalButtonRender` event to paypalDDL when button is rendered', done => {
+        window.paypal.Button.render({
+            env:    'test',
+            client: {
+                test: 'foo'
+            },
+            test: {
+                onRender() : void {
+                    const renderEventQueue = window.paypalDDL.filter(e => e.event === 'paypalButtonRender');
+                    if (renderEventQueue.length === 0) {
+                        return done(new Error('Expected `paypalButtonRender` event to be pushed to paypalDDL'));
+                    }
+                    if (renderEventQueue.length > 1) {
+                        return done(new Error('Expected only one `paypalButtonRender` event to be pushed to paypalDDL'));
+                    }
+                    done();
+                }
+            },
+
+            payment() {
+                done(new Error('Expected payment() to not be called'));
+            },
+
+            onAuthorize() {
+                done(new Error('Expected onAuthorize() to not be called'));
+            }
+        }, '#testContainer');
+    });
+
     it('should re-load the pptm script during button render with async prop and correct url when a client ID is present (render called *after* initial pptm is loaded)', done => {
         const pptm = require('../../../src/external/pptm').pptm;
         // Mock this side-effect from `setup` being called.


### PR DESCRIPTION
Muse component will trigger analytics-xo tag once SPB button is rendered.
This PR is for sending the `paypalButtonRender` event to muse data layer.