### PR TITLE
loading dots logic for first render

### DIFF
--- a/src/button/props.js
+++ b/src/button/props.js
@@ -71,11 +71,12 @@ export const normalizeProps = memoize((props : Object, defs? : { locale? : Local
     locale = locale ? parseLocale(locale) : (defs.locale || getButtonConfig('DEFAULT', 'defaultLocale'));
 
     // $FlowFixMe
+    // funding indicated the allowed/disallowed payment methods (including cards) passed in the integration script
     funding = funding || {};
     funding.allowed = funding.allowed || [];
     funding.disallowed = funding.disallowed || [];
     funding.remembered = funding.remembered || [];
-
+    
     const label  = style[BUTTON_STYLE_OPTIONS.LABEL] || getButtonConfig('DEFAULT', (style.layout === BUTTON_LAYOUT.VERTICAL) ? 'defaultVerticalLabel' : 'defaultLabel');
     const layout = style[BUTTON_STYLE_OPTIONS.LAYOUT] || getButtonConfig(label, 'defaultLayout');
 
@@ -91,11 +92,14 @@ export const normalizeProps = memoize((props : Object, defs? : { locale? : Local
         [ BUTTON_STYLE_OPTIONS.INSTALLMENTPERIOD ]:  installmentperiod
     } = style;
 
+    // max is the maximum number of buttons to be displayed in the iframe
     max = determineMaxButtons({ label, layout, max });
 
     const selected = labelToFunding(label);
     let sources  = determineEligibleFunding({ funding, selected, locale, env, layout, commit });
+    // sources is an array of funding sources eligible to be displayed
     sources = sortBy(sources.slice(0, max), FUNDING_ORDER);
+    // multiple is a boolean value indicating whether the sources is greater than 1
     const multiple = sources.length > 1;
 
     if (multiple) {
@@ -105,7 +109,7 @@ export const normalizeProps = memoize((props : Object, defs? : { locale? : Local
     tagline = enableTagline({ tagline, branding, fundingicons, layout });
 
     const cards = determineEligibleCards({ funding, locale });
-
+    
     return { size, label, locale, color, shape, branding, fundingicons,
         tagline, funding, layout, sources, max, multiple, env, height, cards, installmentperiod, checkoutCustomization };
 });

--- a/src/button/props.js
+++ b/src/button/props.js
@@ -69,9 +69,9 @@ export const normalizeProps = memoize((props : Object, defs? : { locale? : Local
     } = props;
 
     locale = locale ? parseLocale(locale) : (defs.locale || getButtonConfig('DEFAULT', 'defaultLocale'));
-
-    // $FlowFixMe
+    
     // funding indicated the allowed/disallowed payment methods (including cards) passed in the integration script
+    // $FlowFixMe
     funding = funding || {};
     funding.allowed = funding.allowed || [];
     funding.disallowed = funding.disallowed || [];

--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -16,7 +16,7 @@ import { componentStyle, CLASS } from './componentStyle';
 import { getComponentScript } from './componentScript';
 import { componentContent } from './content';
 
-const allowedPersonalizationLabels = [ BUTTON_LABEL.PAYPAL, BUTTON_LABEL.CHECKOUT, BUTTON_LABEL.BUYNOW, BUTTON_LABEL.PAY, BUTTON_LABEL.INSTALLMENT ];
+const allowedPersonalizationLabels = [ BUTTON_LABEL.PAYPAL, BUTTON_LABEL.CHECKOUT, BUTTON_LABEL.BUYNOW, BUTTON_LABEL.PAY ];
 const delay = 0.2;
 
 function LoadingDots(delay) : JsxHTMLNode {
@@ -360,13 +360,9 @@ function renderButton({ size, label, color, locale, branding, multiple, layout, 
         installmentperiod,
         locale
     };
-
-
-    // check for button label=installment. If the personalization text comes through for installment,
-    // we should use that instead of the handler function for content text; if not we should continue
-    // using the handler for installment button
-    contentText = (typeof contentText === 'function' && !(morsText && label === BUTTON_LABEL.INSTALLMENT)) ? contentText(dynamicContent) : contentText;
-    contentText = ( __WEB__ && label !== FUNDING.PAYPAL && source === FUNDING.PAYPAL) ? renderPPPayPalLoadingDots({ color, logoColor }) : renderContent(contentText, { label, locale, color, branding, logoColor, funding, env, cards, dynamicContent, layout, size });
+    
+    contentText = (typeof contentText === 'function') ? contentText(dynamicContent) : contentText;
+    contentText = ( __WEB__ && source === FUNDING.PAYPAL && allowedPersonalizationLabels.indexOf(label) !== -1) ? renderPPPayPalLoadingDots({ color, logoColor }) : renderContent(contentText, { label, locale, color, branding, logoColor, funding, env, cards, dynamicContent, layout, size });
 
     // Define a list of funding options that will not need a tabindex
     const hasTabIndex = [

--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -209,7 +209,7 @@ function renderFundingIcons({ cards, fundingicons, size, layout } :
 }
 
 // this function performs the first button render for eligible population
-function renderPPPayPalLoadingDots({ color, logoColor, branding } : { color : string, logoColor : string, branding : boolean }) : JsxHTMLNode {
+function renderPPPayPalLoadingDots({ color, logoColor, branding, label } : { color : string, logoColor : string, branding : boolean, label : $Values<typeof BUTTON_LABEL> }) : JsxHTMLNode {
     if (!logoColor) {
         throw new Error(`Can not determine logo without logo color`);
     }
@@ -220,7 +220,7 @@ function renderPPPayPalLoadingDots({ color, logoColor, branding } : { color : st
     const loadingDotsElement = ( <span class={ `${ CLASS.TEXT }`}>{ LoadingDots(delay) }</span> );
     
     // this is specifically for the buynow button when the style.branding = false
-    if (!branding) {
+    if (!branding && label === BUTTON_LABEL.BUYNOW) {
         return new JsxHTMLNodeContainer([loadingDotsElement]);
     }
     const spaceElement = ( <span class={ `${ CLASS.TEXT }`}> </span> );

--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -112,7 +112,7 @@ function renderFundingIcons({ cards, fundingicons, size, layout } :
 }
 
 // this function performs the first button render for eligible population
-function renderPPPayPalLoadingDots({ color, logoColor, branding, label } : { color : string, logoColor : string, branding : boolean, label : $Values<typeof BUTTON_LABEL> }) : JsxHTMLNode {
+function renderPPPayPalLoadingDots({ color, logoColor, branding, label } : { color : string, logoColor : $Values<typeof BUTTON_LOGO_COLOR>, branding : boolean, label : string }) : JsxHTMLNode {
     if (!logoColor) {
         throw new Error(`Can not determine logo without logo color`);
     }
@@ -126,10 +126,11 @@ function renderPPPayPalLoadingDots({ color, logoColor, branding, label } : { col
     if (!branding && label === BUTTON_LABEL.BUYNOW) {
         return new JsxHTMLNodeContainer([ loadingDotsElement ]);
     }
-    const spaceElement = (<span class={ `${ CLASS.TEXT }` }> </span>);
     
-    const ppLogo = fundingLogos[BUTTON_LOGO.PP][logoColor];
-    const paypalLogo = fundingLogos[BUTTON_LOGO.PAYPAL]({ logoColor });
+    const ppFundingLogo = fundingLogos[BUTTON_LOGO.PP];
+    const ppLogo =  typeof ppFundingLogo === 'function' ? ppFundingLogo({ logoColor }) : ppFundingLogo[logoColor];
+    const paypalFundingLogo = fundingLogos[BUTTON_LOGO.PAYPAL];
+    const paypalLogo = typeof paypalFundingLogo === 'function' ? paypalFundingLogo({ logoColor }) : paypalFundingLogo[logoColor];
     const nodes = [];
     nodes[0] = (
         <img

--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -3,118 +3,21 @@
 
 import { base64encode } from 'belter/src';
 
-import { BUTTON_SIZE, BUTTON_BRANDING, BUTTON_NUMBER, BUTTON_LOGO_COLOR, BUTTON_LABEL, BUTTON_LAYOUT, ENV, ATTRIBUTE, FUNDING } from '../../constants';
+import { BUTTON_SIZE, BUTTON_BRANDING, BUTTON_NUMBER, BUTTON_LOGO, BUTTON_LOGO_COLOR, BUTTON_LABEL, BUTTON_LAYOUT, ENV, ATTRIBUTE, FUNDING } from '../../constants';
 import { getButtonConfig, labelToFunding, fundingToDefaultLabel } from '../config';
 import { normalizeProps } from '../props';
 import { jsxToHTML, type JsxHTMLNode, type ChildType, jsxRender, JsxHTMLNodeContainer } from '../../lib/jsx';
 import { fundingLogos, cardLogos } from '../../resources';
-import { BUTTON_LOGO } from '../../constants';
 import { validateButtonProps } from '../validate';
 import type { LocaleType, FundingSource, FundingSelection, FundingList, CheckoutCustomizationType } from '../../types';
 
+import { Tagline, Beacon, LoadingDots } from './miscComponent';
 import { componentStyle, CLASS } from './componentStyle';
 import { getComponentScript } from './componentScript';
 import { componentContent } from './content';
 
 const allowedPersonalizationLabels = [ BUTTON_LABEL.PAYPAL, BUTTON_LABEL.CHECKOUT, BUTTON_LABEL.BUYNOW, BUTTON_LABEL.PAY ];
 const delay = 0.2;
-
-function LoadingDots(delay) : JsxHTMLNode {
-    return (
-        <div>
-            <style innerHTML={ `
-                .loading-dots {
-                    color: rgba(0, 0, 0, 0.5);
-                    font-size: inherit;
-                    font-family: Arial, Helvetica, sans-serif;
-                    display: inline-block;
-                }
-
-                .loading-dot {
-                    opacity: 0;
-                    display: inline-block;
-                    animation-name: loading-dot;
-                    animation-duration: 1s;
-                    animation-fill-mode: forwards;
-                    animation-iteration-count: infinite;
-                    margin-right: 2px;
-                }
-
-                .loading-dot-0 {
-                    animation-delay: ${ delay.toFixed(1) }s;
-                }
-
-                .loading-dot-1 {
-                    animation-delay: ${ (delay * 2).toFixed(1) }s;
-                }
-
-                .loading-dot-2 {
-                    animation-delay: ${ (delay * 3).toFixed(1) }s;
-                }
-
-                @keyframes loading-dot {
-                    0% {
-                        opacity: 0;
-                    }
-                    20% {
-                        opacity: 1;
-                    }
-                    30% {
-                        opacity: 1;
-                    }
-                    40% {
-                        opacity: 0;
-                    }
-                    100% {
-                        opacity: 0;
-                    }
-                }
-            ` } />
-            <div class='loading-dots'>
-                {
-                    [ 0, 1, 2 ].map(i =>
-                        <div class={ `loading-dot loading-dot-${ i }` }>•</div>)
-                }
-            </div>
-        </div>
-    );
-}
-
-function Beacon(impression) : JsxHTMLNode {
-    return (
-        <div class='tracking-beacon'>
-            <style innerHTML={ `
-            .tracking-beacon {
-                visibility: hidden;
-                position: absolute;
-                height: 1px;
-                width: 1px;
-            }
-        ` } />
-            <img class='tracking-beacon' src={ impression } />
-        </div>
-    );
-}
-
-function Tagline(tagColor : string, impression : ?string, text : string | JsxHTMLNode) : JsxHTMLNode {
-    const nodes = [];
-    nodes[0] = ( <style innerHTML={ `
-            .tracking-beacon {
-                visibility: hidden;
-                position: absolute;
-                height: 1px;
-                width: 1px;
-            }
-        ` } /> );
-    nodes[1] = (
-        <div class={ `${ CLASS.TAGLINE } ${ CLASS.TAGLINE_COLOR }-${ tagColor }` }>
-            <span>{ text }</span>
-            {
-                impression  && <img class='tracking-beacon' src={ impression } />
-            }
-        </div> );
-    return new JsxHTMLNodeContainer(nodes);
-}
 
 function getCommonButtonClasses({ layout, shape, branding, multiple, env }) : string {
     return [
@@ -217,13 +120,13 @@ function renderPPPayPalLoadingDots({ color, logoColor, branding, label } : { col
         throw new Error(`Can not determine button without color`);
     }
     
-    const loadingDotsElement = ( <span class={ `${ CLASS.TEXT }`}>{ LoadingDots(delay) }</span> );
+    const loadingDotsElement = (<span class={ `${ CLASS.TEXT }` }>{ LoadingDots(delay) }</span>);
     
     // this is specifically for the buynow button when the style.branding = false
     if (!branding && label === BUTTON_LABEL.BUYNOW) {
-        return new JsxHTMLNodeContainer([loadingDotsElement]);
+        return new JsxHTMLNodeContainer([ loadingDotsElement ]);
     }
-    const spaceElement = ( <span class={ `${ CLASS.TEXT }`}> </span> );
+    const spaceElement = (<span class={ `${ CLASS.TEXT }` }> </span>);
     
     const ppLogo = fundingLogos[BUTTON_LOGO.PP][logoColor];
     const paypalLogo = fundingLogos[BUTTON_LOGO.PAYPAL]({ logoColor });
@@ -362,7 +265,7 @@ function renderButton({ size, label, color, locale, branding, multiple, layout, 
     };
     
     contentText = (typeof contentText === 'function') ? contentText(dynamicContent) : contentText;
-    contentText = ( __WEB__ && source === FUNDING.PAYPAL && allowedPersonalizationLabels.indexOf(label) !== -1) ? renderPPPayPalLoadingDots({ color, logoColor }) : renderContent(contentText, { label, locale, color, branding, logoColor, funding, env, cards, dynamicContent, layout, size });
+    contentText = (__WEB__ && source === FUNDING.PAYPAL && allowedPersonalizationLabels.indexOf(label) !== -1) ? renderPPPayPalLoadingDots({ color, logoColor }) : renderContent(contentText, { label, locale, color, branding, logoColor, funding, env, cards, dynamicContent, layout, size });
 
     // Define a list of funding options that will not need a tabindex
     const hasTabIndex = [
@@ -388,7 +291,6 @@ function renderButton({ size, label, color, locale, branding, multiple, layout, 
 }
 
 function renderTagline({ label, tagline, color, locale, multiple, env, cards, checkoutCustomization, layout } : { label : string, color : string, tagline : boolean, locale : LocaleType, multiple : boolean, env : string, cards : $ReadOnlyArray<string>, checkoutCustomization : ?CheckoutCustomizationType, layout : $Values<typeof BUTTON_LAYOUT> }) : ?JsxHTMLNode {
-    const delay = 0.2;
     if (!tagline) {
         return;
     }

--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -140,7 +140,7 @@ function renderPPPayPalLoadingDots({ color, logoColor, branding, label } : { col
         />);
     
     // for an intentional white space
-    nodes[1] = spaceElement;
+    nodes[1] = ' ';
     
     nodes[2] = (
         <img
@@ -150,7 +150,7 @@ function renderPPPayPalLoadingDots({ color, logoColor, branding, label } : { col
         />);
     
     // for an intentional white space
-    nodes[3] = spaceElement;
+    nodes[3] = ' ';
     
     nodes[4] = loadingDotsElement;
     
@@ -266,7 +266,7 @@ function renderButton({ size, label, color, locale, branding, multiple, layout, 
     };
     
     contentText = (typeof contentText === 'function') ? contentText(dynamicContent) : contentText;
-    contentText = (__WEB__ && source === FUNDING.PAYPAL && allowedPersonalizationLabels.indexOf(label) !== -1) ? renderPPPayPalLoadingDots({ color, logoColor }) : renderContent(contentText, { label, locale, color, branding, logoColor, funding, env, cards, dynamicContent, layout, size });
+    contentText = (__WEB__ && buttonLabel === label && allowedPersonalizationLabels.indexOf(label) !== -1) ? renderPPPayPalLoadingDots({ color, logoColor, branding, label }) : renderContent(contentText, { label, locale, color, branding, logoColor, funding, env, cards, dynamicContent, layout, size });
 
     // Define a list of funding options that will not need a tabindex
     const hasTabIndex = [

--- a/src/button/template/miscComponent.jsx
+++ b/src/button/template/miscComponent.jsx
@@ -5,7 +5,7 @@ import { jsxToHTML, type JsxHTMLNode, JsxHTMLNodeContainer } from '../../lib/jsx
 
 import { CLASS } from './componentStyle';
 
-export function LoadingDots(delay) : JsxHTMLNode {
+export function LoadingDots(delay : number) : JsxHTMLNode {
     return (
         <div>
             <style innerHTML={ `
@@ -66,7 +66,7 @@ export function LoadingDots(delay) : JsxHTMLNode {
     );
 }
 
-export function Beacon(impression) : JsxHTMLNode {
+export function Beacon(impression : string) : JsxHTMLNode {
     return (
         <div class='tracking-beacon'>
             <style innerHTML={ `

--- a/src/button/template/miscComponent.jsx
+++ b/src/button/template/miscComponent.jsx
@@ -1,0 +1,103 @@
+/* @flow */
+/** @jsx jsxToHTML */
+
+import { jsxToHTML, type JsxHTMLNode, JsxHTMLNodeContainer } from '../../lib/jsx';
+
+import { CLASS } from './componentStyle';
+
+export function LoadingDots(delay) : JsxHTMLNode {
+    return (
+        <div>
+            <style innerHTML={ `
+                .loading-dots {
+                    color: rgba(0, 0, 0, 0.5);
+                    font-size: inherit;
+                    font-family: Arial, Helvetica, sans-serif;
+                    display: inline-block;
+                }
+
+                .loading-dot {
+                    opacity: 0;
+                    display: inline-block;
+                    animation-name: loading-dot;
+                    animation-duration: 1s;
+                    animation-fill-mode: forwards;
+                    animation-iteration-count: infinite;
+                    margin-right: 2px;
+                }
+
+                .loading-dot-0 {
+                    animation-delay: ${ delay.toFixed(1) }s;
+                }
+
+                .loading-dot-1 {
+                    animation-delay: ${ (delay * 2).toFixed(1) }s;
+                }
+
+                .loading-dot-2 {
+                    animation-delay: ${ (delay * 3).toFixed(1) }s;
+                }
+
+                @keyframes loading-dot {
+                    0% {
+                        opacity: 0;
+                    }
+                    20% {
+                        opacity: 1;
+                    }
+                    30% {
+                        opacity: 1;
+                    }
+                    40% {
+                        opacity: 0;
+                    }
+                    100% {
+                        opacity: 0;
+                    }
+                }
+            ` } />
+            <div class='loading-dots'>
+                {
+                    [ 0, 1, 2 ].map(i =>
+                        <div class={ `loading-dot loading-dot-${ i }` }>•</div>)
+                }
+            </div>
+        </div>
+    );
+}
+
+export function Beacon(impression) : JsxHTMLNode {
+    return (
+        <div class='tracking-beacon'>
+            <style innerHTML={ `
+            .tracking-beacon {
+                visibility: hidden;
+                position: absolute;
+                height: 1px;
+                width: 1px;
+            }
+        ` } />
+            <img class='tracking-beacon' src={ impression } />
+        </div>
+    );
+}
+
+export function Tagline(tagColor : string, impression : ?string, text : string | JsxHTMLNode) : JsxHTMLNode {
+    const nodes = [];
+    nodes[0] = (<style innerHTML={ `
+            .tracking-beacon {
+                visibility: hidden;
+                position: absolute;
+                height: 1px;
+                width: 1px;
+            }
+        ` } />);
+    nodes[1] = (
+        <div class={ `${ CLASS.TAGLINE } ${ CLASS.TAGLINE_COLOR }-${ tagColor }` }>
+            <span>{ text }</span>
+            {
+                impression  && <img class='tracking-beacon' src={ impression } />
+            }
+        </div>);
+    return new JsxHTMLNodeContainer(nodes);
+}


### PR DESCRIPTION
* This is the logic which displays PP+PayPal logos with loading dots for first button render
* It adds white spaces b/w PP, PayPal and PayPal and loading dots
* We render loading dots only for button labels: paypal, pay, checkout, buynow for both layouts
* We render only the loading dots for unbrabded buynow label
