### PR TITLE
Fixed navigation (a11y) issue when navigating through card buttons

### DIFF
--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -361,14 +361,14 @@ function renderButton({ size, label, color, locale, branding, multiple, layout, 
     const hasTabIndex = [
         FUNDING.CARD
     ].indexOf(source) === -1;
-    const role = source === FUNDING.CARD ? {} : { role: 'button'};
+    const role = source === FUNDING.CARD ? {} : { role: 'button' };
     return (
         <div
             { ...{ [ATTRIBUTE.LAYOUT]: layout ? layout : '' } }
             { ...{ [ATTRIBUTE.SIZE]: size ? size : '' } }
             { ...{ [ ATTRIBUTE.FUNDING_SOURCE ]: source, [ ATTRIBUTE.BUTTON ]: true } }
             class={ `${ CLASS.BUTTON } ${ CLASS.NUMBER }-${ i } ${ getCommonButtonClasses({ layout, shape, branding, multiple, env }) } ${ getButtonClasses({ label, color, logoColor }) }` }
-            { ...role }  
+            { ...role }
             tabindex={ hasTabIndex && 0 }>
             { source === FUNDING.CARD ? contentText : renderButtonTextDiv({ contentText, personalizedButtonText, impression, branding, allowedAnimation }) }
         </div>

--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -361,14 +361,14 @@ function renderButton({ size, label, color, locale, branding, multiple, layout, 
     const hasTabIndex = [
         FUNDING.CARD
     ].indexOf(source) === -1;
-
+    const role = source === FUNDING.CARD ? {} : { role: 'button'};
     return (
         <div
             { ...{ [ATTRIBUTE.LAYOUT]: layout ? layout : '' } }
             { ...{ [ATTRIBUTE.SIZE]: size ? size : '' } }
             { ...{ [ ATTRIBUTE.FUNDING_SOURCE ]: source, [ ATTRIBUTE.BUTTON ]: true } }
             class={ `${ CLASS.BUTTON } ${ CLASS.NUMBER }-${ i } ${ getCommonButtonClasses({ layout, shape, branding, multiple, env }) } ${ getButtonClasses({ label, color, logoColor }) }` }
-            role='button'
+            { ...role }  
             tabindex={ hasTabIndex && 0 }>
             { source === FUNDING.CARD ? contentText : renderButtonTextDiv({ contentText, personalizedButtonText, impression, branding, allowedAnimation }) }
         </div>

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -53,6 +53,7 @@ export function checkForCommonErrors() {
         warn(`function_bind_arrity_overwritten`);
     }
 
+    // eslint-disable-next-line compat/compat
     if (window.opener && window.parent !== window) {
         warn(`window_has_opener_and_parent`);
     }


### PR DESCRIPTION
This change was necessary because if a user is navigating with a screen reader on, for instance Voice Over, when navigating through the fields with VO keys (https://webaim.org/articles/voiceover/ -  **control + option + arrow keys**), the user would not be able to click on the card buttons. 

## Before 

Before the changes, when reaching the buttons using control + option + arrow keys, we would have the focus on the wrapper div, not enabling the user to actually click on any of the options such as VISA or MASTERCARD.

![Screen Shot 2020-05-26 at 4 55 39 PM](https://user-images.githubusercontent.com/64982099/82961788-35269d80-9f73-11ea-8190-ae34011c641e.png)

## After

With the changes, when we are rendering the card buttons, the wrapper will not set the attribute role="button", enabling the user to navigate through the card buttons using the VO keys

![Screen Shot 2020-05-26 at 4 55 00 PM](https://user-images.githubusercontent.com/64982099/82961772-2fc95300-9f73-11ea-83ad-f8c82992c330.png)

