### PR TITLE
Don't override the local config for 3ds component

### DIFF
--- a/src/threeDomainSecure/index.js
+++ b/src/threeDomainSecure/index.js
@@ -21,8 +21,7 @@ export const ThreeDomainSecure = create({
 
     get domain() : Object {
         return {
-            ...config.paypalDomains,
-            [ ENV.LOCAL ]: /^http:\/\/localhost.paypal.com:\d+$/
+            ...config.paypalDomains
         };
     },
 


### PR DESCRIPTION
Due to the issue with passing the xprops to child component and that turns the `domain` to an object instead of `string`