### PR TITLE
Updated style of buttons when on focus to improve a11y

### DIFF
--- a/src/ui/buttons/styles/color.js
+++ b/src/ui/buttons/styles/color.js
@@ -154,7 +154,6 @@ export const buttonColorStyle = `
         border: 0.125rem solid #009cde;
         border-radius: inherit;
         box-shadow: 0 0 0 0.5rem #0000a6;
-        pointer-events: none;
     }
 
 

--- a/src/ui/buttons/styles/color.js
+++ b/src/ui/buttons/styles/color.js
@@ -24,10 +24,18 @@ export const buttonColorStyle = `
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.GOLD }:focus {
         outline: none;
-        box-shadow: 0px 0px 1px 3px #0c67ff inset;
     }
-
-
+    .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.GOLD }:focus::after {
+        content: '';
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        bottom: 5px;
+        left: 5px;
+        border: 0.125rem solid #009cde;
+        border-radius: inherit;
+        box-shadow: 0 0 0 0.5rem #0000a6;
+    }
 
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.BLUE } {
@@ -40,10 +48,18 @@ export const buttonColorStyle = `
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.BLUE }:focus {
         outline: none;
-        box-shadow: 0px 0px 1px 3px #0c67ff inset;
     }
-
-
+    .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.BLUE }:focus::after {
+        content: '';
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        bottom: 5px;
+        left: 5px;
+        border: 0.125rem solid #0000a6;
+        border-radius: inherit;
+        box-shadow: 0 0 0 0.5rem #009cde;
+    }
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.SILVER } {
         background: #eee;
@@ -55,10 +71,18 @@ export const buttonColorStyle = `
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.SILVER }:focus {
         outline: none;
-        box-shadow: 0px 0px 1px 3px #0c67ff inset;
     }
-
-
+    .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.SILVER }:focus::after {
+        content: '';
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        bottom: 5px;
+        left: 5px;
+        border: 0.125rem solid #009cde;
+        border-radius: inherit;
+        box-shadow: 0 0 0 0.5rem #0000a6;
+    }
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.DARKBLUE } {
         background: #003087;
@@ -70,7 +94,17 @@ export const buttonColorStyle = `
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.DARKBLUE }:focus {
         outline: none;
-        box-shadow: 0px 0px 1px 3px #0c67ff inset;
+    }
+    .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.DARKBLUE }:focus::after {
+        content: '';
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        bottom: 5px;
+        left: 5px;
+        border: 0.125rem solid #009cde;
+        border-radius: inherit;
+        box-shadow: 0 0 0 0.5rem #0000a6;
     }
 
 
@@ -85,10 +119,18 @@ export const buttonColorStyle = `
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.BLACK }:focus {
         outline: none;
-        box-shadow: 0px 0px 1px 3px #0c67ff inset;
     }
-
-
+    .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.BLACK }:focus::after {
+        content: '';
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        bottom: 5px;
+        left: 5px;
+        border: 0.125rem solid #009cde;
+        border-radius: inherit;
+        box-shadow: 0 0 0 0.5rem #0000a6;
+    }
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.WHITE } {
         background: #fff;
@@ -101,7 +143,18 @@ export const buttonColorStyle = `
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.WHITE }:focus {
         outline: none;
-        box-shadow: 0px 0px 1px 3px #0c67ff inset;
+    }
+    .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.WHITE }:focus::after {
+        content: '';
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        bottom: 5px;
+        left: 5px;
+        border: 0.125rem solid #009cde;
+        border-radius: inherit;
+        box-shadow: 0 0 0 0.5rem #0000a6;
+        pointer-events: none;
     }
 
 


### PR DESCRIPTION
## Description of the problem:

When navigating with keyboard only, we expect that all items are focusable and able to be seen clearly. However, when navigating with a keyboard with grayscale, some buttons ("PayPal CREDIT" and "Debit or Credit Card") are not able to be visually focusable due to color contrast issues. 
 
## Steps to Reproduce:

Log in to a live paypal account. Once you are at the summary page use this URL: https://www.paypal.com/buttons/smart (will be live in march) to get to the appropriate landing page. After the page loads in turn on grayscale and use your keyboard to navigate the flow of the page. As you are navigating the page tab slowly through the example PayPal buttons and notice that they cannot be seen with grayscale on.

Example:

![Screen Shot 2020-05-13 at 3 08 41 PM](https://user-images.githubusercontent.com/64982099/81870906-a99d1d80-952b-11ea-8f3c-93a866fd882e.png)

## Solution

Updated button's style to have two margins when focused. This is the same style/pattern we are using in other Paypal components to handle focus on grayscale and improve accessibility. With those changes it is clear to se where the focus is when navigating through items with the keyboard.

## Results

# Buttons in pill format (focused)

![Screen Shot 2020-05-13 at 1 56 32 PM](https://user-images.githubusercontent.com/64982099/81871057-f680f400-952b-11ea-8951-acd5eab545b5.png)
![Screen Shot 2020-05-13 at 1 59 42 PM](https://user-images.githubusercontent.com/64982099/81871091-fe409880-952b-11ea-828a-5a81541532d7.png)

# Buttons in pill format (focused) in grayscale

![Screen Shot 2020-05-13 at 1 57 36 PM](https://user-images.githubusercontent.com/64982099/81871130-0ac4f100-952c-11ea-9591-cd2761f78eb9.png)
![Screen Shot 2020-05-13 at 1 59 55 PM](https://user-images.githubusercontent.com/64982099/81871144-131d2c00-952c-11ea-93aa-315cb31853aa.png)

# Buttons in rect format (focused) 

![Screen Shot 2020-05-13 at 1 58 21 PM](https://user-images.githubusercontent.com/64982099/81871233-3ea01680-952c-11ea-9743-a62879f43ff3.png)
![Screen Shot 2020-05-13 at 1 59 06 PM](https://user-images.githubusercontent.com/64982099/81871242-4364ca80-952c-11ea-81b5-37bc801fe018.png)

# Buttons in rect format (focused) in grayscale

![Screen Shot 2020-05-13 at 1 58 42 PM](https://user-images.githubusercontent.com/64982099/81871296-5d9ea880-952c-11ea-97c4-9670731545dc.png)
![Screen Shot 2020-05-13 at 1 59 25 PM](https://user-images.githubusercontent.com/64982099/81871312-64c5b680-952c-11ea-8a1e-ac930878d501.png)
