### PR TITLE
Fix links in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,350 +9,350 @@
 
 ## <small>5.0.94 (2020-05-28)</small>
 
-* Add data-instrument-type to button ([3a2533a](http://github.paypal.com/paypal/paypal-checkout/commit/3a2533a))
-* Fix standalone tests ([8dc61e0](http://github.paypal.com/paypal/paypal-checkout/commit/8dc61e0))
-* Use preventClickFocus on buttons ([58e3f5c](http://github.paypal.com/paypal/paypal-checkout/commit/58e3f5c))
+* Add data-instrument-type to button ([3a2533a](https://github.com/paypal/paypal-checkout-components/commit/3a2533a))
+* Fix standalone tests ([8dc61e0](https://github.com/paypal/paypal-checkout-components/commit/8dc61e0))
+* Use preventClickFocus on buttons ([58e3f5c](https://github.com/paypal/paypal-checkout-components/commit/58e3f5c))
 
 
 
 ## <small>5.0.93 (2020-05-27)</small>
 
-* Fix dropdown menu left border ([3519056](http://github.paypal.com/paypal/paypal-checkout/commit/3519056))
-* Updated style of buttons when on focus to improve a11y (#1317) ([159724e](http://github.paypal.com/paypal/paypal-checkout/commit/159724e)), closes [#1317](http://github.paypal.com/paypal/paypal-checkout/issues/1317)
+* Fix dropdown menu left border ([3519056](https://github.com/paypal/paypal-checkout-components/commit/3519056))
+* Updated style of buttons when on focus to improve a11y (#1317) ([159724e](https://github.com/paypal/paypal-checkout-components/commit/159724e)), closes [#1317](https://github.com/paypal/paypal-checkout-components/issues/1317)
 
 
 
 ## <small>5.0.92 (2020-05-21)</small>
 
-* add new title for buttons iframe (#1315) ([725bd42](http://github.paypal.com/paypal/paypal-checkout/commit/725bd42)), closes [#1315](http://github.paypal.com/paypal/paypal-checkout/issues/1315)
-* Added dev vault button ([f6a77c9](http://github.paypal.com/paypal/paypal-checkout/commit/f6a77c9))
-* Do not pass riskData for IE, to avoid url size limit ([c6fd8e9](http://github.paypal.com/paypal/paypal-checkout/commit/c6fd8e9))
+* add new title for buttons iframe (#1315) ([725bd42](https://github.com/paypal/paypal-checkout-components/commit/725bd42)), closes [#1315](https://github.com/paypal/paypal-checkout-components/issues/1315)
+* Added dev vault button ([f6a77c9](https://github.com/paypal/paypal-checkout-components/commit/f6a77c9))
+* Do not pass riskData for IE, to avoid url size limit ([c6fd8e9](https://github.com/paypal/paypal-checkout-components/commit/c6fd8e9))
 
 
 
 ## <small>5.0.91 (2020-05-20)</small>
 
-* Revert "Updated style of buttons when on focus to improve a11y (#1307)" ([4d548d6](http://github.paypal.com/paypal/paypal-checkout/commit/4d548d6)), closes [#1307](http://github.paypal.com/paypal/paypal-checkout/issues/1307)
+* Revert "Updated style of buttons when on focus to improve a11y (#1307)" ([4d548d6](https://github.com/paypal/paypal-checkout-components/commit/4d548d6)), closes [#1307](https://github.com/paypal/paypal-checkout-components/issues/1307)
 
 
 
 ## <small>5.0.90 (2020-05-20)</small>
 
-* [APM] adding mercadopago payment source to payment sdk (#1313) ([6dd0957](http://github.paypal.com/paypal/paypal-checkout/commit/6dd0957)), closes [#1313](http://github.paypal.com/paypal/paypal-checkout/issues/1313)
-* Add aria-labels for button containers (#1306) ([cefb925](http://github.paypal.com/paypal/paypal-checkout/commit/cefb925)), closes [#1306](http://github.paypal.com/paypal/paypal-checkout/issues/1306)
-* Add Vietnamese (vi) and Romanian (ro) (#1297) ([e260ed4](http://github.paypal.com/paypal/paypal-checkout/commit/e260ed4)), closes [#1297](http://github.paypal.com/paypal/paypal-checkout/issues/1297)
-* Fix spinner color to correspond with text color ([a4dccc1](http://github.paypal.com/paypal/paypal-checkout/commit/a4dccc1))
-* Type fixes ([0e3bb65](http://github.paypal.com/paypal/paypal-checkout/commit/0e3bb65))
-* Update blue button color ([1b64664](http://github.paypal.com/paypal/paypal-checkout/commit/1b64664))
-* Updated style of buttons when on focus to improve a11y (#1307) ([cb6eff7](http://github.paypal.com/paypal/paypal-checkout/commit/cb6eff7)), closes [#1307](http://github.paypal.com/paypal/paypal-checkout/issues/1307)
+* [APM] adding mercadopago payment source to payment sdk (#1313) ([6dd0957](https://github.com/paypal/paypal-checkout-components/commit/6dd0957)), closes [#1313](https://github.com/paypal/paypal-checkout-components/issues/1313)
+* Add aria-labels for button containers (#1306) ([cefb925](https://github.com/paypal/paypal-checkout-components/commit/cefb925)), closes [#1306](https://github.com/paypal/paypal-checkout-components/issues/1306)
+* Add Vietnamese (vi) and Romanian (ro) (#1297) ([e260ed4](https://github.com/paypal/paypal-checkout-components/commit/e260ed4)), closes [#1297](https://github.com/paypal/paypal-checkout-components/issues/1297)
+* Fix spinner color to correspond with text color ([a4dccc1](https://github.com/paypal/paypal-checkout-components/commit/a4dccc1))
+* Type fixes ([0e3bb65](https://github.com/paypal/paypal-checkout-components/commit/0e3bb65))
+* Update blue button color ([1b64664](https://github.com/paypal/paypal-checkout-components/commit/1b64664))
+* Updated style of buttons when on focus to improve a11y (#1307) ([cb6eff7](https://github.com/paypal/paypal-checkout-components/commit/cb6eff7)), closes [#1307](https://github.com/paypal/paypal-checkout-components/issues/1307)
 
 
 
 ## <small>5.0.89 (2020-05-12)</small>
 
-* Add bank logo for wallet ([c7446f5](http://github.paypal.com/paypal/paypal-checkout/commit/c7446f5))
-* Add clientMetadataID to checkout and make non-optional ([d86f449](http://github.paypal.com/paypal/paypal-checkout/commit/d86f449))
-* Allow vault and wallet buttons to be 250px and greater ([7563ce4](http://github.paypal.com/paypal/paypal-checkout/commit/7563ce4))
-* Only consider immediate children for optional hiding ([07bb7d1](http://github.paypal.com/paypal/paypal-checkout/commit/07bb7d1))
+* Add bank logo for wallet ([c7446f5](https://github.com/paypal/paypal-checkout-components/commit/c7446f5))
+* Add clientMetadataID to checkout and make non-optional ([d86f449](https://github.com/paypal/paypal-checkout-components/commit/d86f449))
+* Allow vault and wallet buttons to be 250px and greater ([7563ce4](https://github.com/paypal/paypal-checkout-components/commit/7563ce4))
+* Only consider immediate children for optional hiding ([07bb7d1](https://github.com/paypal/paypal-checkout-components/commit/07bb7d1))
 
 
 
 ## <small>5.0.88 (2020-05-04)</small>
 
-* Add Fields component ([dcf1922](http://github.paypal.com/paypal/paypal-checkout/commit/dcf1922))
-* Fix divider color ([a40b656](http://github.paypal.com/paypal/paypal-checkout/commit/a40b656))
-* Fix screenshots ([37be9b5](http://github.paypal.com/paypal/paypal-checkout/commit/37be9b5))
-* Pass logoColor to glyph card ([c0db6b3](http://github.paypal.com/paypal/paypal-checkout/commit/c0db6b3))
-* Update implement-checkout.md ([7b0e5ac](http://github.paypal.com/paypal/paypal-checkout/commit/7b0e5ac))
+* Add Fields component ([dcf1922](https://github.com/paypal/paypal-checkout-components/commit/dcf1922))
+* Fix divider color ([a40b656](https://github.com/paypal/paypal-checkout-components/commit/a40b656))
+* Fix screenshots ([37be9b5](https://github.com/paypal/paypal-checkout-components/commit/37be9b5))
+* Pass logoColor to glyph card ([c0db6b3](https://github.com/paypal/paypal-checkout-components/commit/c0db6b3))
+* Update implement-checkout.md ([7b0e5ac](https://github.com/paypal/paypal-checkout-components/commit/7b0e5ac))
 
 
 
 ## <small>5.0.87 (2020-04-29)</small>
 
-* Add authCode param to checkout component ([81a22a9](http://github.paypal.com/paypal/paypal-checkout/commit/81a22a9))
-* Add extra params to button for remember-me ([3ed59f4](http://github.paypal.com/paypal/paypal-checkout/commit/3ed59f4))
-* Add idToken param to checkout ([c32845b](http://github.paypal.com/paypal/paypal-checkout/commit/c32845b))
-* Add missing screenshots ([3124f6b](http://github.paypal.com/paypal/paypal-checkout/commit/3124f6b))
-* Disable personalization when multiple horizontal buttons ([8820ebf](http://github.paypal.com/paypal/paypal-checkout/commit/8820ebf))
-* Do not call getUserIDToken multiple times ([f588ba9](http://github.paypal.com/paypal/paypal-checkout/commit/f588ba9))
-* Ensure new params are not required ([bba674c](http://github.paypal.com/paypal/paypal-checkout/commit/bba674c))
-* Fix jsx-pragmatic import ([fc86abd](http://github.paypal.com/paypal/paypal-checkout/commit/fc86abd))
-* Fix lint and flow ([d55855a](http://github.paypal.com/paypal/paypal-checkout/commit/d55855a))
-* Flow fixes ([95b318c](http://github.paypal.com/paypal/paypal-checkout/commit/95b318c))
-* Remove temporary credit blacklist ([32b33f1](http://github.paypal.com/paypal/paypal-checkout/commit/32b33f1))
-* Send persistRiskData to button child ([183759f](http://github.paypal.com/paypal/paypal-checkout/commit/183759f))
-* Turn authCode into a lazy createAuthCode function ([a7f30f6](http://github.paypal.com/paypal/paypal-checkout/commit/a7f30f6))
-* Wallet button ([6887ba6](http://github.paypal.com/paypal/paypal-checkout/commit/6887ba6))
+* Add authCode param to checkout component ([81a22a9](https://github.com/paypal/paypal-checkout-components/commit/81a22a9))
+* Add extra params to button for remember-me ([3ed59f4](https://github.com/paypal/paypal-checkout-components/commit/3ed59f4))
+* Add idToken param to checkout ([c32845b](https://github.com/paypal/paypal-checkout-components/commit/c32845b))
+* Add missing screenshots ([3124f6b](https://github.com/paypal/paypal-checkout-components/commit/3124f6b))
+* Disable personalization when multiple horizontal buttons ([8820ebf](https://github.com/paypal/paypal-checkout-components/commit/8820ebf))
+* Do not call getUserIDToken multiple times ([f588ba9](https://github.com/paypal/paypal-checkout-components/commit/f588ba9))
+* Ensure new params are not required ([bba674c](https://github.com/paypal/paypal-checkout-components/commit/bba674c))
+* Fix jsx-pragmatic import ([fc86abd](https://github.com/paypal/paypal-checkout-components/commit/fc86abd))
+* Fix lint and flow ([d55855a](https://github.com/paypal/paypal-checkout-components/commit/d55855a))
+* Flow fixes ([95b318c](https://github.com/paypal/paypal-checkout-components/commit/95b318c))
+* Remove temporary credit blacklist ([32b33f1](https://github.com/paypal/paypal-checkout-components/commit/32b33f1))
+* Send persistRiskData to button child ([183759f](https://github.com/paypal/paypal-checkout-components/commit/183759f))
+* Turn authCode into a lazy createAuthCode function ([a7f30f6](https://github.com/paypal/paypal-checkout-components/commit/a7f30f6))
+* Wallet button ([6887ba6](https://github.com/paypal/paypal-checkout-components/commit/6887ba6))
 
 
 
 ## <small>5.0.86 (2020-03-26)</small>
 
-* Add temporary credit button blacklist ([5057e9c](http://github.paypal.com/paypal/paypal-checkout/commit/5057e9c))
+* Add temporary credit button blacklist ([5057e9c](https://github.com/paypal/paypal-checkout-components/commit/5057e9c))
 
 
 
 ## <small>5.0.85 (2020-03-11)</small>
 
-* Add button.clone and Buttons.instances ([d1aba23](http://github.paypal.com/paypal/paypal-checkout/commit/d1aba23))
-* Show label for all vertical buttons ([994400a](http://github.paypal.com/paypal/paypal-checkout/commit/994400a))
-* FEATURE: Integrate Subscribe as a label for en lang (#1279) ([b2789ed](http://github.paypal.com/paypal/paypal-checkout/commit/b2789ed)), closes [#1279](http://github.paypal.com/paypal/paypal-checkout/issues/1279)
+* Add button.clone and Buttons.instances ([d1aba23](https://github.com/paypal/paypal-checkout-components/commit/d1aba23))
+* Show label for all vertical buttons ([994400a](https://github.com/paypal/paypal-checkout-components/commit/994400a))
+* FEATURE: Integrate Subscribe as a label for en lang (#1279) ([b2789ed](https://github.com/paypal/paypal-checkout-components/commit/b2789ed)), closes [#1279](https://github.com/paypal/paypal-checkout-components/issues/1279)
 
 
 
 ## <small>5.0.84 (2020-02-28)</small>
 
-* Always show card button when eligible and when selected as standalone ([8b8f67c](http://github.paypal.com/paypal/paypal-checkout/commit/8b8f67c))
+* Always show card button when eligible and when selected as standalone ([8b8f67c](https://github.com/paypal/paypal-checkout-components/commit/8b8f67c))
 
 
 
 ## <small>5.0.83 (2020-02-28)</small>
 
-* Always show card button when there is a vaulted card ([2dd6d61](http://github.paypal.com/paypal/paypal-checkout/commit/2dd6d61))
+* Always show card button when there is a vaulted card ([2dd6d61](https://github.com/paypal/paypal-checkout-components/commit/2dd6d61))
 
 
 
 ## <small>5.0.82 (2020-02-26)</small>
 
-* Support standalone vault buttons ([533c9dd](http://github.paypal.com/paypal/paypal-checkout/commit/533c9dd))
+* Support standalone vault buttons ([533c9dd](https://github.com/paypal/paypal-checkout-components/commit/533c9dd))
 
 
 
 ## <small>5.0.81 (2020-02-19)</small>
 
-* Fix card logo ([f6a19a0](http://github.paypal.com/paypal/paypal-checkout/commit/f6a19a0))
+* Fix card logo ([f6a19a0](https://github.com/paypal/paypal-checkout-components/commit/f6a19a0))
 
 
 
 ## <small>5.0.80 (2020-02-19)</small>
 
-* Add additional wallet props ([d7ff243](http://github.paypal.com/paypal/paypal-checkout/commit/d7ff243))
-* Add risk data collector to wallet ([00630ca](http://github.paypal.com/paypal/paypal-checkout/commit/00630ca))
-* Add wallet container and prerender templates ([45ecbad](http://github.paypal.com/paypal/paypal-checkout/commit/45ecbad))
-* Export validateButtonProps ([09e65e3](http://github.paypal.com/paypal/paypal-checkout/commit/09e65e3))
-* Fix multiple button label issue ([46f9490](http://github.paypal.com/paypal/paypal-checkout/commit/46f9490))
+* Add additional wallet props ([d7ff243](https://github.com/paypal/paypal-checkout-components/commit/d7ff243))
+* Add risk data collector to wallet ([00630ca](https://github.com/paypal/paypal-checkout-components/commit/00630ca))
+* Add wallet container and prerender templates ([45ecbad](https://github.com/paypal/paypal-checkout-components/commit/45ecbad))
+* Export validateButtonProps ([09e65e3](https://github.com/paypal/paypal-checkout-components/commit/09e65e3))
+* Fix multiple button label issue ([46f9490](https://github.com/paypal/paypal-checkout-components/commit/46f9490))
 
 
 
 ## <small>5.0.79 (2020-02-12)</small>
 
-* Add auth params to wallet component ([7e75b42](http://github.paypal.com/paypal/paypal-checkout/commit/7e75b42))
+* Add auth params to wallet component ([7e75b42](https://github.com/paypal/paypal-checkout-components/commit/7e75b42))
 
 
 
 ## <small>5.0.78 (2020-02-04)</small>
 
-* Default to paypal for style prop normalization ([c1ba6e8](http://github.paypal.com/paypal/paypal-checkout/commit/c1ba6e8))
+* Default to paypal for style prop normalization ([c1ba6e8](https://github.com/paypal/paypal-checkout-components/commit/c1ba6e8))
 
 
 
 ## <small>5.0.77 (2020-01-31)</small>
 
-* Fix tests ([2f9ff11](http://github.paypal.com/paypal/paypal-checkout/commit/2f9ff11))
-* Fix typo ([c1ef880](http://github.paypal.com/paypal/paypal-checkout/commit/c1ef880))
-* Validate funding eligibility before normalizing style ([118fc83](http://github.paypal.com/paypal/paypal-checkout/commit/118fc83))
+* Fix tests ([2f9ff11](https://github.com/paypal/paypal-checkout-components/commit/2f9ff11))
+* Fix typo ([c1ef880](https://github.com/paypal/paypal-checkout-components/commit/c1ef880))
+* Validate funding eligibility before normalizing style ([118fc83](https://github.com/paypal/paypal-checkout-components/commit/118fc83))
 
 
 
 ## <small>5.0.76 (2020-01-30)</small>
 
-* Add Marks eligibility and tests ([8e016de](http://github.paypal.com/paypal/paypal-checkout/commit/8e016de))
-* Add prop definitions to wallet component ([aa088ec](http://github.paypal.com/paypal/paypal-checkout/commit/aa088ec))
+* Add Marks eligibility and tests ([8e016de](https://github.com/paypal/paypal-checkout-components/commit/8e016de))
+* Add prop definitions to wallet component ([aa088ec](https://github.com/paypal/paypal-checkout-components/commit/aa088ec))
 
 
 
 ## <small>5.0.75 (2020-01-23)</small>
 
-* Add paypal.Buttons().isEligible() ([610bffc](http://github.paypal.com/paypal/paypal-checkout/commit/610bffc))
-* Use refined funding eligibility to render venmo button ([5423936](http://github.paypal.com/paypal/paypal-checkout/commit/5423936))
+* Add paypal.Buttons().isEligible() ([610bffc](https://github.com/paypal/paypal-checkout-components/commit/610bffc))
+* Use refined funding eligibility to render venmo button ([5423936](https://github.com/paypal/paypal-checkout-components/commit/5423936))
 
 
 
 ## <small>5.0.74 (2020-01-22)</small>
 
-* Add Wallet zoid component ([a22161c](http://github.paypal.com/paypal/paypal-checkout/commit/a22161c))
-* Allow label to be passed for standalone buttons ([cfc911b](http://github.paypal.com/paypal/paypal-checkout/commit/cfc911b))
-* Export wallet component ([aa1e120](http://github.paypal.com/paypal/paypal-checkout/commit/aa1e120))
-* Fix bundle size and add checks for future builds ([9b25c3f](http://github.paypal.com/paypal/paypal-checkout/commit/9b25c3f))
-* Fix dev server ([d4cb68c](http://github.paypal.com/paypal/paypal-checkout/commit/d4cb68c))
-* Standalone buttons ([a518d85](http://github.paypal.com/paypal/paypal-checkout/commit/a518d85))
-* Test fixes ([e9bf869](http://github.paypal.com/paypal/paypal-checkout/commit/e9bf869))
+* Add Wallet zoid component ([a22161c](https://github.com/paypal/paypal-checkout-components/commit/a22161c))
+* Allow label to be passed for standalone buttons ([cfc911b](https://github.com/paypal/paypal-checkout-components/commit/cfc911b))
+* Export wallet component ([aa1e120](https://github.com/paypal/paypal-checkout-components/commit/aa1e120))
+* Fix bundle size and add checks for future builds ([9b25c3f](https://github.com/paypal/paypal-checkout-components/commit/9b25c3f))
+* Fix dev server ([d4cb68c](https://github.com/paypal/paypal-checkout-components/commit/d4cb68c))
+* Standalone buttons ([a518d85](https://github.com/paypal/paypal-checkout-components/commit/a518d85))
+* Test fixes ([e9bf869](https://github.com/paypal/paypal-checkout-components/commit/e9bf869))
 
 
 
 ## <small>5.0.73 (2020-01-13)</small>
 
-* Fix null pointer in marks component ([6464a90](http://github.paypal.com/paypal/paypal-checkout/commit/6464a90))
+* Fix null pointer in marks component ([6464a90](https://github.com/paypal/paypal-checkout-components/commit/6464a90))
 
 
 
 ## <small>5.0.72 (2020-01-08)</small>
 
-* Add screenshots ([c42c577](http://github.paypal.com/paypal/paypal-checkout/commit/c42c577))
-* Feat/finalize black button (#1267) ([9dc6000](http://github.paypal.com/paypal/paypal-checkout/commit/9dc6000)), closes [#1267](http://github.paypal.com/paypal/paypal-checkout/issues/1267) [#1233](http://github.paypal.com/paypal/paypal-checkout/issues/1233)
+* Add screenshots ([c42c577](https://github.com/paypal/paypal-checkout-components/commit/c42c577))
+* Feat/finalize black button (#1267) ([9dc6000](https://github.com/paypal/paypal-checkout-components/commit/9dc6000)), closes [#1267](https://github.com/paypal/paypal-checkout-components/issues/1267) [#1233](https://github.com/paypal/paypal-checkout-components/issues/1233)
 
 
 
 ## <small>5.0.71 (2019-12-19)</small>
 
-* Revert "Add screenshots" ([e01c9c6](http://github.paypal.com/paypal/paypal-checkout/commit/e01c9c6))
-* Revert "Feat/finalize black button (#1267)" ([529cad1](http://github.paypal.com/paypal/paypal-checkout/commit/529cad1)), closes [#1267](http://github.paypal.com/paypal/paypal-checkout/issues/1267)
+* Revert "Add screenshots" ([e01c9c6](https://github.com/paypal/paypal-checkout-components/commit/e01c9c6))
+* Revert "Feat/finalize black button (#1267)" ([529cad1](https://github.com/paypal/paypal-checkout-components/commit/529cad1)), closes [#1267](https://github.com/paypal/paypal-checkout-components/issues/1267)
 
 
 
 ## <small>5.0.70 (2019-12-19)</small>
 
-* Add demo content ([0d95094](http://github.paypal.com/paypal/paypal-checkout/commit/0d95094))
-* Add screenshots ([509ccfd](http://github.paypal.com/paypal/paypal-checkout/commit/509ccfd))
-* Feat/finalize black button (#1267) ([e280244](http://github.paypal.com/paypal/paypal-checkout/commit/e280244)), closes [#1267](http://github.paypal.com/paypal/paypal-checkout/issues/1267) [#1233](http://github.paypal.com/paypal/paypal-checkout/issues/1233)
-* show personalized button text only when tagline:false (#1270) ([ad0447a](http://github.paypal.com/paypal/paypal-checkout/commit/ad0447a)), closes [#1270](http://github.paypal.com/paypal/paypal-checkout/issues/1270)
+* Add demo content ([0d95094](https://github.com/paypal/paypal-checkout-components/commit/0d95094))
+* Add screenshots ([509ccfd](https://github.com/paypal/paypal-checkout-components/commit/509ccfd))
+* Feat/finalize black button (#1267) ([e280244](https://github.com/paypal/paypal-checkout-components/commit/e280244)), closes [#1267](https://github.com/paypal/paypal-checkout-components/issues/1267) [#1233](https://github.com/paypal/paypal-checkout-components/issues/1233)
+* show personalized button text only when tagline:false (#1270) ([ad0447a](https://github.com/paypal/paypal-checkout-components/commit/ad0447a)), closes [#1270](https://github.com/paypal/paypal-checkout-components/issues/1270)
 
 
 
 ## <small>5.0.69 (2019-12-11)</small>
 
-* Add Modal component ([bce6108](http://github.paypal.com/paypal/paypal-checkout/commit/bce6108))
-* Remove button aria-label in favor of button content text ([4e64669](http://github.paypal.com/paypal/paypal-checkout/commit/4e64669))
+* Add Modal component ([bce6108](https://github.com/paypal/paypal-checkout-components/commit/bce6108))
+* Remove button aria-label in favor of button content text ([4e64669](https://github.com/paypal/paypal-checkout-components/commit/4e64669))
 
 
 
 ## <small>5.0.68 (2019-11-22)</small>
 
-* Manually insert spaces in credit logo to allow size calculation ([182c009](http://github.paypal.com/paypal/paypal-checkout/commit/182c009))
+* Manually insert spaces in credit logo to allow size calculation ([182c009](https://github.com/paypal/paypal-checkout-components/commit/182c009))
 
 
 
 ## <small>5.0.67 (2019-11-22)</small>
 
-* Allow SPB server to re-fetch vaultable flag ([9fa3b9e](http://github.paypal.com/paypal/paypal-checkout/commit/9fa3b9e))
+* Allow SPB server to re-fetch vaultable flag ([9fa3b9e](https://github.com/paypal/paypal-checkout-components/commit/9fa3b9e))
 
 
 
 ## <small>5.0.66 (2019-11-21)</small>
 
-* Do not add sdkMeta to credit url with sdkMeta already set ([e5f2599](http://github.paypal.com/paypal/paypal-checkout/commit/e5f2599))
+* Do not add sdkMeta to credit url with sdkMeta already set ([e5f2599](https://github.com/paypal/paypal-checkout-components/commit/e5f2599))
 
 
 
 ## <small>5.0.65 (2019-11-21)</small>
 
-* Add tracking beacon to personalization button text ([6902854](http://github.paypal.com/paypal/paypal-checkout/commit/6902854))
-* Personalization animation fixes ([2fe2a89](http://github.paypal.com/paypal/paypal-checkout/commit/2fe2a89))
-* Remove tagline height when no tagline displayed ([72fda11](http://github.paypal.com/paypal/paypal-checkout/commit/72fda11))
+* Add tracking beacon to personalization button text ([6902854](https://github.com/paypal/paypal-checkout-components/commit/6902854))
+* Personalization animation fixes ([2fe2a89](https://github.com/paypal/paypal-checkout-components/commit/2fe2a89))
+* Remove tagline height when no tagline displayed ([72fda11](https://github.com/paypal/paypal-checkout-components/commit/72fda11))
 
 
 
 ## <small>5.0.64 (2019-11-20)</small>
 
-* Add sdkMeta param during credit redirect ([f3253cd](http://github.paypal.com/paypal/paypal-checkout/commit/f3253cd))
-* Factor out loading dots for tagline ([0810270](http://github.paypal.com/paypal/paypal-checkout/commit/0810270))
-* Ramp black button to 100% only for US (for now) (#1257) ([978021c](http://github.paypal.com/paypal/paypal-checkout/commit/978021c)), closes [#1257](http://github.paypal.com/paypal/paypal-checkout/issues/1257)
-* Remove redundant flowfixmes ([c32c0fe](http://github.paypal.com/paypal/paypal-checkout/commit/c32c0fe))
-* Slide transition for button label ([a2ee53b](http://github.paypal.com/paypal/paypal-checkout/commit/a2ee53b))
-* Split out paypal button templates ([f31fbda](http://github.paypal.com/paypal/paypal-checkout/commit/f31fbda))
-* Use box-sizing: border-box across all button elements ([84fda1a](http://github.paypal.com/paypal/paypal-checkout/commit/84fda1a))
+* Add sdkMeta param during credit redirect ([f3253cd](https://github.com/paypal/paypal-checkout-components/commit/f3253cd))
+* Factor out loading dots for tagline ([0810270](https://github.com/paypal/paypal-checkout-components/commit/0810270))
+* Ramp black button to 100% only for US (for now) (#1257) ([978021c](https://github.com/paypal/paypal-checkout-components/commit/978021c)), closes [#1257](https://github.com/paypal/paypal-checkout-components/issues/1257)
+* Remove redundant flowfixmes ([c32c0fe](https://github.com/paypal/paypal-checkout-components/commit/c32c0fe))
+* Slide transition for button label ([a2ee53b](https://github.com/paypal/paypal-checkout-components/commit/a2ee53b))
+* Split out paypal button templates ([f31fbda](https://github.com/paypal/paypal-checkout-components/commit/f31fbda))
+* Use box-sizing: border-box across all button elements ([84fda1a](https://github.com/paypal/paypal-checkout-components/commit/84fda1a))
 
 
 
 ## <small>5.0.63 (2019-10-30)</small>
 
-* Fix the missing data attr for the black button (#1242) ([870d70a](http://github.paypal.com/paypal/paypal-checkout/commit/870d70a)), closes [#1242](http://github.paypal.com/paypal/paypal-checkout/issues/1242)
+* Fix the missing data attr for the black button (#1242) ([870d70a](https://github.com/paypal/paypal-checkout-components/commit/870d70a)), closes [#1242](https://github.com/paypal/paypal-checkout-components/issues/1242)
 
 
 
 ## <small>5.0.62 (2019-10-28)</small>
 
-* Ramp down card button experiment ([669880f](http://github.paypal.com/paypal/paypal-checkout/commit/669880f))
+* Ramp down card button experiment ([669880f](https://github.com/paypal/paypal-checkout-components/commit/669880f))
 
 
 
 ## <small>5.0.61 (2019-10-25)</small>
 
-* Add vault dropdown menu button ([32d3d83](http://github.paypal.com/paypal/paypal-checkout/commit/32d3d83))
-* Work on Inline Guest black button (#1233) ([3b53bfc](http://github.paypal.com/paypal/paypal-checkout/commit/3b53bfc)), closes [#1233](http://github.paypal.com/paypal/paypal-checkout/issues/1233)
-* feat(*): add onKeyPress event to BasicButton and VaultedButton (#1181) ([1c7dab4](http://github.paypal.com/paypal/paypal-checkout/commit/1c7dab4)), closes [#1181](http://github.paypal.com/paypal/paypal-checkout/issues/1181)
+* Add vault dropdown menu button ([32d3d83](https://github.com/paypal/paypal-checkout-components/commit/32d3d83))
+* Work on Inline Guest black button (#1233) ([3b53bfc](https://github.com/paypal/paypal-checkout-components/commit/3b53bfc)), closes [#1233](https://github.com/paypal/paypal-checkout-components/issues/1233)
+* feat(*): add onKeyPress event to BasicButton and VaultedButton (#1181) ([1c7dab4](https://github.com/paypal/paypal-checkout-components/commit/1c7dab4)), closes [#1181](https://github.com/paypal/paypal-checkout-components/issues/1181)
 
 
 
 ## <small>5.0.60 (2019-10-09)</small>
 
-* Consume personalized tagline and button text components ([74a08eb](http://github.paypal.com/paypal/paypal-checkout/commit/74a08eb))
+* Consume personalized tagline and button text components ([74a08eb](https://github.com/paypal/paypal-checkout-components/commit/74a08eb))
 
 
 
 ## <small>5.0.59 (2019-10-02)</small>
 
-* Add new funding types ([790ee87](http://github.paypal.com/paypal/paypal-checkout/commit/790ee87))
-* Add oxxo, boleto and maxima new funding (#1212) ([4acfa24](http://github.paypal.com/paypal/paypal-checkout/commit/4acfa24)), closes [#1212](http://github.paypal.com/paypal/paypal-checkout/issues/1212)
-* Add tests for native component ([1b2399d](http://github.paypal.com/paypal/paypal-checkout/commit/1b2399d))
-* adding Q3 payment methods [payu, blik,trustly and verkkopankki] (#1160) ([7595f56](http://github.paypal.com/paypal/paypal-checkout/commit/7595f56)), closes [#1160](http://github.paypal.com/paypal/paypal-checkout/issues/1160)
-* Disable react/no-unused-prop-types ([5d422c9](http://github.paypal.com/paypal/paypal-checkout/commit/5d422c9))
-* Increase popup size ([ffbfbd6](http://github.paypal.com/paypal/paypal-checkout/commit/ffbfbd6))
-* Minor fixes for smart menu ([cb5880b](http://github.paypal.com/paypal/paypal-checkout/commit/cb5880b))
-* Remove native code from sdk layer ([23f812b](http://github.paypal.com/paypal/paypal-checkout/commit/23f812b))
-* Trustly bug fix and blik priority increased above p24 (#1220) ([66e83cf](http://github.paypal.com/paypal/paypal-checkout/commit/66e83cf)), closes [#1220](http://github.paypal.com/paypal/paypal-checkout/issues/1220)
-* Use spinner page from common components ([147e573](http://github.paypal.com/paypal/paypal-checkout/commit/147e573))
+* Add new funding types ([790ee87](https://github.com/paypal/paypal-checkout-components/commit/790ee87))
+* Add oxxo, boleto and maxima new funding (#1212) ([4acfa24](https://github.com/paypal/paypal-checkout-components/commit/4acfa24)), closes [#1212](https://github.com/paypal/paypal-checkout-components/issues/1212)
+* Add tests for native component ([1b2399d](https://github.com/paypal/paypal-checkout-components/commit/1b2399d))
+* adding Q3 payment methods [payu, blik,trustly and verkkopankki] (#1160) ([7595f56](https://github.com/paypal/paypal-checkout-components/commit/7595f56)), closes [#1160](https://github.com/paypal/paypal-checkout-components/issues/1160)
+* Disable react/no-unused-prop-types ([5d422c9](https://github.com/paypal/paypal-checkout-components/commit/5d422c9))
+* Increase popup size ([ffbfbd6](https://github.com/paypal/paypal-checkout-components/commit/ffbfbd6))
+* Minor fixes for smart menu ([cb5880b](https://github.com/paypal/paypal-checkout-components/commit/cb5880b))
+* Remove native code from sdk layer ([23f812b](https://github.com/paypal/paypal-checkout-components/commit/23f812b))
+* Trustly bug fix and blik priority increased above p24 (#1220) ([66e83cf](https://github.com/paypal/paypal-checkout-components/commit/66e83cf)), closes [#1220](https://github.com/paypal/paypal-checkout-components/issues/1220)
+* Use spinner page from common components ([147e573](https://github.com/paypal/paypal-checkout-components/commit/147e573))
 
 
 
 ## <small>5.0.58 (2019-09-18)</small>
 
-* Add Native component ([3f85901](http://github.paypal.com/paypal/paypal-checkout/commit/3f85901))
+* Add Native component ([3f85901](https://github.com/paypal/paypal-checkout-components/commit/3f85901))
 
 
 
 ## <small>5.0.57 (2019-09-17)</small>
 
-* Add onFocused event registrar ([bda4fe9](http://github.paypal.com/paypal/paypal-checkout/commit/bda4fe9))
-* Allow overriding checkout uri ([5615b57](http://github.paypal.com/paypal/paypal-checkout/commit/5615b57))
+* Add onFocused event registrar ([bda4fe9](https://github.com/paypal/paypal-checkout-components/commit/bda4fe9))
+* Allow overriding checkout uri ([5615b57](https://github.com/paypal/paypal-checkout-components/commit/5615b57))
 
 
 
 ## <small>5.0.56 (2019-09-11)</small>
 
-* Return a function from getPageUrl ([f6f77fe](http://github.paypal.com/paypal/paypal-checkout/commit/f6f77fe))
+* Return a function from getPageUrl ([f6f77fe](https://github.com/paypal/paypal-checkout-components/commit/f6f77fe))
 
 
 
 ## <small>5.0.55 (2019-09-11)</small>
 
-* Make stage host props optional ([dd9cea2](http://github.paypal.com/paypal/paypal-checkout/commit/dd9cea2))
+* Make stage host props optional ([dd9cea2](https://github.com/paypal/paypal-checkout-components/commit/dd9cea2))
 
 
 
 ## <small>5.0.54 (2019-09-10)</small>
 
-* Add getPageUrl prop to buttons ([fb336e0](http://github.paypal.com/paypal/paypal-checkout/commit/fb336e0))
-* Add stageHost and apiStageHost props to button ([60553d9](http://github.paypal.com/paypal/paypal-checkout/commit/60553d9))
+* Add getPageUrl prop to buttons ([fb336e0](https://github.com/paypal/paypal-checkout-components/commit/fb336e0))
+* Add stageHost and apiStageHost props to button ([60553d9](https://github.com/paypal/paypal-checkout-components/commit/60553d9))
 
 
 
 ## <small>5.0.53 (2019-08-15)</small>
 
-* Add extra params to menu component ([883d307](http://github.paypal.com/paypal/paypal-checkout/commit/883d307))
+* Add extra params to menu component ([883d307](https://github.com/paypal/paypal-checkout-components/commit/883d307))
 
 
 
 ## <small>5.0.52 (2019-08-07)</small>
 
-* Add export for menu component ([36dc656](http://github.paypal.com/paypal/paypal-checkout/commit/36dc656))
-* Add menu zoid component ([44e8c3b](http://github.paypal.com/paypal/paypal-checkout/commit/44e8c3b))
-* Add puppeteer download host ([ecac208](http://github.paypal.com/paypal/paypal-checkout/commit/ecac208))
-* Fix circular dependency ([b69c149](http://github.paypal.com/paypal/paypal-checkout/commit/b69c149))
-* Only show personalization if single button ([f15a804](http://github.paypal.com/paypal/paypal-checkout/commit/f15a804))
-* Re-organize directory structure ([1ee9116](http://github.paypal.com/paypal/paypal-checkout/commit/1ee9116))
+* Add export for menu component ([36dc656](https://github.com/paypal/paypal-checkout-components/commit/36dc656))
+* Add menu zoid component ([44e8c3b](https://github.com/paypal/paypal-checkout-components/commit/44e8c3b))
+* Add puppeteer download host ([ecac208](https://github.com/paypal/paypal-checkout-components/commit/ecac208))
+* Fix circular dependency ([b69c149](https://github.com/paypal/paypal-checkout-components/commit/b69c149))
+* Only show personalization if single button ([f15a804](https://github.com/paypal/paypal-checkout-components/commit/f15a804))
+* Re-organize directory structure ([1ee9116](https://github.com/paypal/paypal-checkout-components/commit/1ee9116))
 
 
 
 ## <small>5.0.51 (2019-07-30)</small>
 
-* Fix typo ([1f7ca26](http://github.paypal.com/paypal/paypal-checkout/commit/1f7ca26))
+* Fix typo ([1f7ca26](https://github.com/paypal/paypal-checkout-components/commit/1f7ca26))
 
 
 
 ## <small>5.0.50 (2019-07-30)</small>
 
-* Add nonce to style tag ([49ac557](http://github.paypal.com/paypal/paypal-checkout/commit/49ac557))
+* Add nonce to style tag ([49ac557](https://github.com/paypal/paypal-checkout-components/commit/49ac557))
 
 
 
@@ -363,161 +363,103 @@
 
 ## <small>5.0.48 (2019-07-30)</small>
 
-* Add impression beacon for tagline personalization ([2286fe8](http://github.paypal.com/paypal/paypal-checkout/commit/2286fe8))
+* Add impression beacon for tagline personalization ([2286fe8](https://github.com/paypal/paypal-checkout-components/commit/2286fe8))
 
 
 
 ## <small>5.0.47 (2019-07-29)</small>
 
-* Add missing types ([ff0c7a2](http://github.paypal.com/paypal/paypal-checkout/commit/ff0c7a2))
-* Fix label logic for multiple buttons ([13c5c32](http://github.paypal.com/paypal/paypal-checkout/commit/13c5c32))
-* Remove web static dependency on localization content ([9c11c7c](http://github.paypal.com/paypal/paypal-checkout/commit/9c11c7c))
+* Add missing types ([ff0c7a2](https://github.com/paypal/paypal-checkout-components/commit/ff0c7a2))
+* Fix label logic for multiple buttons ([13c5c32](https://github.com/paypal/paypal-checkout-components/commit/13c5c32))
+* Remove web static dependency on localization content ([9c11c7c](https://github.com/paypal/paypal-checkout-components/commit/9c11c7c))
 
 
 
 ## <small>5.0.46 (2019-07-24)</small>
 
-* Do not show loading dots if label or client token (for vault) not passed ([295db21](http://github.paypal.com/paypal/paypal-checkout/commit/295db21))
+* Do not show loading dots if label or client token (for vault) not passed ([295db21](https://github.com/paypal/paypal-checkout-components/commit/295db21))
 
 
 
 ## <small>5.0.45 (2019-07-24)</small>
 
-* Add loader for localized content in first render ([4b9a8fb](http://github.paypal.com/paypal/paypal-checkout/commit/4b9a8fb))
-* Add personalization of the tagline ([8649279](http://github.paypal.com/paypal/paypal-checkout/commit/8649279))
-* Making darkblue as default for Itau (#1165) ([a4d2764](http://github.paypal.com/paypal/paypal-checkout/commit/a4d2764)), closes [#1165](http://github.paypal.com/paypal/paypal-checkout/issues/1165)
+* Add loader for localized content in first render ([4b9a8fb](https://github.com/paypal/paypal-checkout-components/commit/4b9a8fb))
+* Add personalization of the tagline ([8649279](https://github.com/paypal/paypal-checkout-components/commit/8649279))
+* Making darkblue as default for Itau (#1165) ([a4d2764](https://github.com/paypal/paypal-checkout-components/commit/a4d2764)), closes [#1165](https://github.com/paypal/paypal-checkout-components/issues/1165)
 
 
 
 ## <small>5.0.44 (2019-07-17)</small>
 
-* Add text to ideal button ([24724c1](http://github.paypal.com/paypal/paypal-checkout/commit/24724c1))
+* Add text to ideal button ([24724c1](https://github.com/paypal/paypal-checkout-components/commit/24724c1))
 
 
 
 ## <small>5.0.43 (2019-07-17)</small>
 
-* Do not display vaulted funding if onShippingChange passed ([3dd02b1](http://github.paypal.com/paypal/paypal-checkout/commit/3dd02b1))
+* Do not display vaulted funding if onShippingChange passed ([3dd02b1](https://github.com/paypal/paypal-checkout-components/commit/3dd02b1))
 
 
 
 ## <small>5.0.42 (2019-07-15)</small>
 
-* Accept logo as a parameter for content ([8e893f2](http://github.paypal.com/paypal/paypal-checkout/commit/8e893f2))
-* Add powered by PayPal tagline ([ac23dd1](http://github.paypal.com/paypal/paypal-checkout/commit/ac23dd1))
-* Cleanup ([565d977](http://github.paypal.com/paypal/paypal-checkout/commit/565d977))
-* Fix button prerender transition ([80add1b](http://github.paypal.com/paypal/paypal-checkout/commit/80add1b))
-* Fix popupBridge and add tests ([81318d0](http://github.paypal.com/paypal/paypal-checkout/commit/81318d0))
-* Pass query param for onShippingChange to allow server side eligibility to work ([7155e1a](http://github.paypal.com/paypal/paypal-checkout/commit/7155e1a))
-* Remove label config ([5dca9fa](http://github.paypal.com/paypal/paypal-checkout/commit/5dca9fa))
+* Accept logo as a parameter for content ([8e893f2](https://github.com/paypal/paypal-checkout-components/commit/8e893f2))
+* Add powered by PayPal tagline ([ac23dd1](https://github.com/paypal/paypal-checkout-components/commit/ac23dd1))
+* Cleanup ([565d977](https://github.com/paypal/paypal-checkout-components/commit/565d977))
+* Fix button prerender transition ([80add1b](https://github.com/paypal/paypal-checkout-components/commit/80add1b))
+* Fix popupBridge and add tests ([81318d0](https://github.com/paypal/paypal-checkout-components/commit/81318d0))
+* Pass query param for onShippingChange to allow server side eligibility to work ([7155e1a](https://github.com/paypal/paypal-checkout-components/commit/7155e1a))
+* Remove label config ([5dca9fa](https://github.com/paypal/paypal-checkout-components/commit/5dca9fa))
 
 
 
 ## <small>5.0.41 (2019-07-02)</small>
 
-* Add pay instantly translations ([9125d03](http://github.paypal.com/paypal/paypal-checkout/commit/9125d03))
-* Adjust marks style ([b359da5](http://github.paypal.com/paypal/paypal-checkout/commit/b359da5))
-* Use insertMockSDKScript helper ([f44c06e](http://github.paypal.com/paypal/paypal-checkout/commit/f44c06e))
+* Add pay instantly translations ([9125d03](https://github.com/paypal/paypal-checkout-components/commit/9125d03))
+* Adjust marks style ([b359da5](https://github.com/paypal/paypal-checkout-components/commit/b359da5))
+* Use insertMockSDKScript helper ([f44c06e](https://github.com/paypal/paypal-checkout-components/commit/f44c06e))
 
 
 
 ## <small>5.0.40 (2019-06-17)</small>
 
-* fix(credit-button): Credit button will no longer display if its vendors are all ineligible (#1128) ([61e73f9](http://github.paypal.com/paypal/paypal-checkout/commit/61e73f9)), closes [#1128](http://github.paypal.com/paypal/paypal-checkout/issues/1128)
-* Add card attribute to card buttons ([f918df1](http://github.paypal.com/paypal/paypal-checkout/commit/f918df1))
-* Add debug query param to button ([5c0ec3f](http://github.paypal.com/paypal/paypal-checkout/commit/5c0ec3f))
-* Add enableVault param ([e588c8b](http://github.paypal.com/paypal/paypal-checkout/commit/e588c8b))
-* Add fundingSource to card buttons ([cf76a5e](http://github.paypal.com/paypal/paypal-checkout/commit/cf76a5e))
-* Add margin for vault label ([b9274a9](http://github.paypal.com/paypal/paypal-checkout/commit/b9274a9))
-* Add margin for vault label ([a8d90a3](http://github.paypal.com/paypal/paypal-checkout/commit/a8d90a3))
-* Add SKIP_TEST flag ([ce238e5](http://github.paypal.com/paypal/paypal-checkout/commit/ce238e5))
-* Add vaulted funding header ([2600079](http://github.paypal.com/paypal/paypal-checkout/commit/2600079))
-* Adding ITAU funding (#1124) ([91f01f7](http://github.paypal.com/paypal/paypal-checkout/commit/91f01f7)), closes [#1124](http://github.paypal.com/paypal/paypal-checkout/issues/1124)
-* Change vault tagline ([df0cda8](http://github.paypal.com/paypal/paypal-checkout/commit/df0cda8))
-* Deanonymize cross-window call ([7e6e274](http://github.paypal.com/paypal/paypal-checkout/commit/7e6e274))
-* Defocus button on click ([35de8a9](http://github.paypal.com/paypal/paypal-checkout/commit/35de8a9))
-* Disable apms when onShippingChange passed ([d1e1f02](http://github.paypal.com/paypal/paypal-checkout/commit/d1e1f02))
-* Disable scrolling in card fields frame ([2b88d4d](http://github.paypal.com/paypal/paypal-checkout/commit/2b88d4d))
-* Ensure content does not display at the same time as loading spinner ([b7a022f](http://github.paypal.com/paypal/paypal-checkout/commit/b7a022f))
-* feat(subscriptions) Add Create Subscription Method (#1100) ([44f83b0](http://github.paypal.com/paypal/paypal-checkout/commit/44f83b0)), closes [#1100](http://github.paypal.com/paypal/paypal-checkout/issues/1100)
-* fix card tree shaking ([9cc3513](http://github.paypal.com/paypal/paypal-checkout/commit/9cc3513))
-* Fix checkout iframe scrolling in webviews ([c98ada4](http://github.paypal.com/paypal/paypal-checkout/commit/c98ada4))
-* Fix credit screenshot ([9483f43](http://github.paypal.com/paypal/paypal-checkout/commit/9483f43))
-* Fix dev server ([d7a56a2](http://github.paypal.com/paypal/paypal-checkout/commit/d7a56a2))
-* Fix document passed to prerender template from pre-button-click ([b3fd9ab](http://github.paypal.com/paypal/paypal-checkout/commit/b3fd9ab))
-* Fix fundingEligibility type to make everything optional ([d6e34c2](http://github.paypal.com/paypal/paypal-checkout/commit/d6e34c2))
-* Fix jsx logos integration ([d0e71a7](http://github.paypal.com/paypal/paypal-checkout/commit/d0e71a7))
-* Fix typo ([ec85149](http://github.paypal.com/paypal/paypal-checkout/commit/ec85149))
-* Force card to be ineligible if passed in disableFunding ([d23e5ac](http://github.paypal.com/paypal/paypal-checkout/commit/d23e5ac))
-* Initial Mark component implementation ([b6b60e9](http://github.paypal.com/paypal/paypal-checkout/commit/b6b60e9))
-* More explicit eligibility logic for cards ([4a5d02c](http://github.paypal.com/paypal/paypal-checkout/commit/4a5d02c))
-* Move logic down to smart buttons ([7bb0567](http://github.paypal.com/paypal/paypal-checkout/commit/7bb0567))
-* Null checks for eligibility tree shaking ([75c9270](http://github.paypal.com/paypal/paypal-checkout/commit/75c9270))
-* Pass along data to onClick ([8b49fa4](http://github.paypal.com/paypal/paypal-checkout/commit/8b49fa4))
-* Pass enableThreeDomainSecure ([1e83cca](http://github.paypal.com/paypal/paypal-checkout/commit/1e83cca))
-* Pass in context for button render webpack config ([3ba160f](http://github.paypal.com/paypal/paypal-checkout/commit/3ba160f))
-* Point to /checkoutnow on localhost ([f3b39dc](http://github.paypal.com/paypal/paypal-checkout/commit/f3b39dc))
-* Publish button render event ([162268c](http://github.paypal.com/paypal/paypal-checkout/commit/162268c))
-* Reduce margin for vault header ([1e5811d](http://github.paypal.com/paypal/paypal-checkout/commit/1e5811d))
-* Remove Array.from ([c5604e0](http://github.paypal.com/paypal/paypal-checkout/commit/c5604e0))
-* Remove redundant code handled by smart-buttons ([1a2f890](http://github.paypal.com/paypal/paypal-checkout/commit/1a2f890))
-* Suppress flow checks for puppeteer import ([3caade7](http://github.paypal.com/paypal/paypal-checkout/commit/3caade7))
-* Upgrade flow ([8a4d79b](http://github.paypal.com/paypal/paypal-checkout/commit/8a4d79b))
-* Use @paypal/funding-components module for remembered funding ([fc3b39b](http://github.paypal.com/paypal/paypal-checkout/commit/fc3b39b))
-* Use common overlay component ([3824c08](http://github.paypal.com/paypal/paypal-checkout/commit/3824c08))
-* chore(release): 5.0.22 :tada: ([ab4679e](http://github.paypal.com/paypal/paypal-checkout/commit/ab4679e))
-* chore(release): 5.0.23 :tada: ([c7f2f64](http://github.paypal.com/paypal/paypal-checkout/commit/c7f2f64))
-* chore(release): 5.0.24 :tada: ([bdb8d32](http://github.paypal.com/paypal/paypal-checkout/commit/bdb8d32))
-* chore(release): 5.0.25 :tada: ([c42df58](http://github.paypal.com/paypal/paypal-checkout/commit/c42df58))
-* chore(release): 5.0.26 :tada: ([2b47ff6](http://github.paypal.com/paypal/paypal-checkout/commit/2b47ff6))
-* chore(release): 5.0.27 :tada: ([bf25864](http://github.paypal.com/paypal/paypal-checkout/commit/bf25864))
-* chore(release): 5.0.28 :tada: ([4972c7d](http://github.paypal.com/paypal/paypal-checkout/commit/4972c7d))
-* chore(release): 5.0.29 :tada: ([5229fa8](http://github.paypal.com/paypal/paypal-checkout/commit/5229fa8))
-* chore(release): 5.0.30 :tada: ([ef3c4b9](http://github.paypal.com/paypal/paypal-checkout/commit/ef3c4b9))
-* chore(release): 5.0.31 :tada: ([7f23646](http://github.paypal.com/paypal/paypal-checkout/commit/7f23646))
-* chore(release): 5.0.32 :tada: ([38e0c19](http://github.paypal.com/paypal/paypal-checkout/commit/38e0c19))
-* chore(release): 5.0.33 :tada: ([0075586](http://github.paypal.com/paypal/paypal-checkout/commit/0075586))
-* chore(release): 5.0.34 :tada: ([c997e22](http://github.paypal.com/paypal/paypal-checkout/commit/c997e22))
-* chore(release): 5.0.35 :tada: ([ca91c2e](http://github.paypal.com/paypal/paypal-checkout/commit/ca91c2e))
-* chore(release): 5.0.36 :tada: ([2a2aa76](http://github.paypal.com/paypal/paypal-checkout/commit/2a2aa76))
-* chore(release): 5.0.37 :tada: ([050fc0f](http://github.paypal.com/paypal/paypal-checkout/commit/050fc0f))
-* chore(release): 5.0.38 :tada: ([511cc44](http://github.paypal.com/paypal/paypal-checkout/commit/511cc44))
-* chore(release): 5.0.39 :tada: ([f14ae4e](http://github.paypal.com/paypal/paypal-checkout/commit/f14ae4e))
+* fix(credit-button): Credit button will no longer display if its vendors are all ineligible (#1128) ([61e73f9](https://github.com/paypal/paypal-checkout-components/commit/61e73f9)), closes [#1128](https://github.com/paypal/paypal-checkout-components/issues/1128)
+* Adding ITAU funding (#1124) ([91f01f7](https://github.com/paypal/paypal-checkout-components/commit/91f01f7)), closes [#1124](https://github.com/paypal/paypal-checkout-components/issues/1124)
 
 
 
 ## <small>5.0.39 (2019-06-12)</small>
 
-* Fix credit screenshot ([9483f43](http://github.paypal.com/paypal/paypal-checkout/commit/9483f43))
-* Fix dev server ([d7a56a2](http://github.paypal.com/paypal/paypal-checkout/commit/d7a56a2))
-* Initial Mark component implementation ([b6b60e9](http://github.paypal.com/paypal/paypal-checkout/commit/b6b60e9))
-* Move logic down to smart buttons ([7bb0567](http://github.paypal.com/paypal/paypal-checkout/commit/7bb0567))
-* Point to /checkoutnow on localhost ([f3b39dc](http://github.paypal.com/paypal/paypal-checkout/commit/f3b39dc))
-* Suppress flow checks for puppeteer import ([3caade7](http://github.paypal.com/paypal/paypal-checkout/commit/3caade7))
-* Use @paypal/funding-components module for remembered funding ([fc3b39b](http://github.paypal.com/paypal/paypal-checkout/commit/fc3b39b))
-* Use common overlay component ([3824c08](http://github.paypal.com/paypal/paypal-checkout/commit/3824c08))
+* Fix credit screenshot ([9483f43](https://github.com/paypal/paypal-checkout-components/commit/9483f43))
+* Fix dev server ([d7a56a2](https://github.com/paypal/paypal-checkout-components/commit/d7a56a2))
+* Initial Mark component implementation ([b6b60e9](https://github.com/paypal/paypal-checkout-components/commit/b6b60e9))
+* Move logic down to smart buttons ([7bb0567](https://github.com/paypal/paypal-checkout-components/commit/7bb0567))
+* Point to /checkoutnow on localhost ([f3b39dc](https://github.com/paypal/paypal-checkout-components/commit/f3b39dc))
+* Suppress flow checks for puppeteer import ([3caade7](https://github.com/paypal/paypal-checkout-components/commit/3caade7))
+* Use @paypal/funding-components module for remembered funding ([fc3b39b](https://github.com/paypal/paypal-checkout-components/commit/fc3b39b))
+* Use common overlay component ([3824c08](https://github.com/paypal/paypal-checkout-components/commit/3824c08))
 
 
 
 ## <small>5.0.38 (2019-06-03)</small>
 
-* Add SKIP_TEST flag ([ce238e5](http://github.paypal.com/paypal/paypal-checkout/commit/ce238e5))
-* Ensure content does not display at the same time as loading spinner ([b7a022f](http://github.paypal.com/paypal/paypal-checkout/commit/b7a022f))
-* Pass in context for button render webpack config ([3ba160f](http://github.paypal.com/paypal/paypal-checkout/commit/3ba160f))
-* Upgrade flow ([8a4d79b](http://github.paypal.com/paypal/paypal-checkout/commit/8a4d79b))
+* Add SKIP_TEST flag ([ce238e5](https://github.com/paypal/paypal-checkout-components/commit/ce238e5))
+* Ensure content does not display at the same time as loading spinner ([b7a022f](https://github.com/paypal/paypal-checkout-components/commit/b7a022f))
+* Pass in context for button render webpack config ([3ba160f](https://github.com/paypal/paypal-checkout-components/commit/3ba160f))
+* Upgrade flow ([8a4d79b](https://github.com/paypal/paypal-checkout-components/commit/8a4d79b))
 
 
 
 ## <small>5.0.37 (2019-05-31)</small>
 
-* Fix fundingEligibility type to make everything optional ([d6e34c2](http://github.paypal.com/paypal/paypal-checkout/commit/d6e34c2))
-* Force card to be ineligible if passed in disableFunding ([d23e5ac](http://github.paypal.com/paypal/paypal-checkout/commit/d23e5ac))
+* Fix fundingEligibility type to make everything optional ([d6e34c2](https://github.com/paypal/paypal-checkout-components/commit/d6e34c2))
+* Force card to be ineligible if passed in disableFunding ([d23e5ac](https://github.com/paypal/paypal-checkout-components/commit/d23e5ac))
 
 
 
 ## <small>5.0.36 (2019-05-30)</small>
 
-* Fix jsx logos integration ([d0e71a7](http://github.paypal.com/paypal/paypal-checkout/commit/d0e71a7))
+* Fix jsx logos integration ([d0e71a7](https://github.com/paypal/paypal-checkout-components/commit/d0e71a7))
 
 
 
@@ -528,3221 +470,3453 @@
 
 ## <small>5.0.34 (2019-05-29)</small>
 
-* fix card tree shaking ([9cc3513](http://github.paypal.com/paypal/paypal-checkout/commit/9cc3513))
+* fix card tree shaking ([9cc3513](https://github.com/paypal/paypal-checkout-components/commit/9cc3513))
 
 
 
 ## <small>5.0.33 (2019-05-23)</small>
 
-* Null checks for eligibility tree shaking ([75c9270](http://github.paypal.com/paypal/paypal-checkout/commit/75c9270))
+* Null checks for eligibility tree shaking ([75c9270](https://github.com/paypal/paypal-checkout-components/commit/75c9270))
 
 
 
 ## <small>5.0.32 (2019-05-21)</small>
 
-* Pass along data to onClick ([8b49fa4](http://github.paypal.com/paypal/paypal-checkout/commit/8b49fa4))
+* Pass along data to onClick ([8b49fa4](https://github.com/paypal/paypal-checkout-components/commit/8b49fa4))
 
 
 
 ## <small>5.0.31 (2019-05-21)</small>
 
-* Disable apms when onShippingChange passed ([d1e1f02](http://github.paypal.com/paypal/paypal-checkout/commit/d1e1f02))
+* Disable apms when onShippingChange passed ([d1e1f02](https://github.com/paypal/paypal-checkout-components/commit/d1e1f02))
 
 
 
 ## <small>5.0.30 (2019-05-14)</small>
 
-* chore(release): 5.0.29 :tada: ([5229fa8](http://github.paypal.com/paypal/paypal-checkout/commit/5229fa8))
-* Add debug query param to button ([5c0ec3f](http://github.paypal.com/paypal/paypal-checkout/commit/5c0ec3f))
-* feat(subscriptions) Add Create Subscription Method (#1100) ([44f83b0](http://github.paypal.com/paypal/paypal-checkout/commit/44f83b0)), closes [#1100](http://github.paypal.com/paypal/paypal-checkout/issues/1100)
-
-
-
-## <small>5.0.29 (2019-05-14)</small>
-
-* Add debug query param to button ([5c0ec3f](http://github.paypal.com/paypal/paypal-checkout/commit/5c0ec3f))
+* Add debug query param to button ([5c0ec3f](https://github.com/paypal/paypal-checkout-components/commit/5c0ec3f))
+* feat(subscriptions) Add Create Subscription Method (#1100) ([44f83b0](https://github.com/paypal/paypal-checkout-components/commit/44f83b0)), closes [#1100](https://github.com/paypal/paypal-checkout-components/issues/1100)
 
 
 
 ## <small>5.0.28 (2019-05-14)</small>
 
-* Change vault tagline ([df0cda8](http://github.paypal.com/paypal/paypal-checkout/commit/df0cda8))
-* Defocus button on click ([35de8a9](http://github.paypal.com/paypal/paypal-checkout/commit/35de8a9))
-* Disable scrolling in card fields frame ([2b88d4d](http://github.paypal.com/paypal/paypal-checkout/commit/2b88d4d))
-* Fix typo ([ec85149](http://github.paypal.com/paypal/paypal-checkout/commit/ec85149))
-* Pass enableThreeDomainSecure ([1e83cca](http://github.paypal.com/paypal/paypal-checkout/commit/1e83cca))
-* Publish button render event ([162268c](http://github.paypal.com/paypal/paypal-checkout/commit/162268c))
+* Change vault tagline ([df0cda8](https://github.com/paypal/paypal-checkout-components/commit/df0cda8))
+* Defocus button on click ([35de8a9](https://github.com/paypal/paypal-checkout-components/commit/35de8a9))
+* Disable scrolling in card fields frame ([2b88d4d](https://github.com/paypal/paypal-checkout-components/commit/2b88d4d))
+* Fix typo ([ec85149](https://github.com/paypal/paypal-checkout-components/commit/ec85149))
+* Pass enableThreeDomainSecure ([1e83cca](https://github.com/paypal/paypal-checkout-components/commit/1e83cca))
+* Publish button render event ([162268c](https://github.com/paypal/paypal-checkout-components/commit/162268c))
 
 
 
 ## <small>5.0.27 (2019-05-09)</small>
 
-* Add fundingSource to card buttons ([cf76a5e](http://github.paypal.com/paypal/paypal-checkout/commit/cf76a5e))
+* Add fundingSource to card buttons ([cf76a5e](https://github.com/paypal/paypal-checkout-components/commit/cf76a5e))
 
 
 
 ## <small>5.0.26 (2019-05-09)</small>
 
-* Add card attribute to card buttons ([f918df1](http://github.paypal.com/paypal/paypal-checkout/commit/f918df1))
-* Remove redundant code handled by smart-buttons ([1a2f890](http://github.paypal.com/paypal/paypal-checkout/commit/1a2f890))
+* Add card attribute to card buttons ([f918df1](https://github.com/paypal/paypal-checkout-components/commit/f918df1))
+* Remove redundant code handled by smart-buttons ([1a2f890](https://github.com/paypal/paypal-checkout-components/commit/1a2f890))
 
 
 
 ## <small>5.0.25 (2019-05-03)</small>
 
-* Deanonymize cross-window call ([7e6e274](http://github.paypal.com/paypal/paypal-checkout/commit/7e6e274))
-* Remove Array.from ([c5604e0](http://github.paypal.com/paypal/paypal-checkout/commit/c5604e0))
+* Deanonymize cross-window call ([7e6e274](https://github.com/paypal/paypal-checkout-components/commit/7e6e274))
+* Remove Array.from ([c5604e0](https://github.com/paypal/paypal-checkout-components/commit/c5604e0))
 
 
 
 ## <small>5.0.24 (2019-05-03)</small>
 
-* Fix checkout iframe scrolling in webviews ([c98ada4](http://github.paypal.com/paypal/paypal-checkout/commit/c98ada4))
-* Reduce margin for vault header ([1e5811d](http://github.paypal.com/paypal/paypal-checkout/commit/1e5811d))
+* Fix checkout iframe scrolling in webviews ([c98ada4](https://github.com/paypal/paypal-checkout-components/commit/c98ada4))
+* Reduce margin for vault header ([1e5811d](https://github.com/paypal/paypal-checkout-components/commit/1e5811d))
 
 
 
 ## <small>5.0.23 (2019-05-02)</small>
 
-* chore(release): 5.0.22 :tada: ([ab4679e](http://github.paypal.com/paypal/paypal-checkout/commit/ab4679e))
-* Add enableVault param ([e588c8b](http://github.paypal.com/paypal/paypal-checkout/commit/e588c8b))
-* Add margin for vault label ([b9274a9](http://github.paypal.com/paypal/paypal-checkout/commit/b9274a9))
-* Add margin for vault label ([a8d90a3](http://github.paypal.com/paypal/paypal-checkout/commit/a8d90a3))
-* Add vaulted funding header ([2600079](http://github.paypal.com/paypal/paypal-checkout/commit/2600079))
-* Fix document passed to prerender template from pre-button-click ([b3fd9ab](http://github.paypal.com/paypal/paypal-checkout/commit/b3fd9ab))
-* More explicit eligibility logic for cards ([4a5d02c](http://github.paypal.com/paypal/paypal-checkout/commit/4a5d02c))
-
-
-
-## <small>5.0.22 (2019-05-02)</small>
-
-* Add enableVault param ([e588c8b](http://github.paypal.com/paypal/paypal-checkout/commit/e588c8b))
-* Add margin for vault label ([b9274a9](http://github.paypal.com/paypal/paypal-checkout/commit/b9274a9))
-* Add margin for vault label ([a8d90a3](http://github.paypal.com/paypal/paypal-checkout/commit/a8d90a3))
-* Add vaulted funding header ([2600079](http://github.paypal.com/paypal/paypal-checkout/commit/2600079))
-* Fix document passed to prerender template from pre-button-click ([b3fd9ab](http://github.paypal.com/paypal/paypal-checkout/commit/b3fd9ab))
-* More explicit eligibility logic for cards ([4a5d02c](http://github.paypal.com/paypal/paypal-checkout/commit/4a5d02c))
+* Add enableVault param ([e588c8b](https://github.com/paypal/paypal-checkout-components/commit/e588c8b))
+* Add margin for vault label ([b9274a9](https://github.com/paypal/paypal-checkout-components/commit/b9274a9))
+* Add margin for vault label ([a8d90a3](https://github.com/paypal/paypal-checkout-components/commit/a8d90a3))
+* Add vaulted funding header ([2600079](https://github.com/paypal/paypal-checkout-components/commit/2600079))
+* Fix document passed to prerender template from pre-button-click ([b3fd9ab](https://github.com/paypal/paypal-checkout-components/commit/b3fd9ab))
+* More explicit eligibility logic for cards ([4a5d02c](https://github.com/paypal/paypal-checkout-components/commit/4a5d02c))
 
 
 
 ## <small>5.0.21 (2019-04-30)</small>
 
-* UI fixes ([4eb51d3](http://github.paypal.com/paypal/paypal-checkout/commit/4eb51d3))
+* UI fixes ([4eb51d3](https://github.com/paypal/paypal-checkout-components/commit/4eb51d3))
 
 
 
 ## <small>5.0.20 (2019-04-29)</small>
 
-* Add disableFunding, disableCard, merchantID as button props (#1078) ([8de835c](http://github.paypal.com/paypal/paypal-checkout/commit/8de835c)), closes [#1078](http://github.paypal.com/paypal/paypal-checkout/issues/1078)
-* Add getPopupBridge prop ([068108a](http://github.paypal.com/paypal/paypal-checkout/commit/068108a))
-* Add partnerAttributionID and correlationID to button props ([21c93fc](http://github.paypal.com/paypal/paypal-checkout/commit/21c93fc))
-* Add spinner to buttons ([c1f0171](http://github.paypal.com/paypal/paypal-checkout/commit/c1f0171))
-* Make vault buttons tabbable ([cb9634b](http://github.paypal.com/paypal/paypal-checkout/commit/cb9634b))
-* Pass payment method id to vault buttons ([f4539d0](http://github.paypal.com/paypal/paypal-checkout/commit/f4539d0))
-* Vaulted funding buttons rendering logic ([d0f5eab](http://github.paypal.com/paypal/paypal-checkout/commit/d0f5eab))
+* Add disableFunding, disableCard, merchantID as button props (#1078) ([8de835c](https://github.com/paypal/paypal-checkout-components/commit/8de835c)), closes [#1078](https://github.com/paypal/paypal-checkout-components/issues/1078)
+* Add getPopupBridge prop ([068108a](https://github.com/paypal/paypal-checkout-components/commit/068108a))
+* Add partnerAttributionID and correlationID to button props ([21c93fc](https://github.com/paypal/paypal-checkout-components/commit/21c93fc))
+* Add spinner to buttons ([c1f0171](https://github.com/paypal/paypal-checkout-components/commit/c1f0171))
+* Make vault buttons tabbable ([cb9634b](https://github.com/paypal/paypal-checkout-components/commit/cb9634b))
+* Pass payment method id to vault buttons ([f4539d0](https://github.com/paypal/paypal-checkout-components/commit/f4539d0))
+* Vaulted funding buttons rendering logic ([d0f5eab](https://github.com/paypal/paypal-checkout-components/commit/d0f5eab))
 
 
 
 ## <small>5.0.19 (2019-04-18)</small>
 
-* Add basic end to end tests ([196f87c](http://github.paypal.com/paypal/paypal-checkout/commit/196f87c))
-* Add ci.sh script ([120e4d3](http://github.paypal.com/paypal/paypal-checkout/commit/120e4d3))
-* Add credit test ([85c5315](http://github.paypal.com/paypal/paypal-checkout/commit/85c5315))
-* Add env-vars for configs ([c6a65f8](http://github.paypal.com/paypal/paypal-checkout/commit/c6a65f8))
-* Add retries for end to end tests ([bfcc581](http://github.paypal.com/paypal/paypal-checkout/commit/bfcc581))
-* Add screenshots for success and error case of wait for element ([c35aa19](http://github.paypal.com/paypal/paypal-checkout/commit/c35aa19))
-* Add screenshots to e2e test ([6000142](http://github.paypal.com/paypal/paypal-checkout/commit/6000142))
-* Add test to start with credit and change funding source ([4220a32](http://github.paypal.com/paypal/paypal-checkout/commit/4220a32))
-* Add url error logging to e2e tests ([98d3fdd](http://github.paypal.com/paypal/paypal-checkout/commit/98d3fdd))
-* Fix env var bools ([f944365](http://github.paypal.com/paypal/paypal-checkout/commit/f944365))
-* Fix flow in CI ([aa94364](http://github.paypal.com/paypal/paypal-checkout/commit/aa94364))
-* Log failed requests in e2e tests popup window ([d59cc2e](http://github.paypal.com/paypal/paypal-checkout/commit/d59cc2e))
-* Make timeout configurable for e2e tests ([446bfe1](http://github.paypal.com/paypal/paypal-checkout/commit/446bfe1))
-* Map white button to black logo color ([e02b598](http://github.paypal.com/paypal/paypal-checkout/commit/e02b598))
-* More Flow fixes ([a7d0222](http://github.paypal.com/paypal/paypal-checkout/commit/a7d0222))
-* Move karma tests to test/integration ([1000d98](http://github.paypal.com/paypal/paypal-checkout/commit/1000d98))
-* Refactor and break up button templates ([f375976](http://github.paypal.com/paypal/paypal-checkout/commit/f375976))
-* Remove jest-puppeteer preset ([b9291d4](http://github.paypal.com/paypal/paypal-checkout/commit/b9291d4))
-* Remove some card specific logic from button renderer ([eef57dd](http://github.paypal.com/paypal/paypal-checkout/commit/eef57dd))
-* Run chrome in no-sandbox mode ([736674f](http://github.paypal.com/paypal/paypal-checkout/commit/736674f))
-* Use default logo color for white buttons ([56c13fa](http://github.paypal.com/paypal/paypal-checkout/commit/56c13fa))
+* Add basic end to end tests ([196f87c](https://github.com/paypal/paypal-checkout-components/commit/196f87c))
+* Add ci.sh script ([120e4d3](https://github.com/paypal/paypal-checkout-components/commit/120e4d3))
+* Add credit test ([85c5315](https://github.com/paypal/paypal-checkout-components/commit/85c5315))
+* Add env-vars for configs ([c6a65f8](https://github.com/paypal/paypal-checkout-components/commit/c6a65f8))
+* Add retries for end to end tests ([bfcc581](https://github.com/paypal/paypal-checkout-components/commit/bfcc581))
+* Add screenshots for success and error case of wait for element ([c35aa19](https://github.com/paypal/paypal-checkout-components/commit/c35aa19))
+* Add screenshots to e2e test ([6000142](https://github.com/paypal/paypal-checkout-components/commit/6000142))
+* Add test to start with credit and change funding source ([4220a32](https://github.com/paypal/paypal-checkout-components/commit/4220a32))
+* Add url error logging to e2e tests ([98d3fdd](https://github.com/paypal/paypal-checkout-components/commit/98d3fdd))
+* Fix env var bools ([f944365](https://github.com/paypal/paypal-checkout-components/commit/f944365))
+* Fix flow in CI ([aa94364](https://github.com/paypal/paypal-checkout-components/commit/aa94364))
+* Log failed requests in e2e tests popup window ([d59cc2e](https://github.com/paypal/paypal-checkout-components/commit/d59cc2e))
+* Make timeout configurable for e2e tests ([446bfe1](https://github.com/paypal/paypal-checkout-components/commit/446bfe1))
+* Map white button to black logo color ([e02b598](https://github.com/paypal/paypal-checkout-components/commit/e02b598))
+* More Flow fixes ([a7d0222](https://github.com/paypal/paypal-checkout-components/commit/a7d0222))
+* Move karma tests to test/integration ([1000d98](https://github.com/paypal/paypal-checkout-components/commit/1000d98))
+* Refactor and break up button templates ([f375976](https://github.com/paypal/paypal-checkout-components/commit/f375976))
+* Remove jest-puppeteer preset ([b9291d4](https://github.com/paypal/paypal-checkout-components/commit/b9291d4))
+* Remove some card specific logic from button renderer ([eef57dd](https://github.com/paypal/paypal-checkout-components/commit/eef57dd))
+* Run chrome in no-sandbox mode ([736674f](https://github.com/paypal/paypal-checkout-components/commit/736674f))
+* Use default logo color for white buttons ([56c13fa](https://github.com/paypal/paypal-checkout-components/commit/56c13fa))
 
 
 
 ## <small>5.0.18 (2019-04-09)</small>
 
-* Accessibility (hover and focus state) for each button color ([d19a5bc](http://github.paypal.com/paypal/paypal-checkout/commit/d19a5bc))
-* Pass clientAccessToken down to button ([2f2e427](http://github.paypal.com/paypal/paypal-checkout/commit/2f2e427))
+* Accessibility (hover and focus state) for each button color ([d19a5bc](https://github.com/paypal/paypal-checkout-components/commit/d19a5bc))
+* Pass clientAccessToken down to button ([2f2e427](https://github.com/paypal/paypal-checkout-components/commit/2f2e427))
 
 
 
 ## <small>5.0.17 (2019-04-02)</small>
 
-* Toggle card eligibility based on whether hosted-fields requested ([1eddfbd](http://github.paypal.com/paypal/paypal-checkout/commit/1eddfbd))
+* Toggle card eligibility based on whether hosted-fields requested ([1eddfbd](https://github.com/paypal/paypal-checkout-components/commit/1eddfbd))
 
 
 
 ## <small>5.0.16 (2019-04-01)</small>
 
-* Remove branded check for card eligibility ([a3beed9](http://github.paypal.com/paypal/paypal-checkout/commit/a3beed9))
-* Update README.md ([6b298fa](http://github.paypal.com/paypal/paypal-checkout/commit/6b298fa))
+* Remove branded check for card eligibility ([a3beed9](https://github.com/paypal/paypal-checkout-components/commit/a3beed9))
+* Update README.md ([6b298fa](https://github.com/paypal/paypal-checkout-components/commit/6b298fa))
 
 
 
 ## <small>5.0.15 (2019-03-27)</small>
 
-* Treat missing funding config as ineligible ([c3b32bd](http://github.paypal.com/paypal/paypal-checkout/commit/c3b32bd))
+* Treat missing funding config as ineligible ([c3b32bd](https://github.com/paypal/paypal-checkout-components/commit/c3b32bd))
 
 
 
 ## <small>5.0.14 (2019-03-26)</small>
 
-* Add CardFields component ([a45fc86](http://github.paypal.com/paypal/paypal-checkout/commit/a45fc86))
-* Cleanup ([53a6611](http://github.paypal.com/paypal/paypal-checkout/commit/53a6611))
-* Only suppress card buttons when hosted fields is used ([24a62f1](http://github.paypal.com/paypal/paypal-checkout/commit/24a62f1))
+* Add CardFields component ([a45fc86](https://github.com/paypal/paypal-checkout-components/commit/a45fc86))
+* Cleanup ([53a6611](https://github.com/paypal/paypal-checkout-components/commit/53a6611))
+* Only suppress card buttons when hosted fields is used ([24a62f1](https://github.com/paypal/paypal-checkout-components/commit/24a62f1))
 
 
 
 ## <small>5.0.13 (2019-03-18)</small>
 
-* Add buyerCountry prop ([f9144ef](http://github.paypal.com/paypal/paypal-checkout/commit/f9144ef))
-* Error if no url passed to actions.redirect ([713036b](http://github.paypal.com/paypal/paypal-checkout/commit/713036b))
-* Fix dev server ([20d4847](http://github.paypal.com/paypal/paypal-checkout/commit/20d4847))
-* Fix installment content ([20376d7](http://github.paypal.com/paypal/paypal-checkout/commit/20376d7))
-* Remove old doc ([b3f5562](http://github.paypal.com/paypal/paypal-checkout/commit/b3f5562))
+* Add buyerCountry prop ([f9144ef](https://github.com/paypal/paypal-checkout-components/commit/f9144ef))
+* Error if no url passed to actions.redirect ([713036b](https://github.com/paypal/paypal-checkout-components/commit/713036b))
+* Fix dev server ([20d4847](https://github.com/paypal/paypal-checkout-components/commit/20d4847))
+* Fix installment content ([20376d7](https://github.com/paypal/paypal-checkout-components/commit/20376d7))
+* Remove old doc ([b3f5562](https://github.com/paypal/paypal-checkout-components/commit/b3f5562))
 
 
 
 ## <small>5.0.12 (2019-03-11)</small>
 
-* Add forceIframe as a protected export ([081312e](http://github.paypal.com/paypal/paypal-checkout/commit/081312e))
-* Use same url for all checkout flows ([273c79b](http://github.paypal.com/paypal/paypal-checkout/commit/273c79b))
+* Add forceIframe as a protected export ([081312e](https://github.com/paypal/paypal-checkout-components/commit/081312e))
+* Use same url for all checkout flows ([273c79b](https://github.com/paypal/paypal-checkout-components/commit/273c79b))
 
 
 
 ## <small>5.0.11 (2019-03-07)</small>
 
-* Correctly handle onClick for card icons and pass selected card ([15638ae](http://github.paypal.com/paypal/paypal-checkout/commit/15638ae))
+* Correctly handle onClick for card icons and pass selected card ([15638ae](https://github.com/paypal/paypal-checkout-components/commit/15638ae))
 
 
 
 ## <small>5.0.10 (2019-03-06)</small>
 
-* Make intranet mode warning rather than hard failure ([da967d9](http://github.paypal.com/paypal/paypal-checkout/commit/da967d9))
+* Make intranet mode warning rather than hard failure ([da967d9](https://github.com/paypal/paypal-checkout-components/commit/da967d9))
 
 
 
 ## <small>5.0.9 (2019-03-05)</small>
 
-* Fix black and white secondary color config ([2f48858](http://github.paypal.com/paypal/paypal-checkout/commit/2f48858))
+* Fix black and white secondary color config ([2f48858](https://github.com/paypal/paypal-checkout-components/commit/2f48858))
 
 
 
 ## <small>5.0.8 (2019-03-05)</small>
 
-* Clean up addOnDisplay and addOnClose ([67048b6](http://github.paypal.com/paypal/paypal-checkout/commit/67048b6))
-* Revert "Ensure events are listened to on time" ([782eb3b](http://github.paypal.com/paypal/paypal-checkout/commit/782eb3b))
+* Clean up addOnDisplay and addOnClose ([67048b6](https://github.com/paypal/paypal-checkout-components/commit/67048b6))
+* Revert "Ensure events are listened to on time" ([782eb3b](https://github.com/paypal/paypal-checkout-components/commit/782eb3b))
 
 
 
 ## <small>5.0.7 (2019-03-05)</small>
 
-* Ensure events are listened to on time ([7c76b30](http://github.paypal.com/paypal/paypal-checkout/commit/7c76b30))
+* Ensure events are listened to on time ([7c76b30](https://github.com/paypal/paypal-checkout-components/commit/7c76b30))
 
 
 
 ## <small>5.0.6 (2019-03-04)</small>
 
-* Fix button autoResize ([e6ad017](http://github.paypal.com/paypal/paypal-checkout/commit/e6ad017))
+* Fix button autoResize ([e6ad017](https://github.com/paypal/paypal-checkout-components/commit/e6ad017))
 
 
 
 ## <small>5.0.5 (2019-03-01)</small>
 
-* Auto-authorize if onApprove not implemented ([67d7bc4](http://github.paypal.com/paypal/paypal-checkout/commit/67d7bc4))
-* Cleanup ([86e7473](http://github.paypal.com/paypal/paypal-checkout/commit/86e7473))
-* Do not kick off create order call on prerender ([6fe2a99](http://github.paypal.com/paypal/paypal-checkout/commit/6fe2a99))
-* Export Button template on client on paypal domain ([f776319](http://github.paypal.com/paypal/paypal-checkout/commit/f776319))
-* Pass actions through button onClick ([7138f8c](http://github.paypal.com/paypal/paypal-checkout/commit/7138f8c))
-* Re-add black/white/buynow ([0b57cbb](http://github.paypal.com/paypal/paypal-checkout/commit/0b57cbb))
-* Tests and fixes ([096dd6c](http://github.paypal.com/paypal/paypal-checkout/commit/096dd6c))
-* Use csp nonce for rendering on top level page ([757f85d](http://github.paypal.com/paypal/paypal-checkout/commit/757f85d))
+* Auto-authorize if onApprove not implemented ([67d7bc4](https://github.com/paypal/paypal-checkout-components/commit/67d7bc4))
+* Cleanup ([86e7473](https://github.com/paypal/paypal-checkout-components/commit/86e7473))
+* Do not kick off create order call on prerender ([6fe2a99](https://github.com/paypal/paypal-checkout-components/commit/6fe2a99))
+* Export Button template on client on paypal domain ([f776319](https://github.com/paypal/paypal-checkout-components/commit/f776319))
+* Pass actions through button onClick ([7138f8c](https://github.com/paypal/paypal-checkout-components/commit/7138f8c))
+* Re-add black/white/buynow ([0b57cbb](https://github.com/paypal/paypal-checkout-components/commit/0b57cbb))
+* Tests and fixes ([096dd6c](https://github.com/paypal/paypal-checkout-components/commit/096dd6c))
+* Use csp nonce for rendering on top level page ([757f85d](https://github.com/paypal/paypal-checkout-components/commit/757f85d))
 
 
 
 ## <small>5.0.4 (2019-02-21)</small>
 
-* Register button and checkout components in setup step ([7c14d4f](http://github.paypal.com/paypal/paypal-checkout/commit/7c14d4f))
+* Register button and checkout components in setup step ([7c14d4f](https://github.com/paypal/paypal-checkout-components/commit/7c14d4f))
 
 
 
 ## <small>5.0.3 (2019-02-21)</small>
 
-* Hack in compatibility for old jsx-pragmatic renderer ([c416fff](http://github.paypal.com/paypal/paypal-checkout/commit/c416fff))
-* Upgrade jsx-pragmatic ([e32953b](http://github.paypal.com/paypal/paypal-checkout/commit/e32953b))
+* Hack in compatibility for old jsx-pragmatic renderer ([c416fff](https://github.com/paypal/paypal-checkout-components/commit/c416fff))
+* Upgrade jsx-pragmatic ([e32953b](https://github.com/paypal/paypal-checkout-components/commit/e32953b))
 
 
 
 ## <small>5.0.2 (2019-02-18)</small>
 
-* Add log for driver usage ([f5655f1](http://github.paypal.com/paypal/paypal-checkout/commit/f5655f1))
-* Export dyanmic dependencies and destroy ([ff5073a](http://github.paypal.com/paypal/paypal-checkout/commit/ff5073a))
-* Remove version commits from changelog ([bedb18b](http://github.paypal.com/paypal/paypal-checkout/commit/bedb18b))
-* Update implement-checkout.md ([1dd90e1](http://github.paypal.com/paypal/paypal-checkout/commit/1dd90e1))
-* Update implement-checkout.md ([1fc21cc](http://github.paypal.com/paypal/paypal-checkout/commit/1fc21cc))
-* Update implement-checkout.md ([9f19583](http://github.paypal.com/paypal/paypal-checkout/commit/9f19583))
-* Update implement-checkout.md ([571d3d5](http://github.paypal.com/paypal/paypal-checkout/commit/571d3d5))
-* Use setupSDK to create test namespace ([f30a701](http://github.paypal.com/paypal/paypal-checkout/commit/f30a701))
+* Add log for driver usage ([f5655f1](https://github.com/paypal/paypal-checkout-components/commit/f5655f1))
+* Export dyanmic dependencies and destroy ([ff5073a](https://github.com/paypal/paypal-checkout-components/commit/ff5073a))
+* Remove version commits from changelog ([bedb18b](https://github.com/paypal/paypal-checkout-components/commit/bedb18b))
+* Update implement-checkout.md ([1dd90e1](https://github.com/paypal/paypal-checkout-components/commit/1dd90e1))
+* Update implement-checkout.md ([1fc21cc](https://github.com/paypal/paypal-checkout-components/commit/1fc21cc))
+* Update implement-checkout.md ([9f19583](https://github.com/paypal/paypal-checkout-components/commit/9f19583))
+* Update implement-checkout.md ([571d3d5](https://github.com/paypal/paypal-checkout-components/commit/571d3d5))
+* Use setupSDK to create test namespace ([f30a701](https://github.com/paypal/paypal-checkout-components/commit/f30a701))
 
 
 
 ## <small>5.0.1 (2019-02-13)</small>
 
-* Add csp button prop ([05c1171](http://github.paypal.com/paypal/paypal-checkout/commit/05c1171))
-* Cleanup allowPrimary setting ([8bf180b](http://github.paypal.com/paypal/paypal-checkout/commit/8bf180b))
-* Fix release task ([b1af578](http://github.paypal.com/paypal/paypal-checkout/commit/b1af578))
-* Switch buttons over to smartcomponentnodeweb ([55f9fe2](http://github.paypal.com/paypal/paypal-checkout/commit/55f9fe2))
-* Temporarily add paypal.request ([39c4319](http://github.paypal.com/paypal/paypal-checkout/commit/39c4319))
-* Update fpti event names ([25a59e2](http://github.paypal.com/paypal/paypal-checkout/commit/25a59e2))
-* Update framework demo pages ([1e19587](http://github.paypal.com/paypal/paypal-checkout/commit/1e19587))
-* refactor(publishing): Better publishing workflow with changelog. Yanked from v4 (#1024) ([4feda2d](http://github.paypal.com/paypal/paypal-checkout/commit/4feda2d)), closes [#1024](http://github.paypal.com/paypal/paypal-checkout/issues/1024)
+* Add csp button prop ([05c1171](https://github.com/paypal/paypal-checkout-components/commit/05c1171))
+* Cleanup allowPrimary setting ([8bf180b](https://github.com/paypal/paypal-checkout-components/commit/8bf180b))
+* Fix release task ([b1af578](https://github.com/paypal/paypal-checkout-components/commit/b1af578))
+* Switch buttons over to smartcomponentnodeweb ([55f9fe2](https://github.com/paypal/paypal-checkout-components/commit/55f9fe2))
+* Temporarily add paypal.request ([39c4319](https://github.com/paypal/paypal-checkout-components/commit/39c4319))
+* Update fpti event names ([25a59e2](https://github.com/paypal/paypal-checkout-components/commit/25a59e2))
+* Update framework demo pages ([1e19587](https://github.com/paypal/paypal-checkout-components/commit/1e19587))
+* refactor(publishing): Better publishing workflow with changelog. Yanked from v4 (#1024) ([4feda2d](https://github.com/paypal/paypal-checkout-components/commit/4feda2d)), closes [#1024](https://github.com/paypal/paypal-checkout-components/issues/1024)
 
 
 
 ## 5.0.0 (2019-02-08)
 
-* Dist ([fa7de77](http://github.paypal.com/paypal/paypal-checkout/commit/fa7de77))
-* Do not allow button to be rendered into button element - breaks in firefox ([2b7676b](http://github.paypal.com/paypal/paypal-checkout/commit/2b7676b))
-* Set venmo to remembered mode ([2868e82](http://github.paypal.com/paypal/paypal-checkout/commit/2868e82))
-* Update readme ([eb36c3a](http://github.paypal.com/paypal/paypal-checkout/commit/eb36c3a))
+* 5.0.0 ([d11eb12](https://github.com/paypal/paypal-checkout-components/commit/d11eb12))
+* Dist ([fa7de77](https://github.com/paypal/paypal-checkout-components/commit/fa7de77))
+* Do not allow button to be rendered into button element - breaks in firefox ([2b7676b](https://github.com/paypal/paypal-checkout-components/commit/2b7676b))
+* Set venmo to remembered mode ([2868e82](https://github.com/paypal/paypal-checkout-components/commit/2868e82))
+* Update readme ([eb36c3a](https://github.com/paypal/paypal-checkout-components/commit/eb36c3a))
 
 
 
 ## <small>4.1.47 (2019-02-08)</small>
 
-* Call getCheckoutComponent to register component in parent window ([6eeaa8c](http://github.paypal.com/paypal/paypal-checkout/commit/6eeaa8c))
+* 4.1.47 ([289055a](https://github.com/paypal/paypal-checkout-components/commit/289055a))
+* Call getCheckoutComponent to register component in parent window ([6eeaa8c](https://github.com/paypal/paypal-checkout-components/commit/6eeaa8c))
 
 
 
 ## <small>4.1.46 (2019-02-08)</small>
 
-* Add check-size script ([79a5b33](http://github.paypal.com/paypal/paypal-checkout/commit/79a5b33))
-* Cleanup ([9f3089b](http://github.paypal.com/paypal/paypal-checkout/commit/9f3089b))
-* Dist ([0325dd3](http://github.paypal.com/paypal/paypal-checkout/commit/0325dd3))
-* Update implement-checkout.md ([38ba3ff](http://github.paypal.com/paypal/paypal-checkout/commit/38ba3ff))
-* Update implement-checkout.md ([0e628ef](http://github.paypal.com/paypal/paypal-checkout/commit/0e628ef))
-* Update implement-checkout.md ([ee5fc54](http://github.paypal.com/paypal/paypal-checkout/commit/ee5fc54))
-* Update readme ([1f85734](http://github.paypal.com/paypal/paypal-checkout/commit/1f85734))
-* Zoid upgrade ([95be4ca](http://github.paypal.com/paypal/paypal-checkout/commit/95be4ca))
+* 4.1.46 ([8607eec](https://github.com/paypal/paypal-checkout-components/commit/8607eec))
+* Add check-size script ([79a5b33](https://github.com/paypal/paypal-checkout-components/commit/79a5b33))
+* Cleanup ([9f3089b](https://github.com/paypal/paypal-checkout-components/commit/9f3089b))
+* Dist ([0325dd3](https://github.com/paypal/paypal-checkout-components/commit/0325dd3))
+* Update implement-checkout.md ([38ba3ff](https://github.com/paypal/paypal-checkout-components/commit/38ba3ff))
+* Update implement-checkout.md ([0e628ef](https://github.com/paypal/paypal-checkout-components/commit/0e628ef))
+* Update implement-checkout.md ([ee5fc54](https://github.com/paypal/paypal-checkout-components/commit/ee5fc54))
+* Update readme ([1f85734](https://github.com/paypal/paypal-checkout-components/commit/1f85734))
+* Zoid upgrade ([95be4ca](https://github.com/paypal/paypal-checkout-components/commit/95be4ca))
 
 
 
 ## <small>4.1.45 (2019-01-25)</small>
 
-* Cleanup tests ([ac5edc5](http://github.paypal.com/paypal/paypal-checkout/commit/ac5edc5))
-* Correctly vertical-align button body ([f906aa9](http://github.paypal.com/paypal/paypal-checkout/commit/f906aa9))
-* Dist ([7182bf1](http://github.paypal.com/paypal/paypal-checkout/commit/7182bf1))
-* Enforce vault=true for billing agreement prop ([d53f1d1](http://github.paypal.com/paypal/paypal-checkout/commit/d53f1d1))
-* Fix createBillingAgreement ([500b68d](http://github.paypal.com/paypal/paypal-checkout/commit/500b68d))
-* feat(callback-api): Callback API support for Payments SDK (#990) ([13aabef](http://github.paypal.com/paypal/paypal-checkout/commit/13aabef)), closes [#990](http://github.paypal.com/paypal/paypal-checkout/issues/990)
+* 4.1.45 ([e3d3ece](https://github.com/paypal/paypal-checkout-components/commit/e3d3ece))
+* Cleanup tests ([ac5edc5](https://github.com/paypal/paypal-checkout-components/commit/ac5edc5))
+* Correctly vertical-align button body ([f906aa9](https://github.com/paypal/paypal-checkout-components/commit/f906aa9))
+* Dist ([7182bf1](https://github.com/paypal/paypal-checkout-components/commit/7182bf1))
+* Enforce vault=true for billing agreement prop ([d53f1d1](https://github.com/paypal/paypal-checkout-components/commit/d53f1d1))
+* Fix createBillingAgreement ([500b68d](https://github.com/paypal/paypal-checkout-components/commit/500b68d))
+* feat(callback-api): Callback API support for Payments SDK (#990) ([13aabef](https://github.com/paypal/paypal-checkout-components/commit/13aabef)), closes [#990](https://github.com/paypal/paypal-checkout-components/issues/990)
 
 
 
 ## <small>4.1.44 (2019-01-17)</small>
 
-* Add createBillingAgreement prop ([b8afda5](http://github.paypal.com/paypal/paypal-checkout/commit/b8afda5))
+* 4.1.44 ([50ea6d0](https://github.com/paypal/paypal-checkout-components/commit/50ea6d0))
+* Add createBillingAgreement prop ([b8afda5](https://github.com/paypal/paypal-checkout-components/commit/b8afda5))
 
 
 
 ## <small>4.1.43 (2019-01-10)</small>
 
-* Add props to xchild ([fc5e4d2](http://github.paypal.com/paypal/paypal-checkout/commit/fc5e4d2))
+* 4.1.43 ([d4c8715](https://github.com/paypal/paypal-checkout-components/commit/d4c8715))
+* Add props to xchild ([fc5e4d2](https://github.com/paypal/paypal-checkout-components/commit/fc5e4d2))
 
 
 
 ## <small>4.1.42 (2019-01-10)</small>
 
-* Add xchild for backwards compatibility ([149efe3](http://github.paypal.com/paypal/paypal-checkout/commit/149efe3))
+* 4.1.42 ([8f6715d](https://github.com/paypal/paypal-checkout-components/commit/8f6715d))
+* Add xchild for backwards compatibility ([149efe3](https://github.com/paypal/paypal-checkout-components/commit/149efe3))
 
 
 
 ## <small>4.1.41 (2019-01-10)</small>
 
-* Default checkout to iframe when popups not supported ([8c7fee1](http://github.paypal.com/paypal/paypal-checkout/commit/8c7fee1))
-* Dist ([611a4c7](http://github.paypal.com/paypal/paypal-checkout/commit/611a4c7))
-* Fix module resolution ([0575f45](http://github.paypal.com/paypal/paypal-checkout/commit/0575f45))
+* 4.1.41 ([9ec97bb](https://github.com/paypal/paypal-checkout-components/commit/9ec97bb))
+* Default checkout to iframe when popups not supported ([8c7fee1](https://github.com/paypal/paypal-checkout-components/commit/8c7fee1))
+* Dist ([611a4c7](https://github.com/paypal/paypal-checkout-components/commit/611a4c7))
+* Fix module resolution ([0575f45](https://github.com/paypal/paypal-checkout-components/commit/0575f45))
 
 
 
 ## <small>4.1.40 (2019-01-10)</small>
 
-* Dist ([8805a17](http://github.paypal.com/paypal/paypal-checkout/commit/8805a17))
-* Zoid v8 overhaul ([0fbcbc4](http://github.paypal.com/paypal/paypal-checkout/commit/0fbcbc4))
-* docs(callback-api): Adding integration documentation for the `onShippingChange` xprop (#966) ([6530e82](http://github.paypal.com/paypal/paypal-checkout/commit/6530e82)), closes [#966](http://github.paypal.com/paypal/paypal-checkout/issues/966)
+* 4.1.40 ([78db240](https://github.com/paypal/paypal-checkout-components/commit/78db240))
+* Dist ([8805a17](https://github.com/paypal/paypal-checkout-components/commit/8805a17))
+* Zoid v8 overhaul ([0fbcbc4](https://github.com/paypal/paypal-checkout-components/commit/0fbcbc4))
+* docs(callback-api): Adding integration documentation for the `onShippingChange` xprop (#966) ([6530e82](https://github.com/paypal/paypal-checkout-components/commit/6530e82)), closes [#966](https://github.com/paypal/paypal-checkout-components/issues/966)
 
 
 
 ## <small>4.1.39 (2018-12-14)</small>
 
-* Dist ([29b6e84](http://github.paypal.com/paypal/paypal-checkout/commit/29b6e84))
-* Do not keep margin below last row of buttons ([a36956d](http://github.paypal.com/paypal/paypal-checkout/commit/a36956d))
+* 4.1.39 ([8197bb3](https://github.com/paypal/paypal-checkout-components/commit/8197bb3))
+* Dist ([29b6e84](https://github.com/paypal/paypal-checkout-components/commit/29b6e84))
+* Do not keep margin below last row of buttons ([a36956d](https://github.com/paypal/paypal-checkout-components/commit/a36956d))
 
 
 
 ## <small>4.1.38 (2018-12-13)</small>
 
-* Add implement checkout doc ([0db368f](http://github.paypal.com/paypal/paypal-checkout/commit/0db368f))
-* Do not send sdkMeta in window name to child ([af6a167](http://github.paypal.com/paypal/paypal-checkout/commit/af6a167))
-* Only allow iframe check on paypal domain ([f333ed0](http://github.paypal.com/paypal/paypal-checkout/commit/f333ed0))
-* Use autoResize for buttons component ([7ad008e](http://github.paypal.com/paypal/paypal-checkout/commit/7ad008e))
+* 4.1.38 ([dfbe37a](https://github.com/paypal/paypal-checkout-components/commit/dfbe37a))
+* Add implement checkout doc ([0db368f](https://github.com/paypal/paypal-checkout-components/commit/0db368f))
+* Do not send sdkMeta in window name to child ([af6a167](https://github.com/paypal/paypal-checkout-components/commit/af6a167))
+* Only allow iframe check on paypal domain ([f333ed0](https://github.com/paypal/paypal-checkout-components/commit/f333ed0))
+* Use autoResize for buttons component ([7ad008e](https://github.com/paypal/paypal-checkout-components/commit/7ad008e))
 
 
 
 ## <small>4.1.37 (2018-12-11)</small>
 
-* Dist ([498348c](http://github.paypal.com/paypal/paypal-checkout/commit/498348c))
-* Update to use paypal namespace ([c20102b](http://github.paypal.com/paypal/paypal-checkout/commit/c20102b))
+* 4.1.37 ([3bfedce](https://github.com/paypal/paypal-checkout-components/commit/3bfedce))
+* Dist ([498348c](https://github.com/paypal/paypal-checkout-components/commit/498348c))
+* Update to use paypal namespace ([c20102b](https://github.com/paypal/paypal-checkout-components/commit/c20102b))
 
 
 
 ## <small>4.1.36 (2018-12-11)</small>
 
-* Clean up webpack test config ([372d31c](http://github.paypal.com/paypal/paypal-checkout/commit/372d31c))
-* Dist ([05bfb5c](http://github.paypal.com/paypal/paypal-checkout/commit/05bfb5c))
-* Fix server-side render when possible ([dddd6f2](http://github.paypal.com/paypal/paypal-checkout/commit/dddd6f2))
-* Fix test using base64 ([0220a0a](http://github.paypal.com/paypal/paypal-checkout/commit/0220a0a))
-* Use checkoutnow url on stage ([8f98be0](http://github.paypal.com/paypal/paypal-checkout/commit/8f98be0))
+* 4.1.36 ([009eee3](https://github.com/paypal/paypal-checkout-components/commit/009eee3))
+* Clean up webpack test config ([372d31c](https://github.com/paypal/paypal-checkout-components/commit/372d31c))
+* Dist ([05bfb5c](https://github.com/paypal/paypal-checkout-components/commit/05bfb5c))
+* Fix server-side render when possible ([dddd6f2](https://github.com/paypal/paypal-checkout-components/commit/dddd6f2))
+* Fix test using base64 ([0220a0a](https://github.com/paypal/paypal-checkout-components/commit/0220a0a))
+* Use checkoutnow url on stage ([8f98be0](https://github.com/paypal/paypal-checkout-components/commit/8f98be0))
 
 
 
 ## <small>4.1.35 (2018-12-06)</small>
 
-* Dist ([8a5786d](http://github.paypal.com/paypal/paypal-checkout/commit/8a5786d))
-* Fix proxyRest ([5bcf21d](http://github.paypal.com/paypal/paypal-checkout/commit/5bcf21d))
+* 4.1.35 ([0647d8a](https://github.com/paypal/paypal-checkout-components/commit/0647d8a))
+* Dist ([8a5786d](https://github.com/paypal/paypal-checkout-components/commit/8a5786d))
+* Fix proxyRest ([5bcf21d](https://github.com/paypal/paypal-checkout-components/commit/5bcf21d))
 
 
 
 ## <small>4.1.34 (2018-12-05)</small>
 
-* Fix checkout renderTo patch ([f1c900d](http://github.paypal.com/paypal/paypal-checkout/commit/f1c900d))
+* 4.1.34 ([7c79c33](https://github.com/paypal/paypal-checkout-components/commit/7c79c33))
+* Fix checkout renderTo patch ([f1c900d](https://github.com/paypal/paypal-checkout-components/commit/f1c900d))
 
 
 
 ## <small>4.1.33 (2018-12-05)</small>
 
-* Dist ([8f83dd9](http://github.paypal.com/paypal/paypal-checkout/commit/8f83dd9))
-* Localize button specific stuff ([6527391](http://github.paypal.com/paypal/paypal-checkout/commit/6527391))
-* Rename checkout props with aliases ([7a3cdbb](http://github.paypal.com/paypal/paypal-checkout/commit/7a3cdbb))
+* 4.1.33 ([6864222](https://github.com/paypal/paypal-checkout-components/commit/6864222))
+* Dist ([8f83dd9](https://github.com/paypal/paypal-checkout-components/commit/8f83dd9))
+* Localize button specific stuff ([6527391](https://github.com/paypal/paypal-checkout-components/commit/6527391))
+* Rename checkout props with aliases ([7a3cdbb](https://github.com/paypal/paypal-checkout-components/commit/7a3cdbb))
 
 
 
 ## <small>4.1.32 (2018-12-04)</small>
 
-* Add popup pre-rendering ([3c3de56](http://github.paypal.com/paypal/paypal-checkout/commit/3c3de56))
-* Dist ([449f6d1](http://github.paypal.com/paypal/paypal-checkout/commit/449f6d1))
+* 4.1.32 ([4700a64](https://github.com/paypal/paypal-checkout-components/commit/4700a64))
+* Add popup pre-rendering ([3c3de56](https://github.com/paypal/paypal-checkout-components/commit/3c3de56))
+* Dist ([449f6d1](https://github.com/paypal/paypal-checkout-components/commit/449f6d1))
 
 
 
 ## <small>4.1.31 (2018-12-04)</small>
 
-* Dist ([c6bb0a4](http://github.paypal.com/paypal/paypal-checkout/commit/c6bb0a4))
-* Temporary fix for stage stylesheet render ([59c73c3](http://github.paypal.com/paypal/paypal-checkout/commit/59c73c3))
+* 4.1.31 ([52457d8](https://github.com/paypal/paypal-checkout-components/commit/52457d8))
+* Dist ([c6bb0a4](https://github.com/paypal/paypal-checkout-components/commit/c6bb0a4))
+* Temporary fix for stage stylesheet render ([59c73c3](https://github.com/paypal/paypal-checkout-components/commit/59c73c3))
 
 
 
 ## <small>4.1.30 (2018-12-03)</small>
 
-* Dist ([4fe3131](http://github.paypal.com/paypal/paypal-checkout/commit/4fe3131))
-* Fix period validation ([b97bb05](http://github.paypal.com/paypal/paypal-checkout/commit/b97bb05))
-* User innerHTML for button style tag ([a22d6d0](http://github.paypal.com/paypal/paypal-checkout/commit/a22d6d0))
+* 4.1.30 ([0a49619](https://github.com/paypal/paypal-checkout-components/commit/0a49619))
+* Dist ([4fe3131](https://github.com/paypal/paypal-checkout-components/commit/4fe3131))
+* Fix period validation ([b97bb05](https://github.com/paypal/paypal-checkout-components/commit/b97bb05))
+* User innerHTML for button style tag ([a22d6d0](https://github.com/paypal/paypal-checkout-components/commit/a22d6d0))
 
 
 
 ## <small>4.1.29 (2018-11-30)</small>
 
-* Add scrolling attributes ([5759aac](http://github.paypal.com/paypal/paypal-checkout/commit/5759aac))
-* Dist ([e018196](http://github.paypal.com/paypal/paypal-checkout/commit/e018196))
-* Test fixes ([69f5663](http://github.paypal.com/paypal/paypal-checkout/commit/69f5663))
-* Use mock urls for testing ([da2d3d9](http://github.paypal.com/paypal/paypal-checkout/commit/da2d3d9))
-* Use regex based domain ([35a392d](http://github.paypal.com/paypal/paypal-checkout/commit/35a392d))
+* 4.1.29 ([0c10585](https://github.com/paypal/paypal-checkout-components/commit/0c10585))
+* Add scrolling attributes ([5759aac](https://github.com/paypal/paypal-checkout-components/commit/5759aac))
+* Dist ([e018196](https://github.com/paypal/paypal-checkout-components/commit/e018196))
+* Test fixes ([69f5663](https://github.com/paypal/paypal-checkout-components/commit/69f5663))
+* Use mock urls for testing ([da2d3d9](https://github.com/paypal/paypal-checkout-components/commit/da2d3d9))
+* Use regex based domain ([35a392d](https://github.com/paypal/paypal-checkout-components/commit/35a392d))
 
 
 
 ## <small>4.1.28 (2018-11-20)</small>
 
-* Allow createOrder to return a string ([82b9f01](http://github.paypal.com/paypal/paypal-checkout/commit/82b9f01))
+* 4.1.28 ([673819b](https://github.com/paypal/paypal-checkout-components/commit/673819b))
+* Allow createOrder to return a string ([82b9f01](https://github.com/paypal/paypal-checkout-components/commit/82b9f01))
 
 
 
 ## <small>4.1.27 (2018-11-17)</small>
 
-* Re-add globals for checkout ([1536a16](http://github.paypal.com/paypal/paypal-checkout/commit/1536a16))
+* 4.1.27 ([1d7b7d4](https://github.com/paypal/paypal-checkout-components/commit/1d7b7d4))
+* Re-add globals for checkout ([1536a16](https://github.com/paypal/paypal-checkout-components/commit/1536a16))
 
 
 
 ## <small>4.1.26 (2018-11-17)</small>
 
-* Import checkout component when requested ([aa8c6d8](http://github.paypal.com/paypal/paypal-checkout/commit/aa8c6d8))
+* 4.1.26 ([c75b888](https://github.com/paypal/paypal-checkout-components/commit/c75b888))
+* Import checkout component when requested ([aa8c6d8](https://github.com/paypal/paypal-checkout-components/commit/aa8c6d8))
 
 
 
 ## <small>4.1.25 (2018-11-17)</small>
 
-* Dist ([9eda901](http://github.paypal.com/paypal/paypal-checkout/commit/9eda901))
-* Do not use find for IE11 compatibility ([47b9463](http://github.paypal.com/paypal/paypal-checkout/commit/47b9463))
-* Export checkout on paypal domains when buttons requested ([784de15](http://github.paypal.com/paypal/paypal-checkout/commit/784de15))
-* Nonce fixes ([74873ba](http://github.paypal.com/paypal/paypal-checkout/commit/74873ba))
+* 4.1.25 ([35897cd](https://github.com/paypal/paypal-checkout-components/commit/35897cd))
+* Dist ([9eda901](https://github.com/paypal/paypal-checkout-components/commit/9eda901))
+* Do not use find for IE11 compatibility ([47b9463](https://github.com/paypal/paypal-checkout-components/commit/47b9463))
+* Export checkout on paypal domains when buttons requested ([784de15](https://github.com/paypal/paypal-checkout-components/commit/784de15))
+* Nonce fixes ([74873ba](https://github.com/paypal/paypal-checkout-components/commit/74873ba))
 
 
 
 ## <small>4.1.24 (2018-11-16)</small>
 
-* Dist ([d2cff73](http://github.paypal.com/paypal/paypal-checkout/commit/d2cff73))
-* More type cleanup ([9b750f8](http://github.paypal.com/paypal/paypal-checkout/commit/9b750f8))
-* Move common libraries to web-client ([a7c9237](http://github.paypal.com/paypal/paypal-checkout/commit/a7c9237))
-* Pass sdk meta to button and checkout components ([1e42d6c](http://github.paypal.com/paypal/paypal-checkout/commit/1e42d6c))
-* Remove hacks ([5d0394a](http://github.paypal.com/paypal/paypal-checkout/commit/5d0394a))
-* Use isPayPalDomain from client ([8d0eb65](http://github.paypal.com/paypal/paypal-checkout/commit/8d0eb65))
+* 4.1.24 ([d1ed115](https://github.com/paypal/paypal-checkout-components/commit/d1ed115))
+* Dist ([d2cff73](https://github.com/paypal/paypal-checkout-components/commit/d2cff73))
+* More type cleanup ([9b750f8](https://github.com/paypal/paypal-checkout-components/commit/9b750f8))
+* Move common libraries to web-client ([a7c9237](https://github.com/paypal/paypal-checkout-components/commit/a7c9237))
+* Pass sdk meta to button and checkout components ([1e42d6c](https://github.com/paypal/paypal-checkout-components/commit/1e42d6c))
+* Remove hacks ([5d0394a](https://github.com/paypal/paypal-checkout-components/commit/5d0394a))
+* Use isPayPalDomain from client ([8d0eb65](https://github.com/paypal/paypal-checkout-components/commit/8d0eb65))
 
 
 
 ## <small>4.1.23 (2018-11-14)</small>
 
-* Count funding as ineligible if unbranded ([eb5243b](http://github.paypal.com/paypal/paypal-checkout/commit/eb5243b))
-* Dist ([5d8dd8a](http://github.paypal.com/paypal/paypal-checkout/commit/5d8dd8a))
-* Use innerHTML for script tags ([5e3b786](http://github.paypal.com/paypal/paypal-checkout/commit/5e3b786))
+* 4.1.23 ([a69ffcd](https://github.com/paypal/paypal-checkout-components/commit/a69ffcd))
+* Count funding as ineligible if unbranded ([eb5243b](https://github.com/paypal/paypal-checkout-components/commit/eb5243b))
+* Dist ([5d8dd8a](https://github.com/paypal/paypal-checkout-components/commit/5d8dd8a))
+* Use innerHTML for script tags ([5e3b786](https://github.com/paypal/paypal-checkout-components/commit/5e3b786))
 
 
 
 ## <small>4.1.22 (2018-11-09)</small>
 
-* Dist ([c5c70ee](http://github.paypal.com/paypal/paypal-checkout/commit/c5c70ee))
-* Do not map capture to sale ([ecea0fd](http://github.paypal.com/paypal/paypal-checkout/commit/ecea0fd))
-* Mark funding source as ineligible if not present in eligibility object ([206f824](http://github.paypal.com/paypal/paypal-checkout/commit/206f824))
-* Use paypal-sdk-logos for all svg logos ([b87e098](http://github.paypal.com/paypal/paypal-checkout/commit/b87e098))
+* 4.1.22 ([531de80](https://github.com/paypal/paypal-checkout-components/commit/531de80))
+* Dist ([c5c70ee](https://github.com/paypal/paypal-checkout-components/commit/c5c70ee))
+* Do not map capture to sale ([ecea0fd](https://github.com/paypal/paypal-checkout-components/commit/ecea0fd))
+* Mark funding source as ineligible if not present in eligibility object ([206f824](https://github.com/paypal/paypal-checkout-components/commit/206f824))
+* Use paypal-sdk-logos for all svg logos ([b87e098](https://github.com/paypal/paypal-checkout-components/commit/b87e098))
 
 
 
 ## <small>4.1.21 (2018-11-07)</small>
 
-* Disable package-lock ([5b821df](http://github.paypal.com/paypal/paypal-checkout/commit/5b821df))
-* Dist ([5afaee0](http://github.paypal.com/paypal/paypal-checkout/commit/5afaee0))
-* grumbler-scripts / babel7 / webpack4 upgrade ([78929f5](http://github.paypal.com/paypal/paypal-checkout/commit/78929f5))
-* Use jsx-pragmatic for jsx composition and rendering ([c35e734](http://github.paypal.com/paypal/paypal-checkout/commit/c35e734))
+* 4.1.21 ([184b52e](https://github.com/paypal/paypal-checkout-components/commit/184b52e))
+* Disable package-lock ([5b821df](https://github.com/paypal/paypal-checkout-components/commit/5b821df))
+* Dist ([5afaee0](https://github.com/paypal/paypal-checkout-components/commit/5afaee0))
+* grumbler-scripts / babel7 / webpack4 upgrade ([78929f5](https://github.com/paypal/paypal-checkout-components/commit/78929f5))
+* Use jsx-pragmatic for jsx composition and rendering ([c35e734](https://github.com/paypal/paypal-checkout-components/commit/c35e734))
 
 
 
 ## <small>4.1.20 (2018-11-06)</small>
 
-* Cast order promise to ZalgoPromise to ensure timeout method is present ([d6f8240](http://github.paypal.com/paypal/paypal-checkout/commit/d6f8240))
-* Dist ([d2ef69e](http://github.paypal.com/paypal/paypal-checkout/commit/d2ef69e))
+* 4.1.20 ([681de11](https://github.com/paypal/paypal-checkout-components/commit/681de11))
+* Cast order promise to ZalgoPromise to ensure timeout method is present ([d6f8240](https://github.com/paypal/paypal-checkout-components/commit/d6f8240))
+* Dist ([d2ef69e](https://github.com/paypal/paypal-checkout-components/commit/d2ef69e))
 
 
 
 ## <small>4.1.19 (2018-10-30)</small>
 
-* Dist ([679a4d9](http://github.paypal.com/paypal/paypal-checkout/commit/679a4d9))
-* Do not hard code commit to true in checkout component ([b77cd89](http://github.paypal.com/paypal/paypal-checkout/commit/b77cd89))
+* 4.1.19 ([e4df44b](https://github.com/paypal/paypal-checkout-components/commit/e4df44b))
+* Dist ([679a4d9](https://github.com/paypal/paypal-checkout-components/commit/679a4d9))
+* Do not hard code commit to true in checkout component ([b77cd89](https://github.com/paypal/paypal-checkout-components/commit/b77cd89))
 
 
 
 ## <small>4.1.18 (2018-10-29)</small>
 
-* Dist ([d84abc2](http://github.paypal.com/paypal/paypal-checkout/commit/d84abc2))
-* Fix stop-color in discover logo ([eeacb99](http://github.paypal.com/paypal/paypal-checkout/commit/eeacb99))
-* Pass partner attribution id to orders api ([61bf603](http://github.paypal.com/paypal/paypal-checkout/commit/61bf603))
-* Remove inline style tag from discover logo ([14192a1](http://github.paypal.com/paypal/paypal-checkout/commit/14192a1))
+* 4.1.18 ([ab51563](https://github.com/paypal/paypal-checkout-components/commit/ab51563))
+* Dist ([d84abc2](https://github.com/paypal/paypal-checkout-components/commit/d84abc2))
+* Fix stop-color in discover logo ([eeacb99](https://github.com/paypal/paypal-checkout-components/commit/eeacb99))
+* Pass partner attribution id to orders api ([61bf603](https://github.com/paypal/paypal-checkout-components/commit/61bf603))
+* Remove inline style tag from discover logo ([14192a1](https://github.com/paypal/paypal-checkout-components/commit/14192a1))
 
 
 
 ## <small>4.1.17 (2018-10-17)</small>
 
-* Dist ([5f80751](http://github.paypal.com/paypal/paypal-checkout/commit/5f80751))
-* Remove inline fill styles for svgs to fix firefox issue ([0570d71](http://github.paypal.com/paypal/paypal-checkout/commit/0570d71))
+* 4.1.17 ([eaa935f](https://github.com/paypal/paypal-checkout-components/commit/eaa935f))
+* Dist ([5f80751](https://github.com/paypal/paypal-checkout-components/commit/5f80751))
+* Remove inline fill styles for svgs to fix firefox issue ([0570d71](https://github.com/paypal/paypal-checkout-components/commit/0570d71))
 
 
 
 ## <small>4.1.16 (2018-10-11)</small>
 
-* Apply flow-typing to jsx props and fix type  issues ([900fbf3](http://github.paypal.com/paypal/paypal-checkout/commit/900fbf3))
-* Dist ([4a35bb9](http://github.paypal.com/paypal/paypal-checkout/commit/4a35bb9))
-* Encode and pass fundingEligibility to server-side button render ([b5af846](http://github.paypal.com/paypal/paypal-checkout/commit/b5af846))
+* 4.1.16 ([c2d7e57](https://github.com/paypal/paypal-checkout-components/commit/c2d7e57))
+* Apply flow-typing to jsx props and fix type  issues ([900fbf3](https://github.com/paypal/paypal-checkout-components/commit/900fbf3))
+* Dist ([4a35bb9](https://github.com/paypal/paypal-checkout-components/commit/4a35bb9))
+* Encode and pass fundingEligibility to server-side button render ([b5af846](https://github.com/paypal/paypal-checkout-components/commit/b5af846))
 
 
 
 ## <small>4.1.15 (2018-10-09)</small>
 
-* Always pass locale to credit logo ([482655f](http://github.paypal.com/paypal/paypal-checkout/commit/482655f))
-* Dist ([fa13d32](http://github.paypal.com/paypal/paypal-checkout/commit/fa13d32))
-* Fix sepa logo colors ([4c3ac0d](http://github.paypal.com/paypal/paypal-checkout/commit/4c3ac0d))
-* Include better error messages for incorrect intent and currency ([652489c](http://github.paypal.com/paypal/paypal-checkout/commit/652489c))
-* Use currency and intent from xprops for create order ([ab18813](http://github.paypal.com/paypal/paypal-checkout/commit/ab18813))
+* 4.1.15 ([f64e282](https://github.com/paypal/paypal-checkout-components/commit/f64e282))
+* Always pass locale to credit logo ([482655f](https://github.com/paypal/paypal-checkout-components/commit/482655f))
+* Dist ([fa13d32](https://github.com/paypal/paypal-checkout-components/commit/fa13d32))
+* Fix sepa logo colors ([4c3ac0d](https://github.com/paypal/paypal-checkout-components/commit/4c3ac0d))
+* Include better error messages for incorrect intent and currency ([652489c](https://github.com/paypal/paypal-checkout-components/commit/652489c))
+* Use currency and intent from xprops for create order ([ab18813](https://github.com/paypal/paypal-checkout-components/commit/ab18813))
 
 
 
 ## <small>4.1.14 (2018-10-01)</small>
 
-* Dist ([e09b374](http://github.paypal.com/paypal/paypal-checkout/commit/e09b374))
-* Use paypal-sdk-constants ([7182eb9](http://github.paypal.com/paypal/paypal-checkout/commit/7182eb9))
+* 4.1.14 ([36f1f21](https://github.com/paypal/paypal-checkout-components/commit/36f1f21))
+* Dist ([e09b374](https://github.com/paypal/paypal-checkout-components/commit/e09b374))
+* Use paypal-sdk-constants ([7182eb9](https://github.com/paypal/paypal-checkout-components/commit/7182eb9))
 
 
 
 ## <small>4.1.13 (2018-09-28)</small>
 
-* Default currency in order create ([b812527](http://github.paypal.com/paypal/paypal-checkout/commit/b812527))
-* Dist ([f6c1cbb](http://github.paypal.com/paypal/paypal-checkout/commit/f6c1cbb))
-* Only load cards if branded is enabled ([3b15942](http://github.paypal.com/paypal/paypal-checkout/commit/3b15942))
-* Remove docs in favor of developer.paypal.com ([179acda](http://github.paypal.com/paypal/paypal-checkout/commit/179acda))
-* Upgrade post-robot ([8ff03be](http://github.paypal.com/paypal/paypal-checkout/commit/8ff03be))
+* 4.1.13 ([501e856](https://github.com/paypal/paypal-checkout-components/commit/501e856))
+* Default currency in order create ([b812527](https://github.com/paypal/paypal-checkout-components/commit/b812527))
+* Dist ([f6c1cbb](https://github.com/paypal/paypal-checkout-components/commit/f6c1cbb))
+* Only load cards if branded is enabled ([3b15942](https://github.com/paypal/paypal-checkout-components/commit/3b15942))
+* Remove docs in favor of developer.paypal.com ([179acda](https://github.com/paypal/paypal-checkout-components/commit/179acda))
+* Upgrade post-robot ([8ff03be](https://github.com/paypal/paypal-checkout-components/commit/8ff03be))
 
 
 
 ## <small>4.1.12 (2018-09-20)</small>
 
-* Dist ([37aac10](http://github.paypal.com/paypal/paypal-checkout/commit/37aac10))
-* Use new client url builder and refactor types ([7e46f4d](http://github.paypal.com/paypal/paypal-checkout/commit/7e46f4d))
+* 4.1.12 ([742927b](https://github.com/paypal/paypal-checkout-components/commit/742927b))
+* Dist ([37aac10](https://github.com/paypal/paypal-checkout-components/commit/37aac10))
+* Use new client url builder and refactor types ([7e46f4d](https://github.com/paypal/paypal-checkout-components/commit/7e46f4d))
 
 
 
 ## <small>4.1.11 (2018-09-17)</small>
 
-* Dist ([018b3e9](http://github.paypal.com/paypal/paypal-checkout/commit/018b3e9))
-* Point buttons to /sdk for now ([5f1257f](http://github.paypal.com/paypal/paypal-checkout/commit/5f1257f))
+* 4.1.11 ([afe4904](https://github.com/paypal/paypal-checkout-components/commit/afe4904))
+* Dist ([018b3e9](https://github.com/paypal/paypal-checkout-components/commit/018b3e9))
+* Point buttons to /sdk for now ([5f1257f](https://github.com/paypal/paypal-checkout-components/commit/5f1257f))
 
 
 
 ## <small>4.1.10 (2018-09-15)</small>
 
-* Add nonce to all inline images, script tags and stylesheets in button ([17917ca](http://github.paypal.com/paypal/paypal-checkout/commit/17917ca))
-* Dist ([f7973a6](http://github.paypal.com/paypal/paypal-checkout/commit/f7973a6))
+* 4.1.10 ([1b9e6a4](https://github.com/paypal/paypal-checkout-components/commit/1b9e6a4))
+* Add nonce to all inline images, script tags and stylesheets in button ([17917ca](https://github.com/paypal/paypal-checkout-components/commit/17917ca))
+* Dist ([f7973a6](https://github.com/paypal/paypal-checkout-components/commit/f7973a6))
 
 
 
 ## <small>4.1.9 (2018-09-14)</small>
 
-* Dist ([4f86571](http://github.paypal.com/paypal/paypal-checkout/commit/4f86571))
-* Error out if no eligible funding sources found during button render ([412f79f](http://github.paypal.com/paypal/paypal-checkout/commit/412f79f))
-* Map commit to sale for button query param ([9cd02d8](http://github.paypal.com/paypal/paypal-checkout/commit/9cd02d8))
+* 4.1.9 ([999c297](https://github.com/paypal/paypal-checkout-components/commit/999c297))
+* Dist ([4f86571](https://github.com/paypal/paypal-checkout-components/commit/4f86571))
+* Error out if no eligible funding sources found during button render ([412f79f](https://github.com/paypal/paypal-checkout-components/commit/412f79f))
+* Map commit to sale for button query param ([9cd02d8](https://github.com/paypal/paypal-checkout-components/commit/9cd02d8))
 
 
 
 ## <small>4.1.8 (2018-09-14)</small>
 
-* Change sale to capture ([9876050](http://github.paypal.com/paypal/paypal-checkout/commit/9876050))
-* Dist ([ced29a2](http://github.paypal.com/paypal/paypal-checkout/commit/ced29a2))
-* Fix locale tests ([5a85307](http://github.paypal.com/paypal/paypal-checkout/commit/5a85307))
-* Only call original onCancel if passed ([5055184](http://github.paypal.com/paypal/paypal-checkout/commit/5055184))
-* Rename paypal.Button to paypal.Buttons ([6cd54a8](http://github.paypal.com/paypal/paypal-checkout/commit/6cd54a8))
-* Use getLogger from client and fix tests ([c2cc898](http://github.paypal.com/paypal/paypal-checkout/commit/c2cc898))
+* 4.1.8 ([8bdd636](https://github.com/paypal/paypal-checkout-components/commit/8bdd636))
+* Change sale to capture ([9876050](https://github.com/paypal/paypal-checkout-components/commit/9876050))
+* Dist ([ced29a2](https://github.com/paypal/paypal-checkout-components/commit/ced29a2))
+* Fix locale tests ([5a85307](https://github.com/paypal/paypal-checkout-components/commit/5a85307))
+* Only call original onCancel if passed ([5055184](https://github.com/paypal/paypal-checkout-components/commit/5055184))
+* Rename paypal.Button to paypal.Buttons ([6cd54a8](https://github.com/paypal/paypal-checkout-components/commit/6cd54a8))
+* Use getLogger from client and fix tests ([c2cc898](https://github.com/paypal/paypal-checkout-components/commit/c2cc898))
 
 
 
 ## <small>4.1.7 (2018-09-11)</small>
 
-* Dist ([fc3e9c1](http://github.paypal.com/paypal/paypal-checkout/commit/fc3e9c1))
-* Fix cancel and return actions ([949b516](http://github.paypal.com/paypal/paypal-checkout/commit/949b516))
-* Import web client from src ([0d31217](http://github.paypal.com/paypal/paypal-checkout/commit/0d31217))
+* 4.1.7 ([676d48a](https://github.com/paypal/paypal-checkout-components/commit/676d48a))
+* Dist ([fc3e9c1](https://github.com/paypal/paypal-checkout-components/commit/fc3e9c1))
+* Fix cancel and return actions ([949b516](https://github.com/paypal/paypal-checkout-components/commit/949b516))
+* Import web client from src ([0d31217](https://github.com/paypal/paypal-checkout-components/commit/0d31217))
 
 
 
 ## <small>4.1.6 (2018-09-11)</small>
 
-* Add xcomponent and version prop to checkout for backwards compat ([00e7f5d](http://github.paypal.com/paypal/paypal-checkout/commit/00e7f5d))
-* Dist ([c723266](http://github.paypal.com/paypal/paypal-checkout/commit/c723266))
-* Export checkout as an sdk module ([d5df2a5](http://github.paypal.com/paypal/paypal-checkout/commit/d5df2a5))
-* Fail checkout render if intranet mode ([ee06637](http://github.paypal.com/paypal/paypal-checkout/commit/ee06637))
-* Finalize button interface and streamline localization content ([2c8ed66](http://github.paypal.com/paypal/paypal-checkout/commit/2c8ed66))
-* Import Checkout component for button to allow renderTo to work ([04b2910](http://github.paypal.com/paypal/paypal-checkout/commit/04b2910))
-* Only log ineligible if not intranet ([5b857c2](http://github.paypal.com/paypal/paypal-checkout/commit/5b857c2))
-* Pass clientID prop to checkout ([aec5fe1](http://github.paypal.com/paypal/paypal-checkout/commit/aec5fe1))
-* Pass locale correctly to button url ([da1b49b](http://github.paypal.com/paypal/paypal-checkout/commit/da1b49b))
-* Pass logger down to zoid ([09a6df1](http://github.paypal.com/paypal/paypal-checkout/commit/09a6df1))
-* Point to new smart-button url ([e801ee2](http://github.paypal.com/paypal/paypal-checkout/commit/e801ee2))
-* Remove logLevel prop ([fd9f959](http://github.paypal.com/paypal/paypal-checkout/commit/fd9f959))
-* Remove stageDomain prop ([2ad7696](http://github.paypal.com/paypal/paypal-checkout/commit/2ad7696))
-* Simplify config domain and url definitions ([5ffd616](http://github.paypal.com/paypal/paypal-checkout/commit/5ffd616))
-* Upgrade client, use es6 exports for public interface, global getters ([c16caaa](http://github.paypal.com/paypal/paypal-checkout/commit/c16caaa))
+* 4.1.6 ([57ba7aa](https://github.com/paypal/paypal-checkout-components/commit/57ba7aa))
+* Add xcomponent and version prop to checkout for backwards compat ([00e7f5d](https://github.com/paypal/paypal-checkout-components/commit/00e7f5d))
+* Dist ([c723266](https://github.com/paypal/paypal-checkout-components/commit/c723266))
+* Export checkout as an sdk module ([d5df2a5](https://github.com/paypal/paypal-checkout-components/commit/d5df2a5))
+* Fail checkout render if intranet mode ([ee06637](https://github.com/paypal/paypal-checkout-components/commit/ee06637))
+* Finalize button interface and streamline localization content ([2c8ed66](https://github.com/paypal/paypal-checkout-components/commit/2c8ed66))
+* Import Checkout component for button to allow renderTo to work ([04b2910](https://github.com/paypal/paypal-checkout-components/commit/04b2910))
+* Only log ineligible if not intranet ([5b857c2](https://github.com/paypal/paypal-checkout-components/commit/5b857c2))
+* Pass clientID prop to checkout ([aec5fe1](https://github.com/paypal/paypal-checkout-components/commit/aec5fe1))
+* Pass locale correctly to button url ([da1b49b](https://github.com/paypal/paypal-checkout-components/commit/da1b49b))
+* Pass logger down to zoid ([09a6df1](https://github.com/paypal/paypal-checkout-components/commit/09a6df1))
+* Point to new smart-button url ([e801ee2](https://github.com/paypal/paypal-checkout-components/commit/e801ee2))
+* Remove logLevel prop ([fd9f959](https://github.com/paypal/paypal-checkout-components/commit/fd9f959))
+* Remove stageDomain prop ([2ad7696](https://github.com/paypal/paypal-checkout-components/commit/2ad7696))
+* Simplify config domain and url definitions ([5ffd616](https://github.com/paypal/paypal-checkout-components/commit/5ffd616))
+* Upgrade client, use es6 exports for public interface, global getters ([c16caaa](https://github.com/paypal/paypal-checkout-components/commit/c16caaa))
 
 
 
 ## <small>4.1.5 (2018-08-24)</small>
 
-* Add clientID to button props ([dbd5941](http://github.paypal.com/paypal/paypal-checkout/commit/dbd5941))
-* Dist ([5c5a238](http://github.paypal.com/paypal/paypal-checkout/commit/5c5a238))
-* Remove redundant karma config ([1e419f3](http://github.paypal.com/paypal/paypal-checkout/commit/1e419f3))
-* Switch to createOrder and onApprove ([99b8061](http://github.paypal.com/paypal/paypal-checkout/commit/99b8061))
+* 4.1.5 ([ebf3831](https://github.com/paypal/paypal-checkout-components/commit/ebf3831))
+* Add clientID to button props ([dbd5941](https://github.com/paypal/paypal-checkout-components/commit/dbd5941))
+* Dist ([5c5a238](https://github.com/paypal/paypal-checkout-components/commit/5c5a238))
+* Remove redundant karma config ([1e419f3](https://github.com/paypal/paypal-checkout-components/commit/1e419f3))
+* Switch to createOrder and onApprove ([99b8061](https://github.com/paypal/paypal-checkout-components/commit/99b8061))
 
 
 
 ## <small>4.1.4 (2018-08-21)</small>
 
-* Dist ([d388dd7](http://github.paypal.com/paypal/paypal-checkout/commit/d388dd7))
-* Fix default locale prop ([dae0cc5](http://github.paypal.com/paypal/paypal-checkout/commit/dae0cc5))
+* 4.1.4 ([0d77aeb](https://github.com/paypal/paypal-checkout-components/commit/0d77aeb))
+* Dist ([d388dd7](https://github.com/paypal/paypal-checkout-components/commit/d388dd7))
+* Fix default locale prop ([dae0cc5](https://github.com/paypal/paypal-checkout-components/commit/dae0cc5))
 
 
 
 ## <small>4.1.3 (2018-08-21)</small>
 
-* Dist ([87c407a](http://github.paypal.com/paypal/paypal-checkout/commit/87c407a))
-* Export locale in default props ([17ef133](http://github.paypal.com/paypal/paypal-checkout/commit/17ef133))
+* 4.1.3 ([1c407cb](https://github.com/paypal/paypal-checkout-components/commit/1c407cb))
+* Dist ([87c407a](https://github.com/paypal/paypal-checkout-components/commit/87c407a))
+* Export locale in default props ([17ef133](https://github.com/paypal/paypal-checkout-components/commit/17ef133))
 
 
 
 ## <small>4.1.2 (2018-08-21)</small>
 
-* Add defaults for normalized button props ([ad9c12c](http://github.paypal.com/paypal/paypal-checkout/commit/ad9c12c))
-* Dist ([75d93c9](http://github.paypal.com/paypal/paypal-checkout/commit/75d93c9))
+* 4.1.2 ([148ffb3](https://github.com/paypal/paypal-checkout-components/commit/148ffb3))
+* Add defaults for normalized button props ([ad9c12c](https://github.com/paypal/paypal-checkout-components/commit/ad9c12c))
+* Dist ([75d93c9](https://github.com/paypal/paypal-checkout-components/commit/75d93c9))
 
 
 
 ## <small>4.1.1 (2018-08-21)</small>
 
-* Add dist folder to npm package ([c9946bc](http://github.paypal.com/paypal/paypal-checkout/commit/c9946bc))
+* 4.1.1 ([23cdbc7](https://github.com/paypal/paypal-checkout-components/commit/23cdbc7))
+* Add dist folder to npm package ([c9946bc](https://github.com/paypal/paypal-checkout-components/commit/c9946bc))
 
 
 
 ## 4.1.0 (2018-08-17)
 
-*  Adding p24 and zimpler payment methods for PL,FI countries (#745) ([4d8c3ea](http://github.paypal.com/paypal/paypal-checkout/commit/4d8c3ea)), closes [#745](http://github.paypal.com/paypal/paypal-checkout/issues/745)
-* Add device level eligibility ([ad3414f](http://github.paypal.com/paypal/paypal-checkout/commit/ad3414f))
-* Add dist folder ([cb9d7f3](http://github.paypal.com/paypal/paypal-checkout/commit/cb9d7f3))
-* adding sofort to countries AT, BE, ES, IT, NL and logo change (#726) ([e874408](http://github.paypal.com/paypal/paypal-checkout/commit/e874408)), closes [#726](http://github.paypal.com/paypal/paypal-checkout/issues/726)
-* APMs should not be showing in horizontal layout (#717) ([4be1416](http://github.paypal.com/paypal/paypal-checkout/commit/4be1416)), closes [#717](http://github.paypal.com/paypal/paypal-checkout/issues/717)
-* avoiding changes to package.json when doing an `npm install` ([79485d0](http://github.paypal.com/paypal/paypal-checkout/commit/79485d0))
-* Cleanup ([4cd5d7b](http://github.paypal.com/paypal/paypal-checkout/commit/4cd5d7b))
-* Cleanup ([0e92386](http://github.paypal.com/paypal/paypal-checkout/commit/0e92386))
-* Disable jest cache ([a87fdee](http://github.paypal.com/paypal/paypal-checkout/commit/a87fdee))
-* Disallow venmo for non-mobile without mutating array ([1f945de](http://github.paypal.com/paypal/paypal-checkout/commit/1f945de))
-* Dist ([a2018f1](http://github.paypal.com/paypal/paypal-checkout/commit/a2018f1))
-* donot support popup for edge on ios -_- (#759) ([5b246be](http://github.paypal.com/paypal/paypal-checkout/commit/5b246be)), closes [#759](http://github.paypal.com/paypal/paypal-checkout/issues/759)
-* Fix screenshot tests ([6536842](http://github.paypal.com/paypal/paypal-checkout/commit/6536842))
-* Force iframe flow for MacOS CNA (Captive Network Assistant / Captive Portal) (#710) ([1a813eb](http://github.paypal.com/paypal/paypal-checkout/commit/1a813eb)), closes [#710](http://github.paypal.com/paypal/paypal-checkout/issues/710)
-* gql query for epm to enable card (#720) ([9c4a406](http://github.paypal.com/paypal/paypal-checkout/commit/9c4a406)), closes [#720](http://github.paypal.com/paypal/paypal-checkout/issues/720)
-* Load only eligible funding sources and locale content ([65a8233](http://github.paypal.com/paypal/paypal-checkout/commit/65a8233))
-* Migrate reusable utility functions to belter ([5ce83e2](http://github.paypal.com/paypal/paypal-checkout/commit/5ce83e2))
-* Move back to plain json object for button label content ([2657496](http://github.paypal.com/paypal/paypal-checkout/commit/2657496))
-* Point client-side logs at /xoplatform/logger, not /webapps/hermes (#689) ([b484fce](http://github.paypal.com/paypal/paypal-checkout/commit/b484fce)), closes [#689](http://github.paypal.com/paypal/paypal-checkout/issues/689)
-* Prebuild button render code ([a616638](http://github.paypal.com/paypal/paypal-checkout/commit/a616638))
-* Remove globals handled by grumbler-scripts ([b92cc25](http://github.paypal.com/paypal/paypal-checkout/commit/b92cc25))
-* Remove version params ([9a03f36](http://github.paypal.com/paypal/paypal-checkout/commit/9a03f36))
-* Simplify config and content ([9b382d4](http://github.paypal.com/paypal/paypal-checkout/commit/9b382d4))
-* Test fixes ([22e64dd](http://github.paypal.com/paypal/paypal-checkout/commit/22e64dd))
-* Test fixes ([91d7a34](http://github.paypal.com/paypal/paypal-checkout/commit/91d7a34))
-* Update browser compatibility ([7518a7d](http://github.paypal.com/paypal/paypal-checkout/commit/7518a7d))
-* Update ie-intranet.md (#755) ([ff5ebd9](http://github.paypal.com/paypal/paypal-checkout/commit/ff5ebd9)), closes [#755](http://github.paypal.com/paypal/paypal-checkout/issues/755)
-* Use belter to manage experiments ([5435ecd](http://github.paypal.com/paypal/paypal-checkout/commit/5435ecd))
-* Use body from http response ([6019ed6](http://github.paypal.com/paypal/paypal-checkout/commit/6019ed6))
-* Use client logger ([f0962e5](http://github.paypal.com/paypal/paypal-checkout/commit/f0962e5))
-* Use jsx to programatically generate svgs for button logos (#730) ([e6b57ff](http://github.paypal.com/paypal/paypal-checkout/commit/e6b57ff)), closes [#730](http://github.paypal.com/paypal/paypal-checkout/issues/730)
-* v2 order api (#761) ([54f4e93](http://github.paypal.com/paypal/paypal-checkout/commit/54f4e93)), closes [#761](http://github.paypal.com/paypal/paypal-checkout/issues/761)
-* v5 purge ([f4365a8](http://github.paypal.com/paypal/paypal-checkout/commit/f4365a8))
-* feat(credit): PayPal Credit button will use DE logo for DE locales (#697) ([56bd7b6](http://github.paypal.com/paypal/paypal-checkout/commit/56bd7b6)), closes [#697](http://github.paypal.com/paypal/paypal-checkout/issues/697)
-* feat(iframe): Use the iFrame for all standalone apps; native and non-native (#747) ([477b400](http://github.paypal.com/paypal/paypal-checkout/commit/477b400)), closes [#747](http://github.paypal.com/paypal/paypal-checkout/issues/747)
-* feat(label): Label support for vertical PayPal button (#696) ([04f71fb](http://github.paypal.com/paypal/paypal-checkout/commit/04f71fb)), closes [#696](http://github.paypal.com/paypal/paypal-checkout/issues/696)
-* fix(locale): Changing translations for BR/MX installment labels (#714) ([5cb3286](http://github.paypal.com/paypal/paypal-checkout/commit/5cb3286)), closes [#714](http://github.paypal.com/paypal/paypal-checkout/issues/714)
-* fix(redirect): Fixing `actions.redirect` from within iOS webviews. (#753) ([9726d8e](http://github.paypal.com/paypal/paypal-checkout/commit/9726d8e)), closes [#753](http://github.paypal.com/paypal/paypal-checkout/issues/753)
+*  Adding p24 and zimpler payment methods for PL,FI countries (#745) ([4d8c3ea](https://github.com/paypal/paypal-checkout-components/commit/4d8c3ea)), closes [#745](https://github.com/paypal/paypal-checkout-components/issues/745)
+* 4.1.0 ([c194312](https://github.com/paypal/paypal-checkout-components/commit/c194312))
+* Add device level eligibility ([ad3414f](https://github.com/paypal/paypal-checkout-components/commit/ad3414f))
+* Add dist folder ([cb9d7f3](https://github.com/paypal/paypal-checkout-components/commit/cb9d7f3))
+* adding sofort to countries AT, BE, ES, IT, NL and logo change (#726) ([e874408](https://github.com/paypal/paypal-checkout-components/commit/e874408)), closes [#726](https://github.com/paypal/paypal-checkout-components/issues/726)
+* APMs should not be showing in horizontal layout (#717) ([4be1416](https://github.com/paypal/paypal-checkout-components/commit/4be1416)), closes [#717](https://github.com/paypal/paypal-checkout-components/issues/717)
+* avoiding changes to package.json when doing an `npm install` ([79485d0](https://github.com/paypal/paypal-checkout-components/commit/79485d0))
+* Cleanup ([0e92386](https://github.com/paypal/paypal-checkout-components/commit/0e92386))
+* Cleanup ([4cd5d7b](https://github.com/paypal/paypal-checkout-components/commit/4cd5d7b))
+* Disable jest cache ([a87fdee](https://github.com/paypal/paypal-checkout-components/commit/a87fdee))
+* Disallow venmo for non-mobile without mutating array ([1f945de](https://github.com/paypal/paypal-checkout-components/commit/1f945de))
+* Dist ([a2018f1](https://github.com/paypal/paypal-checkout-components/commit/a2018f1))
+* donot support popup for edge on ios -_- (#759) ([5b246be](https://github.com/paypal/paypal-checkout-components/commit/5b246be)), closes [#759](https://github.com/paypal/paypal-checkout-components/issues/759)
+* Fix screenshot tests ([6536842](https://github.com/paypal/paypal-checkout-components/commit/6536842))
+* Force iframe flow for MacOS CNA (Captive Network Assistant / Captive Portal) (#710) ([1a813eb](https://github.com/paypal/paypal-checkout-components/commit/1a813eb)), closes [#710](https://github.com/paypal/paypal-checkout-components/issues/710)
+* gql query for epm to enable card (#720) ([9c4a406](https://github.com/paypal/paypal-checkout-components/commit/9c4a406)), closes [#720](https://github.com/paypal/paypal-checkout-components/issues/720)
+* Load only eligible funding sources and locale content ([65a8233](https://github.com/paypal/paypal-checkout-components/commit/65a8233))
+* Migrate reusable utility functions to belter ([5ce83e2](https://github.com/paypal/paypal-checkout-components/commit/5ce83e2))
+* Move back to plain json object for button label content ([2657496](https://github.com/paypal/paypal-checkout-components/commit/2657496))
+* Point client-side logs at /xoplatform/logger, not /webapps/hermes (#689) ([b484fce](https://github.com/paypal/paypal-checkout-components/commit/b484fce)), closes [#689](https://github.com/paypal/paypal-checkout-components/issues/689)
+* Prebuild button render code ([a616638](https://github.com/paypal/paypal-checkout-components/commit/a616638))
+* Remove globals handled by grumbler-scripts ([b92cc25](https://github.com/paypal/paypal-checkout-components/commit/b92cc25))
+* Remove version params ([9a03f36](https://github.com/paypal/paypal-checkout-components/commit/9a03f36))
+* Simplify config and content ([9b382d4](https://github.com/paypal/paypal-checkout-components/commit/9b382d4))
+* Test fixes ([22e64dd](https://github.com/paypal/paypal-checkout-components/commit/22e64dd))
+* Test fixes ([91d7a34](https://github.com/paypal/paypal-checkout-components/commit/91d7a34))
+* Update browser compatibility ([7518a7d](https://github.com/paypal/paypal-checkout-components/commit/7518a7d))
+* Update ie-intranet.md (#755) ([ff5ebd9](https://github.com/paypal/paypal-checkout-components/commit/ff5ebd9)), closes [#755](https://github.com/paypal/paypal-checkout-components/issues/755)
+* Use belter to manage experiments ([5435ecd](https://github.com/paypal/paypal-checkout-components/commit/5435ecd))
+* Use body from http response ([6019ed6](https://github.com/paypal/paypal-checkout-components/commit/6019ed6))
+* Use client logger ([f0962e5](https://github.com/paypal/paypal-checkout-components/commit/f0962e5))
+* Use jsx to programatically generate svgs for button logos (#730) ([e6b57ff](https://github.com/paypal/paypal-checkout-components/commit/e6b57ff)), closes [#730](https://github.com/paypal/paypal-checkout-components/issues/730)
+* v2 order api (#761) ([54f4e93](https://github.com/paypal/paypal-checkout-components/commit/54f4e93)), closes [#761](https://github.com/paypal/paypal-checkout-components/issues/761)
+* v5 purge ([f4365a8](https://github.com/paypal/paypal-checkout-components/commit/f4365a8))
+* feat(credit): PayPal Credit button will use DE logo for DE locales (#697) ([56bd7b6](https://github.com/paypal/paypal-checkout-components/commit/56bd7b6)), closes [#697](https://github.com/paypal/paypal-checkout-components/issues/697)
+* feat(iframe): Use the iFrame for all standalone apps; native and non-native (#747) ([477b400](https://github.com/paypal/paypal-checkout-components/commit/477b400)), closes [#747](https://github.com/paypal/paypal-checkout-components/issues/747)
+* feat(label): Label support for vertical PayPal button (#696) ([04f71fb](https://github.com/paypal/paypal-checkout-components/commit/04f71fb)), closes [#696](https://github.com/paypal/paypal-checkout-components/issues/696)
+* fix(locale): Changing translations for BR/MX installment labels (#714) ([5cb3286](https://github.com/paypal/paypal-checkout-components/commit/5cb3286)), closes [#714](https://github.com/paypal/paypal-checkout-components/issues/714)
+* fix(redirect): Fixing `actions.redirect` from within iOS webviews. (#753) ([9726d8e](https://github.com/paypal/paypal-checkout-components/commit/9726d8e)), closes [#753](https://github.com/paypal/paypal-checkout-components/issues/753)
 
 
 
 ## <small>4.0.204 (2018-06-15)</small>
 
-* Dist ([16a3cc7](http://github.paypal.com/paypal/paypal-checkout/commit/16a3cc7))
-* Fixing tests (#716) ([57e4740](http://github.paypal.com/paypal/paypal-checkout/commit/57e4740)), closes [#716](http://github.paypal.com/paypal/paypal-checkout/issues/716)
-* Update config.js (#702) ([812aefe](http://github.paypal.com/paypal/paypal-checkout/commit/812aefe)), closes [#702](http://github.paypal.com/paypal/paypal-checkout/issues/702)
-* Updating config (#704) ([4d60abd](http://github.paypal.com/paypal/paypal-checkout/commit/4d60abd)), closes [#704](http://github.paypal.com/paypal/paypal-checkout/issues/704)
-* fix(config): Disabling Venmo checkout for `getcargo.today` (#713) ([7803816](http://github.paypal.com/paypal/paypal-checkout/commit/7803816)), closes [#713](http://github.paypal.com/paypal/paypal-checkout/issues/713)
-* feat(button): Support for SOFORT button (#692) ([f2016c9](http://github.paypal.com/paypal/paypal-checkout/commit/f2016c9)), closes [#692](http://github.paypal.com/paypal/paypal-checkout/issues/692)
+* 4.0.204 ([de70805](https://github.com/paypal/paypal-checkout-components/commit/de70805))
+* Dist ([16a3cc7](https://github.com/paypal/paypal-checkout-components/commit/16a3cc7))
+* Fixing tests (#716) ([57e4740](https://github.com/paypal/paypal-checkout-components/commit/57e4740)), closes [#716](https://github.com/paypal/paypal-checkout-components/issues/716)
+* Update config.js (#702) ([812aefe](https://github.com/paypal/paypal-checkout-components/commit/812aefe)), closes [#702](https://github.com/paypal/paypal-checkout-components/issues/702)
+* Updating config (#704) ([4d60abd](https://github.com/paypal/paypal-checkout-components/commit/4d60abd)), closes [#704](https://github.com/paypal/paypal-checkout-components/issues/704)
+* fix(config): Disabling Venmo checkout for `getcargo.today` (#713) ([7803816](https://github.com/paypal/paypal-checkout-components/commit/7803816)), closes [#713](https://github.com/paypal/paypal-checkout-components/issues/713)
+* feat(button): Support for SOFORT button (#692) ([f2016c9](https://github.com/paypal/paypal-checkout-components/commit/f2016c9)), closes [#692](https://github.com/paypal/paypal-checkout-components/issues/692)
 
 
 
 ## <small>4.0.203 (2018-05-29)</small>
 
-* (docs): Revise upgrade doc (#690) ([188fe7f](http://github.paypal.com/paypal/paypal-checkout/commit/188fe7f)), closes [#690](http://github.paypal.com/paypal/paypal-checkout/issues/690)
-* adding dist file to .flowconfig ignore ([88cb73a](http://github.paypal.com/paypal/paypal-checkout/commit/88cb73a))
-* Dist ([8521d5f](http://github.paypal.com/paypal/paypal-checkout/commit/8521d5f))
-* fixing flow config ([ac41315](http://github.paypal.com/paypal/paypal-checkout/commit/ac41315))
-* Inlined card fields (#670) ([3faf421](http://github.paypal.com/paypal/paypal-checkout/commit/3faf421)), closes [#670](http://github.paypal.com/paypal/paypal-checkout/issues/670)
-* Ramping experiment down to zero (#693) ([394fa6c](http://github.paypal.com/paypal/paypal-checkout/commit/394fa6c)), closes [#693](http://github.paypal.com/paypal/paypal-checkout/issues/693)
-* Update config.js (#694) ([9a9d889](http://github.paypal.com/paypal/paypal-checkout/commit/9a9d889)), closes [#694](http://github.paypal.com/paypal/paypal-checkout/issues/694)
-* chore: add webpack dev server command to build and watch checkout code (#683) ([085aecd](http://github.paypal.com/paypal/paypal-checkout/commit/085aecd)), closes [#683](http://github.paypal.com/paypal/paypal-checkout/issues/683)
+* (docs): Revise upgrade doc (#690) ([188fe7f](https://github.com/paypal/paypal-checkout-components/commit/188fe7f)), closes [#690](https://github.com/paypal/paypal-checkout-components/issues/690)
+* 4.0.203 ([5a0b1c3](https://github.com/paypal/paypal-checkout-components/commit/5a0b1c3))
+* adding dist file to .flowconfig ignore ([88cb73a](https://github.com/paypal/paypal-checkout-components/commit/88cb73a))
+* Dist ([8521d5f](https://github.com/paypal/paypal-checkout-components/commit/8521d5f))
+* fixing flow config ([ac41315](https://github.com/paypal/paypal-checkout-components/commit/ac41315))
+* Inlined card fields (#670) ([3faf421](https://github.com/paypal/paypal-checkout-components/commit/3faf421)), closes [#670](https://github.com/paypal/paypal-checkout-components/issues/670)
+* Ramping experiment down to zero (#693) ([394fa6c](https://github.com/paypal/paypal-checkout-components/commit/394fa6c)), closes [#693](https://github.com/paypal/paypal-checkout-components/issues/693)
+* Update config.js (#694) ([9a9d889](https://github.com/paypal/paypal-checkout-components/commit/9a9d889)), closes [#694](https://github.com/paypal/paypal-checkout-components/issues/694)
+* chore: add webpack dev server command to build and watch checkout code (#683) ([085aecd](https://github.com/paypal/paypal-checkout-components/commit/085aecd)), closes [#683](https://github.com/paypal/paypal-checkout-components/issues/683)
 
 
 
 ## <small>4.0.202 (2018-05-07)</small>
 
-* Dist ([91865bf](http://github.paypal.com/paypal/paypal-checkout/commit/91865bf))
-* Make stage url configurable ([b0c4ba9](http://github.paypal.com/paypal/paypal-checkout/commit/b0c4ba9))
-* Use stage and stageurl from props in child ([1084838](http://github.paypal.com/paypal/paypal-checkout/commit/1084838))
+* 4.0.202 ([48e3648](https://github.com/paypal/paypal-checkout-components/commit/48e3648))
+* Dist ([91865bf](https://github.com/paypal/paypal-checkout-components/commit/91865bf))
+* Make stage url configurable ([b0c4ba9](https://github.com/paypal/paypal-checkout-components/commit/b0c4ba9))
+* Use stage and stageurl from props in child ([1084838](https://github.com/paypal/paypal-checkout-components/commit/1084838))
 
 
 
 ## <small>4.0.201 (2018-05-04)</small>
 
-* Dist ([72c01ae](http://github.paypal.com/paypal/paypal-checkout/commit/72c01ae))
-* Remove flow from globals.js ([1ccee21](http://github.paypal.com/paypal/paypal-checkout/commit/1ccee21))
+* 4.0.201 ([e5bffe4](https://github.com/paypal/paypal-checkout-components/commit/e5bffe4))
+* Dist ([72c01ae](https://github.com/paypal/paypal-checkout-components/commit/72c01ae))
+* Remove flow from globals.js ([1ccee21](https://github.com/paypal/paypal-checkout-components/commit/1ccee21))
 
 
 
 ## <small>4.0.200 (2018-05-04)</small>
 
-* Add warning for object assign bad polyfill ([971c5ab](http://github.paypal.com/paypal/paypal-checkout/commit/971c5ab))
-* Dist ([233872f](http://github.paypal.com/paypal/paypal-checkout/commit/233872f))
-* Do not try to deserialize json for build vars ([d922b5b](http://github.paypal.com/paypal/paypal-checkout/commit/d922b5b))
-* Edge stability fixes ([1e833d3](http://github.paypal.com/paypal/paypal-checkout/commit/1e833d3))
-* Fresh install on fastpublish ([6b0218e](http://github.paypal.com/paypal/paypal-checkout/commit/6b0218e))
-* Include globals in __sdk__.js ([bc62ba7](http://github.paypal.com/paypal/paypal-checkout/commit/bc62ba7))
-* Namespace and export globals ([71563d6](http://github.paypal.com/paypal/paypal-checkout/commit/71563d6))
-* Remove package-lock ([084191c](http://github.paypal.com/paypal/paypal-checkout/commit/084191c))
-* Shipping Options changes (#667) ([9b903b0](http://github.paypal.com/paypal/paypal-checkout/commit/9b903b0)), closes [#667](http://github.paypal.com/paypal/paypal-checkout/issues/667)
-* Upgrade common client ([a8b8a06](http://github.paypal.com/paypal/paypal-checkout/commit/a8b8a06))
-* white logos, spl css for alt pay btns (#663) ([a2c2feb](http://github.paypal.com/paypal/paypal-checkout/commit/a2c2feb)), closes [#663](http://github.paypal.com/paypal/paypal-checkout/issues/663)
+* 4.0.200 ([82de49e](https://github.com/paypal/paypal-checkout-components/commit/82de49e))
+* Add warning for object assign bad polyfill ([971c5ab](https://github.com/paypal/paypal-checkout-components/commit/971c5ab))
+* Dist ([233872f](https://github.com/paypal/paypal-checkout-components/commit/233872f))
+* Do not try to deserialize json for build vars ([d922b5b](https://github.com/paypal/paypal-checkout-components/commit/d922b5b))
+* Edge stability fixes ([1e833d3](https://github.com/paypal/paypal-checkout-components/commit/1e833d3))
+* Fresh install on fastpublish ([6b0218e](https://github.com/paypal/paypal-checkout-components/commit/6b0218e))
+* Include globals in __sdk__.js ([bc62ba7](https://github.com/paypal/paypal-checkout-components/commit/bc62ba7))
+* Namespace and export globals ([71563d6](https://github.com/paypal/paypal-checkout-components/commit/71563d6))
+* Remove package-lock ([084191c](https://github.com/paypal/paypal-checkout-components/commit/084191c))
+* Shipping Options changes (#667) ([9b903b0](https://github.com/paypal/paypal-checkout-components/commit/9b903b0)), closes [#667](https://github.com/paypal/paypal-checkout-components/issues/667)
+* Upgrade common client ([a8b8a06](https://github.com/paypal/paypal-checkout-components/commit/a8b8a06))
+* white logos, spl css for alt pay btns (#663) ([a2c2feb](https://github.com/paypal/paypal-checkout-components/commit/a2c2feb)), closes [#663](https://github.com/paypal/paypal-checkout-components/issues/663)
 
 
 
 ## <small>4.0.199 (2018-04-26)</small>
 
-* Dist ([90aa45e](http://github.paypal.com/paypal/paypal-checkout/commit/90aa45e))
-* Revert "Upgrade common client" ([a76a57c](http://github.paypal.com/paypal/paypal-checkout/commit/a76a57c))
+* 4.0.199 ([5e067c5](https://github.com/paypal/paypal-checkout-components/commit/5e067c5))
+* Dist ([90aa45e](https://github.com/paypal/paypal-checkout-components/commit/90aa45e))
+* Revert "Upgrade common client" ([a76a57c](https://github.com/paypal/paypal-checkout-components/commit/a76a57c))
 
 
 
 ## <small>4.0.198 (2018-04-25)</small>
 
-* Dist ([b88ced6](http://github.paypal.com/paypal/paypal-checkout/commit/b88ced6))
-* Fix doc typos ([a076351](http://github.paypal.com/paypal/paypal-checkout/commit/a076351))
-* Upgrade common client ([c73a473](http://github.paypal.com/paypal/paypal-checkout/commit/c73a473))
+* 4.0.198 ([1eadb69](https://github.com/paypal/paypal-checkout-components/commit/1eadb69))
+* Dist ([b88ced6](https://github.com/paypal/paypal-checkout-components/commit/b88ced6))
+* Fix doc typos ([a076351](https://github.com/paypal/paypal-checkout-components/commit/a076351))
+* Upgrade common client ([c73a473](https://github.com/paypal/paypal-checkout-components/commit/c73a473))
 
 
 
 ## <small>4.0.197 (2018-04-24)</small>
 
-* Dist ([7e199d6](http://github.paypal.com/paypal/paypal-checkout/commit/7e199d6))
-* Log browser for button render ([933b34e](http://github.paypal.com/paypal/paypal-checkout/commit/933b34e))
+* 4.0.197 ([7f6b9ea](https://github.com/paypal/paypal-checkout-components/commit/7f6b9ea))
+* Dist ([7e199d6](https://github.com/paypal/paypal-checkout-components/commit/7e199d6))
+* Log browser for button render ([933b34e](https://github.com/paypal/paypal-checkout-components/commit/933b34e))
 
 
 
 ## <small>4.0.196 (2018-04-24)</small>
 
-* Add logging for button style ([8e55d13](http://github.paypal.com/paypal/paypal-checkout/commit/8e55d13))
-* Add to venmo blacklist ([6f64ff6](http://github.paypal.com/paypal/paypal-checkout/commit/6f64ff6))
-* Add to venmo blacklist ([25cc9b7](http://github.paypal.com/paypal/paypal-checkout/commit/25cc9b7))
-* Add to venmo blacklist ([c76e3bf](http://github.paypal.com/paypal/paypal-checkout/commit/c76e3bf))
-* Better stringifyError and consistent use ([2f1b6e9](http://github.paypal.com/paypal/paypal-checkout/commit/2f1b6e9))
-* Dist ([9be4932](http://github.paypal.com/paypal/paypal-checkout/commit/9be4932))
-* Do not expose get and execute rest payment functions ([c7f5c87](http://github.paypal.com/paypal/paypal-checkout/commit/c7f5c87))
-* Flow fixes ([0c1d3fc](http://github.paypal.com/paypal/paypal-checkout/commit/0c1d3fc))
-* Return promise from renderTo hack ([358b28b](http://github.paypal.com/paypal/paypal-checkout/commit/358b28b))
-* Upgrade flow ([78afff9](http://github.paypal.com/paypal/paypal-checkout/commit/78afff9))
-* Walk up element tree to find parent element to base button size on ([338781c](http://github.paypal.com/paypal/paypal-checkout/commit/338781c))
+* 4.0.196 ([51b34eb](https://github.com/paypal/paypal-checkout-components/commit/51b34eb))
+* Add logging for button style ([8e55d13](https://github.com/paypal/paypal-checkout-components/commit/8e55d13))
+* Add to venmo blacklist ([c76e3bf](https://github.com/paypal/paypal-checkout-components/commit/c76e3bf))
+* Add to venmo blacklist ([25cc9b7](https://github.com/paypal/paypal-checkout-components/commit/25cc9b7))
+* Add to venmo blacklist ([6f64ff6](https://github.com/paypal/paypal-checkout-components/commit/6f64ff6))
+* Better stringifyError and consistent use ([2f1b6e9](https://github.com/paypal/paypal-checkout-components/commit/2f1b6e9))
+* Dist ([9be4932](https://github.com/paypal/paypal-checkout-components/commit/9be4932))
+* Do not expose get and execute rest payment functions ([c7f5c87](https://github.com/paypal/paypal-checkout-components/commit/c7f5c87))
+* Flow fixes ([0c1d3fc](https://github.com/paypal/paypal-checkout-components/commit/0c1d3fc))
+* Return promise from renderTo hack ([358b28b](https://github.com/paypal/paypal-checkout-components/commit/358b28b))
+* Upgrade flow ([78afff9](https://github.com/paypal/paypal-checkout-components/commit/78afff9))
+* Walk up element tree to find parent element to base button size on ([338781c](https://github.com/paypal/paypal-checkout-components/commit/338781c))
 
 
 
 ## <small>4.0.195 (2018-04-18)</small>
 
-* Dist ([ab5ee1b](http://github.paypal.com/paypal/paypal-checkout/commit/ab5ee1b))
-* Locale fix take two ([0795806](http://github.paypal.com/paypal/paypal-checkout/commit/0795806))
-* Revert "Default to browser locale for credit experiment eligibility" ([3cd25c2](http://github.paypal.com/paypal/paypal-checkout/commit/3cd25c2))
+* 4.0.195 ([10d1d55](https://github.com/paypal/paypal-checkout-components/commit/10d1d55))
+* Dist ([ab5ee1b](https://github.com/paypal/paypal-checkout-components/commit/ab5ee1b))
+* Locale fix take two ([0795806](https://github.com/paypal/paypal-checkout-components/commit/0795806))
+* Revert "Default to browser locale for credit experiment eligibility" ([3cd25c2](https://github.com/paypal/paypal-checkout-components/commit/3cd25c2))
 
 
 
 ## <small>4.0.194 (2018-04-18)</small>
 
-* Default to browser locale for credit experiment eligibility ([dc3e600](http://github.paypal.com/paypal/paypal-checkout/commit/dc3e600))
-* Dist ([86416a3](http://github.paypal.com/paypal/paypal-checkout/commit/86416a3))
+* 4.0.194 ([dc0a035](https://github.com/paypal/paypal-checkout-components/commit/dc0a035))
+* Default to browser locale for credit experiment eligibility ([dc3e600](https://github.com/paypal/paypal-checkout-components/commit/dc3e600))
+* Dist ([86416a3](https://github.com/paypal/paypal-checkout-components/commit/86416a3))
 
 
 
 ## <small>4.0.193 (2018-04-18)</small>
 
-* Dist ([e9a450c](http://github.paypal.com/paypal/paypal-checkout/commit/e9a450c))
-* Upgrade to latest shared client ([a918075](http://github.paypal.com/paypal/paypal-checkout/commit/a918075))
+* 4.0.193 ([5fe3be3](https://github.com/paypal/paypal-checkout-components/commit/5fe3be3))
+* Dist ([e9a450c](https://github.com/paypal/paypal-checkout-components/commit/e9a450c))
+* Upgrade to latest shared client ([a918075](https://github.com/paypal/paypal-checkout-components/commit/a918075))
 
 
 
 ## <small>4.0.192 (2018-04-17)</small>
 
-* changing stage ports to test on paypal staging env (#656) ([775810f](http://github.paypal.com/paypal/paypal-checkout/commit/775810f)), closes [#656](http://github.paypal.com/paypal/paypal-checkout/issues/656)
-* Dist ([3d4b4ab](http://github.paypal.com/paypal/paypal-checkout/commit/3d4b4ab))
-* enable alt pay button only for commit=true (#654) ([5aa15f3](http://github.paypal.com/paypal/paypal-checkout/commit/5aa15f3)), closes [#654](http://github.paypal.com/paypal/paypal-checkout/issues/654)
-* Use new __sdk__.js format ([5df47c1](http://github.paypal.com/paypal/paypal-checkout/commit/5df47c1))
+* 4.0.192 ([d3a2d83](https://github.com/paypal/paypal-checkout-components/commit/d3a2d83))
+* changing stage ports to test on paypal staging env (#656) ([775810f](https://github.com/paypal/paypal-checkout-components/commit/775810f)), closes [#656](https://github.com/paypal/paypal-checkout-components/issues/656)
+* Dist ([3d4b4ab](https://github.com/paypal/paypal-checkout-components/commit/3d4b4ab))
+* enable alt pay button only for commit=true (#654) ([5aa15f3](https://github.com/paypal/paypal-checkout-components/commit/5aa15f3)), closes [#654](https://github.com/paypal/paypal-checkout-components/issues/654)
+* Use new __sdk__.js format ([5df47c1](https://github.com/paypal/paypal-checkout-components/commit/5df47c1))
 
 
 
 ## <small>4.0.191 (2018-04-11)</small>
 
-* Add meta object for both button and checkout components ([c7c52b9](http://github.paypal.com/paypal/paypal-checkout/commit/c7c52b9))
-* Dist ([1f4f464](http://github.paypal.com/paypal/paypal-checkout/commit/1f4f464))
-* Upgrade hi-base32 ([e02b76a](http://github.paypal.com/paypal/paypal-checkout/commit/e02b76a))
+* 4.0.191 ([7737863](https://github.com/paypal/paypal-checkout-components/commit/7737863))
+* Add meta object for both button and checkout components ([c7c52b9](https://github.com/paypal/paypal-checkout-components/commit/c7c52b9))
+* Dist ([1f4f464](https://github.com/paypal/paypal-checkout-components/commit/1f4f464))
+* Upgrade hi-base32 ([e02b76a](https://github.com/paypal/paypal-checkout-components/commit/e02b76a))
 
 
 
 ## <small>4.0.190 (2018-04-11)</small>
 
-* Dist ([533dee6](http://github.paypal.com/paypal/paypal-checkout/commit/533dee6))
-* Use commonjs export for __sdk__.js ([869cdf2](http://github.paypal.com/paypal/paypal-checkout/commit/869cdf2))
+* 4.0.190 ([6c40491](https://github.com/paypal/paypal-checkout-components/commit/6c40491))
+* Dist ([533dee6](https://github.com/paypal/paypal-checkout-components/commit/533dee6))
+* Use commonjs export for __sdk__.js ([869cdf2](https://github.com/paypal/paypal-checkout-components/commit/869cdf2))
 
 
 
 ## <small>4.0.189 (2018-04-11)</small>
 
-* Add __sdk__.js in package.json ([bb6425e](http://github.paypal.com/paypal/paypal-checkout/commit/bb6425e))
-* Dist ([80860f8](http://github.paypal.com/paypal/paypal-checkout/commit/80860f8))
+* 4.0.189 ([73504e8](https://github.com/paypal/paypal-checkout-components/commit/73504e8))
+* Add __sdk__.js in package.json ([bb6425e](https://github.com/paypal/paypal-checkout-components/commit/bb6425e))
+* Dist ([80860f8](https://github.com/paypal/paypal-checkout-components/commit/80860f8))
 
 
 
 ## <small>4.0.188 (2018-04-11)</small>
 
-* Add __sdk__.js ([f91c4f5](http://github.paypal.com/paypal/paypal-checkout/commit/f91c4f5))
-* Add to venmo blacklist ([37546a5](http://github.paypal.com/paypal/paypal-checkout/commit/37546a5))
-* alt pay button: url config (#652) ([89c793c](http://github.paypal.com/paypal/paypal-checkout/commit/89c793c)), closes [#652](http://github.paypal.com/paypal/paypal-checkout/issues/652)
-* Dist ([7943f55](http://github.paypal.com/paypal/paypal-checkout/commit/7943f55))
-* Point to web-client declarations ([9f05c44](http://github.paypal.com/paypal/paypal-checkout/commit/9f05c44))
+* 4.0.188 ([8d07e33](https://github.com/paypal/paypal-checkout-components/commit/8d07e33))
+* Add __sdk__.js ([f91c4f5](https://github.com/paypal/paypal-checkout-components/commit/f91c4f5))
+* Add to venmo blacklist ([37546a5](https://github.com/paypal/paypal-checkout-components/commit/37546a5))
+* alt pay button: url config (#652) ([89c793c](https://github.com/paypal/paypal-checkout-components/commit/89c793c)), closes [#652](https://github.com/paypal/paypal-checkout-components/issues/652)
+* Dist ([7943f55](https://github.com/paypal/paypal-checkout-components/commit/7943f55))
+* Point to web-client declarations ([9f05c44](https://github.com/paypal/paypal-checkout-components/commit/9f05c44))
 
 
 
 ## <small>4.0.187 (2018-04-04)</small>
 
-* Add spacing to RU checkout label ([28e8a14](http://github.paypal.com/paypal/paypal-checkout/commit/28e8a14))
-* Dist ([bc50729](http://github.paypal.com/paypal/paypal-checkout/commit/bc50729))
-* Fix typo in config ([f328dfb](http://github.paypal.com/paypal/paypal-checkout/commit/f328dfb))
-* Underline continue link, not entire container ([55104a2](http://github.paypal.com/paypal/paypal-checkout/commit/55104a2))
+* 4.0.187 ([7411cff](https://github.com/paypal/paypal-checkout-components/commit/7411cff))
+* Add spacing to RU checkout label ([28e8a14](https://github.com/paypal/paypal-checkout-components/commit/28e8a14))
+* Dist ([bc50729](https://github.com/paypal/paypal-checkout-components/commit/bc50729))
+* Fix typo in config ([f328dfb](https://github.com/paypal/paypal-checkout-components/commit/f328dfb))
+* Underline continue link, not entire container ([55104a2](https://github.com/paypal/paypal-checkout-components/commit/55104a2))
 
 
 
 ## <small>4.0.186 (2018-04-02)</small>
 
-* Accessibility fixes for close button ([bddf347](http://github.paypal.com/paypal/paypal-checkout/commit/bddf347))
-* Add HowTo Integration Videos (#642) ([fe64f3a](http://github.paypal.com/paypal/paypal-checkout/commit/fe64f3a)), closes [#642](http://github.paypal.com/paypal/paypal-checkout/issues/642)
-* Add to venmo blacklist ([fbe2f82](http://github.paypal.com/paypal/paypal-checkout/commit/fbe2f82))
-* Add underline to continue link ([3163e7f](http://github.paypal.com/paypal/paypal-checkout/commit/3163e7f))
-* Altpay (#638) ([6e52a0d](http://github.paypal.com/paypal/paypal-checkout/commit/6e52a0d)), closes [#638](http://github.paypal.com/paypal/paypal-checkout/issues/638)
-* Better type declarations for button props ([17f7aaa](http://github.paypal.com/paypal/paypal-checkout/commit/17f7aaa))
-* Dist ([a01ff72](http://github.paypal.com/paypal/paypal-checkout/commit/a01ff72))
-* Lock babel-eslint to working version ([5363927](http://github.paypal.com/paypal/paypal-checkout/commit/5363927))
-* Log errors and warnings silently (#643) ([1a1a451](http://github.paypal.com/paypal/paypal-checkout/commit/1a1a451)), closes [#643](http://github.paypal.com/paypal/paypal-checkout/issues/643) [#548](http://github.paypal.com/paypal/paypal-checkout/issues/548)
-* Remove Object.assign polyfill ([b78a3a4](http://github.paypal.com/paypal/paypal-checkout/commit/b78a3a4))
+* 4.0.186 ([85d61be](https://github.com/paypal/paypal-checkout-components/commit/85d61be))
+* Accessibility fixes for close button ([bddf347](https://github.com/paypal/paypal-checkout-components/commit/bddf347))
+* Add HowTo Integration Videos (#642) ([fe64f3a](https://github.com/paypal/paypal-checkout-components/commit/fe64f3a)), closes [#642](https://github.com/paypal/paypal-checkout-components/issues/642)
+* Add to venmo blacklist ([fbe2f82](https://github.com/paypal/paypal-checkout-components/commit/fbe2f82))
+* Add underline to continue link ([3163e7f](https://github.com/paypal/paypal-checkout-components/commit/3163e7f))
+* Altpay (#638) ([6e52a0d](https://github.com/paypal/paypal-checkout-components/commit/6e52a0d)), closes [#638](https://github.com/paypal/paypal-checkout-components/issues/638)
+* Better type declarations for button props ([17f7aaa](https://github.com/paypal/paypal-checkout-components/commit/17f7aaa))
+* Dist ([a01ff72](https://github.com/paypal/paypal-checkout-components/commit/a01ff72))
+* Lock babel-eslint to working version ([5363927](https://github.com/paypal/paypal-checkout-components/commit/5363927))
+* Log errors and warnings silently (#643) ([1a1a451](https://github.com/paypal/paypal-checkout-components/commit/1a1a451)), closes [#643](https://github.com/paypal/paypal-checkout-components/issues/643) [#548](https://github.com/paypal/paypal-checkout-components/issues/548)
+* Remove Object.assign polyfill ([b78a3a4](https://github.com/paypal/paypal-checkout-components/commit/b78a3a4))
 
 
 
 ## <small>4.0.185 (2018-03-23)</small>
 
-* Add electron check to popup support check ([5e41ef7](http://github.paypal.com/paypal/paypal-checkout/commit/5e41ef7))
-* Dist ([3e5cdb1](http://github.paypal.com/paypal/paypal-checkout/commit/3e5cdb1))
-* Only call isCreditDualEligible once ([e4d8e56](http://github.paypal.com/paypal/paypal-checkout/commit/e4d8e56))
+* 4.0.185 ([377163e](https://github.com/paypal/paypal-checkout-components/commit/377163e))
+* Add electron check to popup support check ([5e41ef7](https://github.com/paypal/paypal-checkout-components/commit/5e41ef7))
+* Dist ([3e5cdb1](https://github.com/paypal/paypal-checkout-components/commit/3e5cdb1))
+* Only call isCreditDualEligible once ([e4d8e56](https://github.com/paypal/paypal-checkout-components/commit/e4d8e56))
 
 
 
 ## <small>4.0.184 (2018-03-21)</small>
 
-* Add another venmo blacklisted domain ([20b1c3b](http://github.paypal.com/paypal/paypal-checkout/commit/20b1c3b))
-* Dist ([fac9712](http://github.paypal.com/paypal/paypal-checkout/commit/fac9712))
-* Persist throttle percentiles for each experiment ([fe1a1ca](http://github.paypal.com/paypal/paypal-checkout/commit/fe1a1ca))
-* Use constants for throttle groups ([6c80119](http://github.paypal.com/paypal/paypal-checkout/commit/6c80119))
+* 4.0.184 ([21c8c9e](https://github.com/paypal/paypal-checkout-components/commit/21c8c9e))
+* Add another venmo blacklisted domain ([20b1c3b](https://github.com/paypal/paypal-checkout-components/commit/20b1c3b))
+* Dist ([fac9712](https://github.com/paypal/paypal-checkout-components/commit/fac9712))
+* Persist throttle percentiles for each experiment ([fe1a1ca](https://github.com/paypal/paypal-checkout-components/commit/fe1a1ca))
+* Use constants for throttle groups ([6c80119](https://github.com/paypal/paypal-checkout-components/commit/6c80119))
 
 
 
 ## <small>4.0.183 (2018-03-19)</small>
 
-* Dist ([bb4d07a](http://github.paypal.com/paypal/paypal-checkout/commit/bb4d07a))
-* Only allow logs for started experiments ([555b137](http://github.paypal.com/paypal/paypal-checkout/commit/555b137))
+* 4.0.183 ([a60775a](https://github.com/paypal/paypal-checkout-components/commit/a60775a))
+* Dist ([bb4d07a](https://github.com/paypal/paypal-checkout-components/commit/bb4d07a))
+* Only allow logs for started experiments ([555b137](https://github.com/paypal/paypal-checkout-components/commit/555b137))
 
 
 
 ## <small>4.0.182 (2018-03-19)</small>
 
-* Dist ([7dfb2a8](http://github.paypal.com/paypal/paypal-checkout/commit/7dfb2a8))
-* Make sure credit experiment logging includes button session id ([272f259](http://github.paypal.com/paypal/paypal-checkout/commit/272f259))
-* Remove actions.order ([6e16113](http://github.paypal.com/paypal/paypal-checkout/commit/6e16113))
-* Remove postinstall from publish script ([531b69e](http://github.paypal.com/paypal/paypal-checkout/commit/531b69e))
+* 4.0.182 ([992180a](https://github.com/paypal/paypal-checkout-components/commit/992180a))
+* Dist ([7dfb2a8](https://github.com/paypal/paypal-checkout-components/commit/7dfb2a8))
+* Make sure credit experiment logging includes button session id ([272f259](https://github.com/paypal/paypal-checkout-components/commit/272f259))
+* Remove actions.order ([6e16113](https://github.com/paypal/paypal-checkout-components/commit/6e16113))
+* Remove postinstall from publish script ([531b69e](https://github.com/paypal/paypal-checkout-components/commit/531b69e))
 
 
 
 ## <small>4.0.181 (2018-03-15)</small>
 
-* Add a click log to credit throttle ([8646867](http://github.paypal.com/paypal/paypal-checkout/commit/8646867))
-* Better typing for throttle objects ([7117551](http://github.paypal.com/paypal/paypal-checkout/commit/7117551))
-* Dist ([8db5a5f](http://github.paypal.com/paypal/paypal-checkout/commit/8db5a5f))
-* Use original onKey for ready ([69f8188](http://github.paypal.com/paypal/paypal-checkout/commit/69f8188))
+* 4.0.181 ([f8d391b](https://github.com/paypal/paypal-checkout-components/commit/f8d391b))
+* Add a click log to credit throttle ([8646867](https://github.com/paypal/paypal-checkout-components/commit/8646867))
+* Better typing for throttle objects ([7117551](https://github.com/paypal/paypal-checkout-components/commit/7117551))
+* Dist ([8db5a5f](https://github.com/paypal/paypal-checkout-components/commit/8db5a5f))
+* Use original onKey for ready ([69f8188](https://github.com/paypal/paypal-checkout-components/commit/69f8188))
 
 
 
 ## <small>4.0.180 (2018-03-13)</small>
 
-* Dist ([6bc4047](http://github.paypal.com/paypal/paypal-checkout/commit/6bc4047))
-* Fix country eligibility check for credit experiment ([ec38f51](http://github.paypal.com/paypal/paypal-checkout/commit/ec38f51))
-* Remove extraneous function bind check ([fe6a65f](http://github.paypal.com/paypal/paypal-checkout/commit/fe6a65f))
+* 4.0.180 ([685c8e3](https://github.com/paypal/paypal-checkout-components/commit/685c8e3))
+* Dist ([6bc4047](https://github.com/paypal/paypal-checkout-components/commit/6bc4047))
+* Fix country eligibility check for credit experiment ([ec38f51](https://github.com/paypal/paypal-checkout-components/commit/ec38f51))
+* Remove extraneous function bind check ([fe6a65f](https://github.com/paypal/paypal-checkout-components/commit/fe6a65f))
 
 
 
 ## <small>4.0.179 (2018-03-13)</small>
 
-* Add assertions for version being passed in url and window name ([1646120](http://github.paypal.com/paypal/paypal-checkout/commit/1646120))
-* Add more warnings for broken library behavior ([f6161ae](http://github.paypal.com/paypal/paypal-checkout/commit/f6161ae))
-* Add new venmo blacklisted sites ([5d4012d](http://github.paypal.com/paypal/paypal-checkout/commit/5d4012d))
-* Add test case for new prop which is unknown to child ([8c86637](http://github.paypal.com/paypal/paypal-checkout/commit/8c86637))
-* Add tests for button server-side render in node env ([f88fb27](http://github.paypal.com/paypal/paypal-checkout/commit/f88fb27))
-* Allow passing in a filename for screenshot button configs ([30274cd](http://github.paypal.com/paypal/paypal-checkout/commit/30274cd))
-* Better error messaging for multiple load ([99c3322](http://github.paypal.com/paypal/paypal-checkout/commit/99c3322))
-* Disable sandbox prefill login ([8b216e2](http://github.paypal.com/paypal/paypal-checkout/commit/8b216e2))
-* Dist ([5172cf8](http://github.paypal.com/paypal/paypal-checkout/commit/5172cf8))
-* Do not disable iframe mode for checkout after onAuthorize and onCancel ([cc2f28f](http://github.paypal.com/paypal/paypal-checkout/commit/cc2f28f))
-* Do not hard-code width of modal message ([830eb40](http://github.paypal.com/paypal/paypal-checkout/commit/830eb40))
-* Enable automatic dual-credit button experiment ([2d77d73](http://github.paypal.com/paypal/paypal-checkout/commit/2d77d73))
-* Fail earlier for any button diff errors ([cbe72fc](http://github.paypal.com/paypal/paypal-checkout/commit/cbe72fc))
-* Fix overlay modal position ([5808f36](http://github.paypal.com/paypal/paypal-checkout/commit/5808f36))
-* Fix race condition for meta listener ([07d2365](http://github.paypal.com/paypal/paypal-checkout/commit/07d2365))
-* Fix webpack filename assertion ([9d6409d](http://github.paypal.com/paypal/paypal-checkout/commit/9d6409d))
-* Include paypal-braintree-web-client and attach button to public api ([db8e5ad](http://github.paypal.com/paypal/paypal-checkout/commit/db8e5ad))
-* Increase screenshot jasmine timeout ([7e7fc0b](http://github.paypal.com/paypal/paypal-checkout/commit/7e7fc0b))
-* Manually bump to v4.0.178 to match rollback version ([62a167d](http://github.paypal.com/paypal/paypal-checkout/commit/62a167d))
-* More specific imports for button render path ([7db6f96](http://github.paypal.com/paypal/paypal-checkout/commit/7db6f96))
-* New PayPal languages for CZ, FI, GR, HU, SK (#619) ([717a176](http://github.paypal.com/paypal/paypal-checkout/commit/717a176)), closes [#619](http://github.paypal.com/paypal/paypal-checkout/issues/619)
-* Only run credit test for US locale ([6d9a452](http://github.paypal.com/paypal/paypal-checkout/commit/6d9a452))
-* Only use WebpackPromiseShimPlugin when chunking is enabled ([c9f4a9a](http://github.paypal.com/paypal/paypal-checkout/commit/c9f4a9a))
-* small typo on the Reactjs implementation (#622) ([0907cda](http://github.paypal.com/paypal/paypal-checkout/commit/0907cda)), closes [#622](http://github.paypal.com/paypal/paypal-checkout/issues/622)
-* Switch instanceof to typeof for function checks ([58e0ad4](http://github.paypal.com/paypal/paypal-checkout/commit/58e0ad4))
-* Treat lib build as minor version ([360c93a](http://github.paypal.com/paypal/paypal-checkout/commit/360c93a))
-* Use Component.xprops where possible ([3a63ae4](http://github.paypal.com/paypal/paypal-checkout/commit/3a63ae4))
-* Use webpack config builder for karma ([fb4cf88](http://github.paypal.com/paypal/paypal-checkout/commit/fb4cf88))
+* 4.0.179 ([c1f9402](https://github.com/paypal/paypal-checkout-components/commit/c1f9402))
+* Add assertions for version being passed in url and window name ([1646120](https://github.com/paypal/paypal-checkout-components/commit/1646120))
+* Add more warnings for broken library behavior ([f6161ae](https://github.com/paypal/paypal-checkout-components/commit/f6161ae))
+* Add new venmo blacklisted sites ([5d4012d](https://github.com/paypal/paypal-checkout-components/commit/5d4012d))
+* Add test case for new prop which is unknown to child ([8c86637](https://github.com/paypal/paypal-checkout-components/commit/8c86637))
+* Add tests for button server-side render in node env ([f88fb27](https://github.com/paypal/paypal-checkout-components/commit/f88fb27))
+* Allow passing in a filename for screenshot button configs ([30274cd](https://github.com/paypal/paypal-checkout-components/commit/30274cd))
+* Better error messaging for multiple load ([99c3322](https://github.com/paypal/paypal-checkout-components/commit/99c3322))
+* Disable sandbox prefill login ([8b216e2](https://github.com/paypal/paypal-checkout-components/commit/8b216e2))
+* Dist ([5172cf8](https://github.com/paypal/paypal-checkout-components/commit/5172cf8))
+* Do not disable iframe mode for checkout after onAuthorize and onCancel ([cc2f28f](https://github.com/paypal/paypal-checkout-components/commit/cc2f28f))
+* Do not hard-code width of modal message ([830eb40](https://github.com/paypal/paypal-checkout-components/commit/830eb40))
+* Enable automatic dual-credit button experiment ([2d77d73](https://github.com/paypal/paypal-checkout-components/commit/2d77d73))
+* Fail earlier for any button diff errors ([cbe72fc](https://github.com/paypal/paypal-checkout-components/commit/cbe72fc))
+* Fix overlay modal position ([5808f36](https://github.com/paypal/paypal-checkout-components/commit/5808f36))
+* Fix race condition for meta listener ([07d2365](https://github.com/paypal/paypal-checkout-components/commit/07d2365))
+* Fix webpack filename assertion ([9d6409d](https://github.com/paypal/paypal-checkout-components/commit/9d6409d))
+* Include paypal-braintree-web-client and attach button to public api ([db8e5ad](https://github.com/paypal/paypal-checkout-components/commit/db8e5ad))
+* Increase screenshot jasmine timeout ([7e7fc0b](https://github.com/paypal/paypal-checkout-components/commit/7e7fc0b))
+* Manually bump to v4.0.178 to match rollback version ([62a167d](https://github.com/paypal/paypal-checkout-components/commit/62a167d))
+* More specific imports for button render path ([7db6f96](https://github.com/paypal/paypal-checkout-components/commit/7db6f96))
+* New PayPal languages for CZ, FI, GR, HU, SK (#619) ([717a176](https://github.com/paypal/paypal-checkout-components/commit/717a176)), closes [#619](https://github.com/paypal/paypal-checkout-components/issues/619)
+* Only run credit test for US locale ([6d9a452](https://github.com/paypal/paypal-checkout-components/commit/6d9a452))
+* Only use WebpackPromiseShimPlugin when chunking is enabled ([c9f4a9a](https://github.com/paypal/paypal-checkout-components/commit/c9f4a9a))
+* small typo on the Reactjs implementation (#622) ([0907cda](https://github.com/paypal/paypal-checkout-components/commit/0907cda)), closes [#622](https://github.com/paypal/paypal-checkout-components/issues/622)
+* Switch instanceof to typeof for function checks ([58e0ad4](https://github.com/paypal/paypal-checkout-components/commit/58e0ad4))
+* Treat lib build as minor version ([360c93a](https://github.com/paypal/paypal-checkout-components/commit/360c93a))
+* Use Component.xprops where possible ([3a63ae4](https://github.com/paypal/paypal-checkout-components/commit/3a63ae4))
+* Use webpack config builder for karma ([fb4cf88](https://github.com/paypal/paypal-checkout-components/commit/fb4cf88))
 
 
 
 ## <small>4.0.176 (2018-02-16)</small>
 
-* Dist ([94cd966](http://github.paypal.com/paypal/paypal-checkout/commit/94cd966))
-* Fix versioning ([9738520](http://github.paypal.com/paypal/paypal-checkout/commit/9738520))
+* 4.0.176 ([47d13b9](https://github.com/paypal/paypal-checkout-components/commit/47d13b9))
+* Dist ([94cd966](https://github.com/paypal/paypal-checkout-components/commit/94cd966))
+* Fix versioning ([9738520](https://github.com/paypal/paypal-checkout-components/commit/9738520))
 
 
 
 ## <small>4.0.175 (2018-02-15)</small>
 
-* Dist ([86c6dc4](http://github.paypal.com/paypal/paypal-checkout/commit/86c6dc4))
-* Remove flow-typed from postinstall ([da61749](http://github.paypal.com/paypal/paypal-checkout/commit/da61749))
+* 4.0.175 ([17853bf](https://github.com/paypal/paypal-checkout-components/commit/17853bf))
+* Dist ([86c6dc4](https://github.com/paypal/paypal-checkout-components/commit/86c6dc4))
+* Remove flow-typed from postinstall ([da61749](https://github.com/paypal/paypal-checkout-components/commit/da61749))
 
 
 
 ## <small>4.0.174 (2018-02-15)</small>
 
-* Add checkout.button.v4.js, begin lazy-loading refactor ([e19a65e](http://github.paypal.com/paypal/paypal-checkout/commit/e19a65e))
-* Add dist and node_modules to .eslintignore ([cec8445](http://github.paypal.com/paypal/paypal-checkout/commit/cec8445))
-* Add paypal.logFundingEligibility ([a03fb39](http://github.paypal.com/paypal/paypal-checkout/commit/a03fb39))
-* Add shipping options and risk tracking to client side payment api ([feb98c7](http://github.paypal.com/paypal/paypal-checkout/commit/feb98c7))
-* Add support for optional chunking in webpack builds ([15cf4b7](http://github.paypal.com/paypal/paypal-checkout/commit/15cf4b7))
-* Add title to iframe overlay container ([c8fbad1](http://github.paypal.com/paypal/paypal-checkout/commit/c8fbad1))
-* Add webpack base config ([97e2494](http://github.paypal.com/paypal/paypal-checkout/commit/97e2494))
-* Add webpack-base task to build just checkout.js ([8f8dca0](http://github.paypal.com/paypal/paypal-checkout/commit/8f8dca0))
-* Bump complexity limit ([5e410f0](http://github.paypal.com/paypal/paypal-checkout/commit/5e410f0))
-* Clean up unused dependencies ([70af5c3](http://github.paypal.com/paypal/paypal-checkout/commit/70af5c3))
-* Correct PayerID mapping in return uri for NativeXO (#586) ([f16af1c](http://github.paypal.com/paypal/paypal-checkout/commit/f16af1c)), closes [#586](http://github.paypal.com/paypal/paypal-checkout/issues/586)
-* Dist ([a5eb184](http://github.paypal.com/paypal/paypal-checkout/commit/a5eb184))
-* Enable ModuleConcatenationPlugin ([ed723b9](http://github.paypal.com/paypal/paypal-checkout/commit/ed723b9))
-* Ensure eslint is applied to jsx file ([21c2398](http://github.paypal.com/paypal/paypal-checkout/commit/21c2398))
-* Env fixes ([f2173f6](http://github.paypal.com/paypal/paypal-checkout/commit/f2173f6))
-* ES6ify and flow-type webpack config ([b5a1dfd](http://github.paypal.com/paypal/paypal-checkout/commit/b5a1dfd))
-* Fix onCancel for Checkout to call even with no token ([a5ad16a](http://github.paypal.com/paypal/paypal-checkout/commit/a5ad16a))
-* Move from gulp to npm scripts ([b3f4b48](http://github.paypal.com/paypal/paypal-checkout/commit/b3f4b48))
-* Refactor to group config and constants avoid deep nested directories ([f38eb61](http://github.paypal.com/paypal/paypal-checkout/commit/f38eb61))
-* Remove flow and babel from build step ([2a14cc6](http://github.paypal.com/paypal/paypal-checkout/commit/2a14cc6))
-* Support popupBridge onCancel ([ac2a9ea](http://github.paypal.com/paypal/paypal-checkout/commit/ac2a9ea))
-* Switch interface back to non-lazy mode ([4f290a6](http://github.paypal.com/paypal/paypal-checkout/commit/4f290a6))
-* Use Object.assign when available ([31b13c1](http://github.paypal.com/paypal/paypal-checkout/commit/31b13c1))
-* Use qs in webpack config ([7a4e946](http://github.paypal.com/paypal/paypal-checkout/commit/7a4e946))
-* Use webpack-promise-shim-plugin to enable lazy loading in older browsers ([770e38f](http://github.paypal.com/paypal/paypal-checkout/commit/770e38f))
+* 4.0.174 ([694c9f3](https://github.com/paypal/paypal-checkout-components/commit/694c9f3))
+* Add checkout.button.v4.js, begin lazy-loading refactor ([e19a65e](https://github.com/paypal/paypal-checkout-components/commit/e19a65e))
+* Add dist and node_modules to .eslintignore ([cec8445](https://github.com/paypal/paypal-checkout-components/commit/cec8445))
+* Add paypal.logFundingEligibility ([a03fb39](https://github.com/paypal/paypal-checkout-components/commit/a03fb39))
+* Add shipping options and risk tracking to client side payment api ([feb98c7](https://github.com/paypal/paypal-checkout-components/commit/feb98c7))
+* Add support for optional chunking in webpack builds ([15cf4b7](https://github.com/paypal/paypal-checkout-components/commit/15cf4b7))
+* Add title to iframe overlay container ([c8fbad1](https://github.com/paypal/paypal-checkout-components/commit/c8fbad1))
+* Add webpack base config ([97e2494](https://github.com/paypal/paypal-checkout-components/commit/97e2494))
+* Add webpack-base task to build just checkout.js ([8f8dca0](https://github.com/paypal/paypal-checkout-components/commit/8f8dca0))
+* Bump complexity limit ([5e410f0](https://github.com/paypal/paypal-checkout-components/commit/5e410f0))
+* Clean up unused dependencies ([70af5c3](https://github.com/paypal/paypal-checkout-components/commit/70af5c3))
+* Correct PayerID mapping in return uri for NativeXO (#586) ([f16af1c](https://github.com/paypal/paypal-checkout-components/commit/f16af1c)), closes [#586](https://github.com/paypal/paypal-checkout-components/issues/586)
+* Dist ([a5eb184](https://github.com/paypal/paypal-checkout-components/commit/a5eb184))
+* Enable ModuleConcatenationPlugin ([ed723b9](https://github.com/paypal/paypal-checkout-components/commit/ed723b9))
+* Ensure eslint is applied to jsx file ([21c2398](https://github.com/paypal/paypal-checkout-components/commit/21c2398))
+* Env fixes ([f2173f6](https://github.com/paypal/paypal-checkout-components/commit/f2173f6))
+* ES6ify and flow-type webpack config ([b5a1dfd](https://github.com/paypal/paypal-checkout-components/commit/b5a1dfd))
+* Fix onCancel for Checkout to call even with no token ([a5ad16a](https://github.com/paypal/paypal-checkout-components/commit/a5ad16a))
+* Move from gulp to npm scripts ([b3f4b48](https://github.com/paypal/paypal-checkout-components/commit/b3f4b48))
+* Refactor to group config and constants avoid deep nested directories ([f38eb61](https://github.com/paypal/paypal-checkout-components/commit/f38eb61))
+* Remove flow and babel from build step ([2a14cc6](https://github.com/paypal/paypal-checkout-components/commit/2a14cc6))
+* Support popupBridge onCancel ([ac2a9ea](https://github.com/paypal/paypal-checkout-components/commit/ac2a9ea))
+* Switch interface back to non-lazy mode ([4f290a6](https://github.com/paypal/paypal-checkout-components/commit/4f290a6))
+* Use Object.assign when available ([31b13c1](https://github.com/paypal/paypal-checkout-components/commit/31b13c1))
+* Use qs in webpack config ([7a4e946](https://github.com/paypal/paypal-checkout-components/commit/7a4e946))
+* Use webpack-promise-shim-plugin to enable lazy loading in older browsers ([770e38f](https://github.com/paypal/paypal-checkout-components/commit/770e38f))
 
 
 
 ## <small>4.0.173 (2018-01-16)</small>
 
-* Add jcb logo ([7434725](http://github.paypal.com/paypal/paypal-checkout/commit/7434725))
-* Add more venmo blacklists ([8601c3b](http://github.paypal.com/paypal/paypal-checkout/commit/8601c3b))
-* Dist ([9565446](http://github.paypal.com/paypal/paypal-checkout/commit/9565446))
-* Fixes for params passed through popup bridge ([c4656a7](http://github.paypal.com/paypal/paypal-checkout/commit/c4656a7))
-* Improve logo size ([b68034f](http://github.paypal.com/paypal/paypal-checkout/commit/b68034f))
-* Raise test memory ([43ef7a0](http://github.paypal.com/paypal/paypal-checkout/commit/43ef7a0))
+* 4.0.173 ([2ec3b3b](https://github.com/paypal/paypal-checkout-components/commit/2ec3b3b))
+* Add jcb logo ([7434725](https://github.com/paypal/paypal-checkout-components/commit/7434725))
+* Add more venmo blacklists ([8601c3b](https://github.com/paypal/paypal-checkout-components/commit/8601c3b))
+* Dist ([9565446](https://github.com/paypal/paypal-checkout-components/commit/9565446))
+* Fixes for params passed through popup bridge ([c4656a7](https://github.com/paypal/paypal-checkout-components/commit/c4656a7))
+* Improve logo size ([b68034f](https://github.com/paypal/paypal-checkout-components/commit/b68034f))
+* Raise test memory ([43ef7a0](https://github.com/paypal/paypal-checkout-components/commit/43ef7a0))
 
 
 
 ## <small>4.0.172 (2018-01-10)</small>
 
-* Add actions.order.get and actions.order.capture ([51e3a2b](http://github.paypal.com/paypal/paypal-checkout/commit/51e3a2b))
-* Add rest bindings for payment and order api get, capture, execute ([8e7a213](http://github.paypal.com/paypal/paypal-checkout/commit/8e7a213))
-* Allow rendering checkout to any port on localhost ([a011928](http://github.paypal.com/paypal/paypal-checkout/commit/a011928))
-* Dist ([4bff86c](http://github.paypal.com/paypal/paypal-checkout/commit/4bff86c))
-* Enable ideal button and point to alt pay url ([c5861e7](http://github.paypal.com/paypal/paypal-checkout/commit/c5861e7))
-* Fix domain setting hostname lookup ([20528a4](http://github.paypal.com/paypal/paypal-checkout/commit/20528a4))
-* Fix logger to prioritize token as context id, when available ([a3f6c86](http://github.paypal.com/paypal/paypal-checkout/commit/a3f6c86))
-* Memoize props.payment to avoid double call for popup blocker case ([68d090a](http://github.paypal.com/paypal/paypal-checkout/commit/68d090a))
-* Only call onError if present ([e8a8cea](http://github.paypal.com/paypal/paypal-checkout/commit/e8a8cea))
-* Update performance.md ([362401d](http://github.paypal.com/paypal/paypal-checkout/commit/362401d))
-* Update performance.md ([2a6c710](http://github.paypal.com/paypal/paypal-checkout/commit/2a6c710))
+* 4.0.172 ([e8b39ed](https://github.com/paypal/paypal-checkout-components/commit/e8b39ed))
+* Add actions.order.get and actions.order.capture ([51e3a2b](https://github.com/paypal/paypal-checkout-components/commit/51e3a2b))
+* Add rest bindings for payment and order api get, capture, execute ([8e7a213](https://github.com/paypal/paypal-checkout-components/commit/8e7a213))
+* Allow rendering checkout to any port on localhost ([a011928](https://github.com/paypal/paypal-checkout-components/commit/a011928))
+* Dist ([4bff86c](https://github.com/paypal/paypal-checkout-components/commit/4bff86c))
+* Enable ideal button and point to alt pay url ([c5861e7](https://github.com/paypal/paypal-checkout-components/commit/c5861e7))
+* Fix domain setting hostname lookup ([20528a4](https://github.com/paypal/paypal-checkout-components/commit/20528a4))
+* Fix logger to prioritize token as context id, when available ([a3f6c86](https://github.com/paypal/paypal-checkout-components/commit/a3f6c86))
+* Memoize props.payment to avoid double call for popup blocker case ([68d090a](https://github.com/paypal/paypal-checkout-components/commit/68d090a))
+* Only call onError if present ([e8a8cea](https://github.com/paypal/paypal-checkout-components/commit/e8a8cea))
+* Update performance.md ([362401d](https://github.com/paypal/paypal-checkout-components/commit/362401d))
+* Update performance.md ([2a6c710](https://github.com/paypal/paypal-checkout-components/commit/2a6c710))
 
 
 
 ## <small>4.0.171 (2017-12-16)</small>
 
-* Dist ([ca77ac8](http://github.paypal.com/paypal/paypal-checkout/commit/ca77ac8))
-* Fix sandbox credential typer to only trigger on page load ([ee5e992](http://github.paypal.com/paypal/paypal-checkout/commit/ee5e992))
+* 4.0.171 ([40df732](https://github.com/paypal/paypal-checkout-components/commit/40df732))
+* Dist ([ca77ac8](https://github.com/paypal/paypal-checkout-components/commit/ca77ac8))
+* Fix sandbox credential typer to only trigger on page load ([ee5e992](https://github.com/paypal/paypal-checkout-components/commit/ee5e992))
 
 
 
 ## <small>4.0.170 (2017-12-15)</small>
 
-* Dist ([ffa3c24](http://github.paypal.com/paypal/paypal-checkout/commit/ffa3c24))
-* Prefill credentials on sandbox ([a74ced3](http://github.paypal.com/paypal/paypal-checkout/commit/a74ced3))
+* 4.0.170 ([3a1ac69](https://github.com/paypal/paypal-checkout-components/commit/3a1ac69))
+* Dist ([ffa3c24](https://github.com/paypal/paypal-checkout-components/commit/ffa3c24))
+* Prefill credentials on sandbox ([a74ced3](https://github.com/paypal/paypal-checkout-components/commit/a74ced3))
 
 
 
 ## <small>4.0.169 (2017-12-12)</small>
 
-* Add demo_sandbox_client_id and demo_production_client_id ([3cc440d](http://github.paypal.com/paypal/paypal-checkout/commit/3cc440d))
-* Dist ([2a96d96](http://github.paypal.com/paypal/paypal-checkout/commit/2a96d96))
-* Export actions.request in onAuthorize ([56b03ad](http://github.paypal.com/paypal/paypal-checkout/commit/56b03ad))
+* 4.0.169 ([755f976](https://github.com/paypal/paypal-checkout-components/commit/755f976))
+* Add demo_sandbox_client_id and demo_production_client_id ([3cc440d](https://github.com/paypal/paypal-checkout-components/commit/3cc440d))
+* Dist ([2a96d96](https://github.com/paypal/paypal-checkout-components/commit/2a96d96))
+* Export actions.request in onAuthorize ([56b03ad](https://github.com/paypal/paypal-checkout-components/commit/56b03ad))
 
 
 
 ## <small>4.0.168 (2017-12-08)</small>
 
-* (readme): Add Create REst application video (#547) ([775c2cb](http://github.paypal.com/paypal/paypal-checkout/commit/775c2cb)), closes [#547](http://github.paypal.com/paypal/paypal-checkout/issues/547)
-* Add extra experiment instrumentation ([b8238e5](http://github.paypal.com/paypal/paypal-checkout/commit/b8238e5))
-* Add new ELV logo ([92075ca](http://github.paypal.com/paypal/paypal-checkout/commit/92075ca))
-* Allow more than four card buttons ([f3874f7](http://github.paypal.com/paypal/paypal-checkout/commit/f3874f7))
-* Better version-matching logic for child windows ([cba487c](http://github.paypal.com/paypal/paypal-checkout/commit/cba487c))
-* Config cleanup ([7c75e7a](http://github.paypal.com/paypal/paypal-checkout/commit/7c75e7a))
-* Dist ([3812eb1](http://github.paypal.com/paypal/paypal-checkout/commit/3812eb1))
-* Do not destroy button for onAuthorize failures ([471fcec](http://github.paypal.com/paypal/paypal-checkout/commit/471fcec))
-* Fix api calls from file protocol pages ([fb52607](http://github.paypal.com/paypal/paypal-checkout/commit/fb52607))
-* Fix max width for card logo ([df3afb5](http://github.paypal.com/paypal/paypal-checkout/commit/df3afb5))
-* Integrate with braintree-paypal-client-config ([62db93f](http://github.paypal.com/paypal/paypal-checkout/commit/62db93f))
-* Pass back object from actions.payment.tokenize ([bd4c255](http://github.paypal.com/paypal/paypal-checkout/commit/bd4c255))
-* Update domain level settings to support top-level domains ([84b620c](http://github.paypal.com/paypal/paypal-checkout/commit/84b620c))
-* Use Checkout.canRenderTo to decide whether to render to top or parent ([8268f9e](http://github.paypal.com/paypal/paypal-checkout/commit/8268f9e))
+* (readme): Add Create REst application video (#547) ([775c2cb](https://github.com/paypal/paypal-checkout-components/commit/775c2cb)), closes [#547](https://github.com/paypal/paypal-checkout-components/issues/547)
+* 4.0.168 ([71872cc](https://github.com/paypal/paypal-checkout-components/commit/71872cc))
+* Add extra experiment instrumentation ([b8238e5](https://github.com/paypal/paypal-checkout-components/commit/b8238e5))
+* Add new ELV logo ([92075ca](https://github.com/paypal/paypal-checkout-components/commit/92075ca))
+* Allow more than four card buttons ([f3874f7](https://github.com/paypal/paypal-checkout-components/commit/f3874f7))
+* Better version-matching logic for child windows ([cba487c](https://github.com/paypal/paypal-checkout-components/commit/cba487c))
+* Config cleanup ([7c75e7a](https://github.com/paypal/paypal-checkout-components/commit/7c75e7a))
+* Dist ([3812eb1](https://github.com/paypal/paypal-checkout-components/commit/3812eb1))
+* Do not destroy button for onAuthorize failures ([471fcec](https://github.com/paypal/paypal-checkout-components/commit/471fcec))
+* Fix api calls from file protocol pages ([fb52607](https://github.com/paypal/paypal-checkout-components/commit/fb52607))
+* Fix max width for card logo ([df3afb5](https://github.com/paypal/paypal-checkout-components/commit/df3afb5))
+* Integrate with braintree-paypal-client-config ([62db93f](https://github.com/paypal/paypal-checkout-components/commit/62db93f))
+* Pass back object from actions.payment.tokenize ([bd4c255](https://github.com/paypal/paypal-checkout-components/commit/bd4c255))
+* Update domain level settings to support top-level domains ([84b620c](https://github.com/paypal/paypal-checkout-components/commit/84b620c))
+* Use Checkout.canRenderTo to decide whether to render to top or parent ([8268f9e](https://github.com/paypal/paypal-checkout-components/commit/8268f9e))
 
 
 
 ## <small>4.0.167 (2017-11-30)</small>
 
-* Adjust button styles ([d3516fc](http://github.paypal.com/paypal/paypal-checkout/commit/d3516fc))
-* Dist ([4649e9a](http://github.paypal.com/paypal/paypal-checkout/commit/4649e9a))
-* Experiment cleanup ([9082369](http://github.paypal.com/paypal/paypal-checkout/commit/9082369))
-* Fall back to iframe mode for popup open failures ([b31e4a0](http://github.paypal.com/paypal/paypal-checkout/commit/b31e4a0))
-* Mark QQ browser as not supporting popups ([88115a4](http://github.paypal.com/paypal/paypal-checkout/commit/88115a4))
+* 4.0.167 ([0030637](https://github.com/paypal/paypal-checkout-components/commit/0030637))
+* Adjust button styles ([d3516fc](https://github.com/paypal/paypal-checkout-components/commit/d3516fc))
+* Dist ([4649e9a](https://github.com/paypal/paypal-checkout-components/commit/4649e9a))
+* Experiment cleanup ([9082369](https://github.com/paypal/paypal-checkout-components/commit/9082369))
+* Fall back to iframe mode for popup open failures ([b31e4a0](https://github.com/paypal/paypal-checkout-components/commit/b31e4a0))
+* Mark QQ browser as not supporting popups ([88115a4](https://github.com/paypal/paypal-checkout-components/commit/88115a4))
 
 
 
 ## <small>4.0.166 (2017-11-17)</small>
 
-* Add token to all fpti events when available ([1a17df9](http://github.paypal.com/paypal/paypal-checkout/commit/1a17df9))
-* Default button session id to regular session id if not present ([8facdaf](http://github.paypal.com/paypal/paypal-checkout/commit/8facdaf))
-* Dist ([81ca8a2](http://github.paypal.com/paypal/paypal-checkout/commit/81ca8a2))
-* Do not throw if can not parse query params ([5516fa9](http://github.paypal.com/paypal/paypal-checkout/commit/5516fa9))
-* Revert "Ramp top pay button to 100%" ([451b994](http://github.paypal.com/paypal/paypal-checkout/commit/451b994))
-* Throttle instrumentation fixes ([aabab5a](http://github.paypal.com/paypal/paypal-checkout/commit/aabab5a))
+* 4.0.166 ([8b2cbeb](https://github.com/paypal/paypal-checkout-components/commit/8b2cbeb))
+* Add token to all fpti events when available ([1a17df9](https://github.com/paypal/paypal-checkout-components/commit/1a17df9))
+* Default button session id to regular session id if not present ([8facdaf](https://github.com/paypal/paypal-checkout-components/commit/8facdaf))
+* Dist ([81ca8a2](https://github.com/paypal/paypal-checkout-components/commit/81ca8a2))
+* Do not throw if can not parse query params ([5516fa9](https://github.com/paypal/paypal-checkout-components/commit/5516fa9))
+* Revert "Ramp top pay button to 100%" ([451b994](https://github.com/paypal/paypal-checkout-components/commit/451b994))
+* Throttle instrumentation fixes ([aabab5a](https://github.com/paypal/paypal-checkout-components/commit/aabab5a))
 
 
 
 ## <small>4.0.165 (2017-11-15)</small>
 
-* Dist ([1a99709](http://github.paypal.com/paypal/paypal-checkout/commit/1a99709))
-* Fix issue getting session id from url ([16723c1](http://github.paypal.com/paypal/paypal-checkout/commit/16723c1))
+* 4.0.165 ([b588afb](https://github.com/paypal/paypal-checkout-components/commit/b588afb))
+* Dist ([1a99709](https://github.com/paypal/paypal-checkout-components/commit/1a99709))
+* Fix issue getting session id from url ([16723c1](https://github.com/paypal/paypal-checkout-components/commit/16723c1))
 
 
 
 ## <small>4.0.164 (2017-11-15)</small>
 
-* Dist ([26b419b](http://github.paypal.com/paypal/paypal-checkout/commit/26b419b))
-* Fix typo in button session id lookup ([45e0998](http://github.paypal.com/paypal/paypal-checkout/commit/45e0998))
+* 4.0.164 ([a18f91e](https://github.com/paypal/paypal-checkout-components/commit/a18f91e))
+* Dist ([26b419b](https://github.com/paypal/paypal-checkout-components/commit/26b419b))
+* Fix typo in button session id lookup ([45e0998](https://github.com/paypal/paypal-checkout-components/commit/45e0998))
 
 
 
 ## <small>4.0.163 (2017-11-15)</small>
 
-* Dist ([917aa01](http://github.paypal.com/paypal/paypal-checkout/commit/917aa01))
-* Log client-side payment call using pay id as context type ([ba64912](http://github.paypal.com/paypal/paypal-checkout/commit/ba64912))
+* 4.0.163 ([a8b2ab4](https://github.com/paypal/paypal-checkout-components/commit/a8b2ab4))
+* Dist ([917aa01](https://github.com/paypal/paypal-checkout-components/commit/917aa01))
+* Log client-side payment call using pay id as context type ([ba64912](https://github.com/paypal/paypal-checkout-components/commit/ba64912))
 
 
 
 ## <small>4.0.162 (2017-11-14)</small>
 
-* Add domain-specific settings ([1743bd8](http://github.paypal.com/paypal/paypal-checkout/commit/1743bd8))
-* Dist ([bb4430d](http://github.paypal.com/paypal/paypal-checkout/commit/bb4430d))
-* Expose actions.payment.tokenize in onAuthorize ([ffd1132](http://github.paypal.com/paypal/paypal-checkout/commit/ffd1132))
-* Fix focus test ([3b45780](http://github.paypal.com/paypal/paypal-checkout/commit/3b45780))
-* Instrumentation fixes ([3b3ac87](http://github.paypal.com/paypal/paypal-checkout/commit/3b3ac87))
-* Log gets on data.nonce ([319d624](http://github.paypal.com/paypal/paypal-checkout/commit/319d624))
-* Patch onAuthorize onProps to determine if intent present ([7ec4642](http://github.paypal.com/paypal/paypal-checkout/commit/7ec4642))
-* Ramp top pay button to 100% ([4848041](http://github.paypal.com/paypal/paypal-checkout/commit/4848041))
-* Re-add onRememberUser as a fully-fledged prop ([1cd97af](http://github.paypal.com/paypal/paypal-checkout/commit/1cd97af))
+* 4.0.162 ([fbf4cee](https://github.com/paypal/paypal-checkout-components/commit/fbf4cee))
+* Add domain-specific settings ([1743bd8](https://github.com/paypal/paypal-checkout-components/commit/1743bd8))
+* Dist ([bb4430d](https://github.com/paypal/paypal-checkout-components/commit/bb4430d))
+* Expose actions.payment.tokenize in onAuthorize ([ffd1132](https://github.com/paypal/paypal-checkout-components/commit/ffd1132))
+* Fix focus test ([3b45780](https://github.com/paypal/paypal-checkout-components/commit/3b45780))
+* Instrumentation fixes ([3b3ac87](https://github.com/paypal/paypal-checkout-components/commit/3b3ac87))
+* Log gets on data.nonce ([319d624](https://github.com/paypal/paypal-checkout-components/commit/319d624))
+* Patch onAuthorize onProps to determine if intent present ([7ec4642](https://github.com/paypal/paypal-checkout-components/commit/7ec4642))
+* Ramp top pay button to 100% ([4848041](https://github.com/paypal/paypal-checkout-components/commit/4848041))
+* Re-add onRememberUser as a fully-fledged prop ([1cd97af](https://github.com/paypal/paypal-checkout-components/commit/1cd97af))
 
 
 
 ## <small>4.0.161 (2017-11-09)</small>
 
-* Add allowpaymentrequest prop to iframe button ([9802f5f](http://github.paypal.com/paypal/paypal-checkout/commit/9802f5f))
-* Add aria-label to the button ([77ca2fb](http://github.paypal.com/paypal/paypal-checkout/commit/77ca2fb))
-* Add elo card icon ([2206b21](http://github.paypal.com/paypal/paypal-checkout/commit/2206b21))
-* Add paypal.isFundingRemembered ([7c985a8](http://github.paypal.com/paypal/paypal-checkout/commit/7c985a8))
-* Add temporary onRememberUser callback and remove component-meta remember hack ([1780aff](http://github.paypal.com/paypal/paypal-checkout/commit/1780aff))
-* Allow postMessage to popups in tests and add specific post-bridge tests ([d2b9a35](http://github.paypal.com/paypal/paypal-checkout/commit/d2b9a35))
-* Clean up bridges after each test ([a9d5884](http://github.paypal.com/paypal/paypal-checkout/commit/a9d5884))
-* Disable venmo for more sites ([b0d9606](http://github.paypal.com/paypal/paypal-checkout/commit/b0d9606))
-* Dist ([a8df4a9](http://github.paypal.com/paypal/paypal-checkout/commit/a8df4a9))
-* Enforce return or done in mocha tests ([66ed913](http://github.paypal.com/paypal/paypal-checkout/commit/66ed913))
-* Fix button logo rendering in Firefox ([dc6c5bd](http://github.paypal.com/paypal/paypal-checkout/commit/dc6c5bd))
-* Fix venmo blacklist ([e948aa6](http://github.paypal.com/paypal/paypal-checkout/commit/e948aa6))
-* Improve overlay continue button text ([004367a](http://github.paypal.com/paypal/paypal-checkout/commit/004367a))
-* In iOS show alert explaining next step to re-focus popup ([52a0590](http://github.paypal.com/paypal/paypal-checkout/commit/52a0590))
-* Log individual cards ([25e7f79](http://github.paypal.com/paypal/paypal-checkout/commit/25e7f79))
-* Log initial token using button guid ([2ac0e4d](http://github.paypal.com/paypal/paypal-checkout/commit/2ac0e4d))
-* Pass in closeComponent to onAuthorize and onCancel for popup bridge case ([ad57623](http://github.paypal.com/paypal/paypal-checkout/commit/ad57623))
-* Support intent for popup bridge case ([b14d5c5](http://github.paypal.com/paypal/paypal-checkout/commit/b14d5c5))
-* Switch sandbox payment create back to www url ([a21a0ba](http://github.paypal.com/paypal/paypal-checkout/commit/a21a0ba))
+* 4.0.161 ([09b2e19](https://github.com/paypal/paypal-checkout-components/commit/09b2e19))
+* Add allowpaymentrequest prop to iframe button ([9802f5f](https://github.com/paypal/paypal-checkout-components/commit/9802f5f))
+* Add aria-label to the button ([77ca2fb](https://github.com/paypal/paypal-checkout-components/commit/77ca2fb))
+* Add elo card icon ([2206b21](https://github.com/paypal/paypal-checkout-components/commit/2206b21))
+* Add paypal.isFundingRemembered ([7c985a8](https://github.com/paypal/paypal-checkout-components/commit/7c985a8))
+* Add temporary onRememberUser callback and remove component-meta remember hack ([1780aff](https://github.com/paypal/paypal-checkout-components/commit/1780aff))
+* Allow postMessage to popups in tests and add specific post-bridge tests ([d2b9a35](https://github.com/paypal/paypal-checkout-components/commit/d2b9a35))
+* Clean up bridges after each test ([a9d5884](https://github.com/paypal/paypal-checkout-components/commit/a9d5884))
+* Disable venmo for more sites ([b0d9606](https://github.com/paypal/paypal-checkout-components/commit/b0d9606))
+* Dist ([a8df4a9](https://github.com/paypal/paypal-checkout-components/commit/a8df4a9))
+* Enforce return or done in mocha tests ([66ed913](https://github.com/paypal/paypal-checkout-components/commit/66ed913))
+* Fix button logo rendering in Firefox ([dc6c5bd](https://github.com/paypal/paypal-checkout-components/commit/dc6c5bd))
+* Fix venmo blacklist ([e948aa6](https://github.com/paypal/paypal-checkout-components/commit/e948aa6))
+* Improve overlay continue button text ([004367a](https://github.com/paypal/paypal-checkout-components/commit/004367a))
+* In iOS show alert explaining next step to re-focus popup ([52a0590](https://github.com/paypal/paypal-checkout-components/commit/52a0590))
+* Log individual cards ([25e7f79](https://github.com/paypal/paypal-checkout-components/commit/25e7f79))
+* Log initial token using button guid ([2ac0e4d](https://github.com/paypal/paypal-checkout-components/commit/2ac0e4d))
+* Pass in closeComponent to onAuthorize and onCancel for popup bridge case ([ad57623](https://github.com/paypal/paypal-checkout-components/commit/ad57623))
+* Support intent for popup bridge case ([b14d5c5](https://github.com/paypal/paypal-checkout-components/commit/b14d5c5))
+* Switch sandbox payment create back to www url ([a21a0ba](https://github.com/paypal/paypal-checkout-components/commit/a21a0ba))
 
 
 
 ## <small>4.0.160 (2017-11-06)</small>
 
-* Dist ([c9976bc](http://github.paypal.com/paypal/paypal-checkout/commit/c9976bc))
+* 4.0.160 ([5ded424](https://github.com/paypal/paypal-checkout-components/commit/5ded424))
+* Dist ([c9976bc](https://github.com/paypal/paypal-checkout-components/commit/c9976bc))
 
 
 
 ## <small>4.0.159 (2017-11-06)</small>
 
-* Dist ([94bf1a8](http://github.paypal.com/paypal/paypal-checkout/commit/94bf1a8))
+* 4.0.159 ([99d2ecc](https://github.com/paypal/paypal-checkout-components/commit/99d2ecc))
+* Dist ([94bf1a8](https://github.com/paypal/paypal-checkout-components/commit/94bf1a8))
 
 
 
 ## <small>4.0.158 (2017-11-05)</small>
 
-* Dist ([4b27093](http://github.paypal.com/paypal/paypal-checkout/commit/4b27093))
-* Ramp up top-pay-button to 50% ([b28a4c8](http://github.paypal.com/paypal/paypal-checkout/commit/b28a4c8))
+* 4.0.158 ([c6a7b07](https://github.com/paypal/paypal-checkout-components/commit/c6a7b07))
+* Dist ([4b27093](https://github.com/paypal/paypal-checkout-components/commit/4b27093))
+* Ramp up top-pay-button to 50% ([b28a4c8](https://github.com/paypal/paypal-checkout-components/commit/b28a4c8))
 
 
 
 ## <small>4.0.157 (2017-11-02)</small>
 
-* Add lint and typecheck to fastpublish ([11ed276](http://github.paypal.com/paypal/paypal-checkout/commit/11ed276))
-* Dist ([181fe7a](http://github.paypal.com/paypal/paypal-checkout/commit/181fe7a))
-* Hard-code quick fix for demo app ([7a26846](http://github.paypal.com/paypal/paypal-checkout/commit/7a26846))
-* Style prop fixes for login component ([298afe1](http://github.paypal.com/paypal/paypal-checkout/commit/298afe1))
+* 4.0.157 ([2fbca47](https://github.com/paypal/paypal-checkout-components/commit/2fbca47))
+* Add lint and typecheck to fastpublish ([11ed276](https://github.com/paypal/paypal-checkout-components/commit/11ed276))
+* Dist ([181fe7a](https://github.com/paypal/paypal-checkout-components/commit/181fe7a))
+* Hard-code quick fix for demo app ([7a26846](https://github.com/paypal/paypal-checkout-components/commit/7a26846))
+* Style prop fixes for login component ([298afe1](https://github.com/paypal/paypal-checkout-components/commit/298afe1))
 
 
 
 ## <small>4.0.156 (2017-11-02)</small>
 
-* Dist ([286e7f4](http://github.paypal.com/paypal/paypal-checkout/commit/286e7f4))
-* Fix top button click action ([6f956c3](http://github.paypal.com/paypal/paypal-checkout/commit/6f956c3))
+* 4.0.156 ([43fa2f1](https://github.com/paypal/paypal-checkout-components/commit/43fa2f1))
+* Dist ([286e7f4](https://github.com/paypal/paypal-checkout-components/commit/286e7f4))
+* Fix top button click action ([6f956c3](https://github.com/paypal/paypal-checkout-components/commit/6f956c3))
 
 
 
 ## <small>4.0.155 (2017-11-02)</small>
 
-* Add client-side order create support ([b6ff6dc](http://github.paypal.com/paypal/paypal-checkout/commit/b6ff6dc))
-* Add domain-level venmo opt-out ([5610e46](http://github.paypal.com/paypal/paypal-checkout/commit/5610e46))
-* Add experiment for top pay button ([6c5d9d0](http://github.paypal.com/paypal/paypal-checkout/commit/6c5d9d0))
-* Dist ([e39ef78](http://github.paypal.com/paypal/paypal-checkout/commit/e39ef78))
-* Improve http response header and error handling ([40e94ed](http://github.paypal.com/paypal/paypal-checkout/commit/40e94ed))
+* 4.0.155 ([7b9df90](https://github.com/paypal/paypal-checkout-components/commit/7b9df90))
+* Add client-side order create support ([b6ff6dc](https://github.com/paypal/paypal-checkout-components/commit/b6ff6dc))
+* Add domain-level venmo opt-out ([5610e46](https://github.com/paypal/paypal-checkout-components/commit/5610e46))
+* Add experiment for top pay button ([6c5d9d0](https://github.com/paypal/paypal-checkout-components/commit/6c5d9d0))
+* Dist ([e39ef78](https://github.com/paypal/paypal-checkout-components/commit/e39ef78))
+* Improve http response header and error handling ([40e94ed](https://github.com/paypal/paypal-checkout-components/commit/40e94ed))
 
 
 
 ## <small>4.0.154 (2017-11-01)</small>
 
-* Dist ([c8ffa43](http://github.paypal.com/paypal/paypal-checkout/commit/c8ffa43))
-* Go directly to xoon for elv and card buttons ([e30cfb2](http://github.paypal.com/paypal/paypal-checkout/commit/e30cfb2))
+* 4.0.154 ([875a014](https://github.com/paypal/paypal-checkout-components/commit/875a014))
+* Dist ([c8ffa43](https://github.com/paypal/paypal-checkout-components/commit/c8ffa43))
+* Go directly to xoon for elv and card buttons ([e30cfb2](https://github.com/paypal/paypal-checkout-components/commit/e30cfb2))
 
 
 
 ## <small>4.0.153 (2017-10-31)</small>
 
-* Dist ([6ca693a](http://github.paypal.com/paypal/paypal-checkout/commit/6ca693a))
+* 4.0.153 ([cc0fced](https://github.com/paypal/paypal-checkout-components/commit/cc0fced))
+* Dist ([6ca693a](https://github.com/paypal/paypal-checkout-components/commit/6ca693a))
 
 
 
 ## <small>4.0.152 (2017-10-31)</small>
 
-* [fix] 100% width on iPhone 5 portrait (#519) ([f766779](http://github.paypal.com/paypal/paypal-checkout/commit/f766779)), closes [#519](http://github.paypal.com/paypal/paypal-checkout/issues/519)
-* Detect desktop Macintosh webviews ([0c32ee4](http://github.paypal.com/paypal/paypal-checkout/commit/0c32ee4))
-* Dist ([9ebda30](http://github.paypal.com/paypal/paypal-checkout/commit/9ebda30))
-* Fix lint error ([5028572](http://github.paypal.com/paypal/paypal-checkout/commit/5028572))
+* [fix] 100% width on iPhone 5 portrait (#519) ([f766779](https://github.com/paypal/paypal-checkout-components/commit/f766779)), closes [#519](https://github.com/paypal/paypal-checkout-components/issues/519)
+* 4.0.152 ([e692437](https://github.com/paypal/paypal-checkout-components/commit/e692437))
+* Detect desktop Macintosh webviews ([0c32ee4](https://github.com/paypal/paypal-checkout-components/commit/0c32ee4))
+* Dist ([9ebda30](https://github.com/paypal/paypal-checkout-components/commit/9ebda30))
+* Fix lint error ([5028572](https://github.com/paypal/paypal-checkout-components/commit/5028572))
 
 
 
 ## <small>4.0.151 (2017-10-28)</small>
 
-* Dist ([7aa1632](http://github.paypal.com/paypal/paypal-checkout/commit/7aa1632))
+* 4.0.151 ([ce395f3](https://github.com/paypal/paypal-checkout-components/commit/ce395f3))
+* Dist ([7aa1632](https://github.com/paypal/paypal-checkout-components/commit/7aa1632))
 
 
 
 ## <small>4.0.150 (2017-10-28)</small>
 
-* Default Object.assign in checkout flow if not present ([8b265a5](http://github.paypal.com/paypal/paypal-checkout/commit/8b265a5))
-* Dist ([997f1d1](http://github.paypal.com/paypal/paypal-checkout/commit/997f1d1))
-* Fallback in full-page mode if allowed ([a704ce7](http://github.paypal.com/paypal/paypal-checkout/commit/a704ce7))
+* 4.0.150 ([6c96b58](https://github.com/paypal/paypal-checkout-components/commit/6c96b58))
+* Default Object.assign in checkout flow if not present ([8b265a5](https://github.com/paypal/paypal-checkout-components/commit/8b265a5))
+* Dist ([997f1d1](https://github.com/paypal/paypal-checkout-components/commit/997f1d1))
+* Fallback in full-page mode if allowed ([a704ce7](https://github.com/paypal/paypal-checkout-components/commit/a704ce7))
 
 
 
 ## <small>4.0.149 (2017-10-28)</small>
 
-* Add logging for edge ([6c159e7](http://github.paypal.com/paypal/paypal-checkout/commit/6c159e7))
-* Dist ([0d18aa3](http://github.paypal.com/paypal/paypal-checkout/commit/0d18aa3))
-* Warn if prerender ends up running actual code (IE/Edge issue) ([d49971c](http://github.paypal.com/paypal/paypal-checkout/commit/d49971c))
+* 4.0.149 ([4f8d8a0](https://github.com/paypal/paypal-checkout-components/commit/4f8d8a0))
+* Add logging for edge ([6c159e7](https://github.com/paypal/paypal-checkout-components/commit/6c159e7))
+* Dist ([0d18aa3](https://github.com/paypal/paypal-checkout-components/commit/0d18aa3))
+* Warn if prerender ends up running actual code (IE/Edge issue) ([d49971c](https://github.com/paypal/paypal-checkout-components/commit/d49971c))
 
 
 
 ## <small>4.0.148 (2017-10-27)</small>
 
-* Add fastpublish script ([45d6c40](http://github.paypal.com/paypal/paypal-checkout/commit/45d6c40))
-* Dist ([737e6f2](http://github.paypal.com/paypal/paypal-checkout/commit/737e6f2))
-* Fix timeout ([2fb0452](http://github.paypal.com/paypal/paypal-checkout/commit/2fb0452))
+* 4.0.148 ([6ca52ac](https://github.com/paypal/paypal-checkout-components/commit/6ca52ac))
+* Add fastpublish script ([45d6c40](https://github.com/paypal/paypal-checkout-components/commit/45d6c40))
+* Dist ([737e6f2](https://github.com/paypal/paypal-checkout-components/commit/737e6f2))
+* Fix timeout ([2fb0452](https://github.com/paypal/paypal-checkout-components/commit/2fb0452))
 
 
 
 ## <small>4.0.147 (2017-10-27)</small>
 
-* Dist ([d43dd7a](http://github.paypal.com/paypal/paypal-checkout/commit/d43dd7a))
-* Fix venmo disallowed check ([2b2e6af](http://github.paypal.com/paypal/paypal-checkout/commit/2b2e6af))
+* 4.0.147 ([29b51f5](https://github.com/paypal/paypal-checkout-components/commit/29b51f5))
+* Dist ([d43dd7a](https://github.com/paypal/paypal-checkout-components/commit/d43dd7a))
+* Fix venmo disallowed check ([2b2e6af](https://github.com/paypal/paypal-checkout-components/commit/2b2e6af))
 
 
 
 ## <small>4.0.146 (2017-10-27)</small>
 
-* Add card funding source attribute to funding icons ([153e551](http://github.paypal.com/paypal/paypal-checkout/commit/153e551))
-* Adjust button height ([8731781](http://github.paypal.com/paypal/paypal-checkout/commit/8731781))
-* Adjust discover button ([3ccbd4f](http://github.paypal.com/paypal/paypal-checkout/commit/3ccbd4f))
-* Allow disabling payment timeout for certain domains ([6f7ab2f](http://github.paypal.com/paypal/paypal-checkout/commit/6f7ab2f))
-* Disable rendering venmo button on server-side for non-devices ([990ad11](http://github.paypal.com/paypal/paypal-checkout/commit/990ad11))
-* Dist ([cbdfd68](http://github.paypal.com/paypal/paypal-checkout/commit/cbdfd68))
-* Fall back to full page mode on any error for configured merchants ([0559b12](http://github.paypal.com/paypal/paypal-checkout/commit/0559b12))
-* Fix logo height ([6b16276](http://github.paypal.com/paypal/paypal-checkout/commit/6b16276))
-* Fix showing loading spinner on overlay ([0609429](http://github.paypal.com/paypal/paypal-checkout/commit/0609429))
-* Lint fixes ([c64130b](http://github.paypal.com/paypal/paypal-checkout/commit/c64130b))
-* Only enable discover card for US buyers ([24815eb](http://github.paypal.com/paypal/paypal-checkout/commit/24815eb))
-* Throw better error messages for remembered test ([6db8098](http://github.paypal.com/paypal/paypal-checkout/commit/6db8098))
+* 4.0.146 ([da29e29](https://github.com/paypal/paypal-checkout-components/commit/da29e29))
+* Add card funding source attribute to funding icons ([153e551](https://github.com/paypal/paypal-checkout-components/commit/153e551))
+* Adjust button height ([8731781](https://github.com/paypal/paypal-checkout-components/commit/8731781))
+* Adjust discover button ([3ccbd4f](https://github.com/paypal/paypal-checkout-components/commit/3ccbd4f))
+* Allow disabling payment timeout for certain domains ([6f7ab2f](https://github.com/paypal/paypal-checkout-components/commit/6f7ab2f))
+* Disable rendering venmo button on server-side for non-devices ([990ad11](https://github.com/paypal/paypal-checkout-components/commit/990ad11))
+* Dist ([cbdfd68](https://github.com/paypal/paypal-checkout-components/commit/cbdfd68))
+* Fall back to full page mode on any error for configured merchants ([0559b12](https://github.com/paypal/paypal-checkout-components/commit/0559b12))
+* Fix logo height ([6b16276](https://github.com/paypal/paypal-checkout-components/commit/6b16276))
+* Fix showing loading spinner on overlay ([0609429](https://github.com/paypal/paypal-checkout-components/commit/0609429))
+* Lint fixes ([c64130b](https://github.com/paypal/paypal-checkout-components/commit/c64130b))
+* Only enable discover card for US buyers ([24815eb](https://github.com/paypal/paypal-checkout-components/commit/24815eb))
+* Throw better error messages for remembered test ([6db8098](https://github.com/paypal/paypal-checkout-components/commit/6db8098))
 
 
 
 ## <small>4.0.145 (2017-10-26)</small>
 
-* Dist ([34ce14e](http://github.paypal.com/paypal/paypal-checkout/commit/34ce14e))
-* Fix lint errors ([a57277a](http://github.paypal.com/paypal/paypal-checkout/commit/a57277a))
-* Fix locale issues ([fb5ede5](http://github.paypal.com/paypal/paypal-checkout/commit/fb5ede5))
+* 4.0.145 ([f12cc99](https://github.com/paypal/paypal-checkout-components/commit/f12cc99))
+* Dist ([34ce14e](https://github.com/paypal/paypal-checkout-components/commit/34ce14e))
+* Fix lint errors ([a57277a](https://github.com/paypal/paypal-checkout-components/commit/a57277a))
+* Fix locale issues ([fb5ede5](https://github.com/paypal/paypal-checkout-components/commit/fb5ede5))
 
 
 
 ## <small>4.0.144 (2017-10-26)</small>
 
-* Dist ([f69002b](http://github.paypal.com/paypal/paypal-checkout/commit/f69002b))
-* Do not wrap card icons in span ([971d6c2](http://github.paypal.com/paypal/paypal-checkout/commit/971d6c2))
+* 4.0.144 ([828e155](https://github.com/paypal/paypal-checkout-components/commit/828e155))
+* Dist ([f69002b](https://github.com/paypal/paypal-checkout-components/commit/f69002b))
+* Do not wrap card icons in span ([971d6c2](https://github.com/paypal/paypal-checkout-components/commit/971d6c2))
 
 
 
 ## <small>4.0.143 (2017-10-25)</small>
 
-* Accept promise for client id ([0f7501a](http://github.paypal.com/paypal/paypal-checkout/commit/0f7501a))
-* Consider locales before languages in browser settings ([c321347](http://github.paypal.com/paypal/paypal-checkout/commit/c321347))
-* Dist ([a6d689e](http://github.paypal.com/paypal/paypal-checkout/commit/a6d689e))
-* Remove button fix hack ([75a3d2c](http://github.paypal.com/paypal/paypal-checkout/commit/75a3d2c))
+* 4.0.143 ([b2757bf](https://github.com/paypal/paypal-checkout-components/commit/b2757bf))
+* Accept promise for client id ([0f7501a](https://github.com/paypal/paypal-checkout-components/commit/0f7501a))
+* Consider locales before languages in browser settings ([c321347](https://github.com/paypal/paypal-checkout-components/commit/c321347))
+* Dist ([a6d689e](https://github.com/paypal/paypal-checkout-components/commit/a6d689e))
+* Remove button fix hack ([75a3d2c](https://github.com/paypal/paypal-checkout-components/commit/75a3d2c))
 
 
 
 ## <small>4.0.142 (2017-10-23)</small>
 
-* Allow fundingicons to be clicked ([c29e160](http://github.paypal.com/paypal/paypal-checkout/commit/c29e160))
-* Clean up responsive styles ([6167dcd](http://github.paypal.com/paypal/paypal-checkout/commit/6167dcd))
-* Dist ([1b870f8](http://github.paypal.com/paypal/paypal-checkout/commit/1b870f8))
-* Improve button validation logic ([0ccc9c1](http://github.paypal.com/paypal/paypal-checkout/commit/0ccc9c1))
-* Improve locale detection logic ([90e6691](http://github.paypal.com/paypal/paypal-checkout/commit/90e6691))
+* 4.0.142 ([1ea1231](https://github.com/paypal/paypal-checkout-components/commit/1ea1231))
+* Allow fundingicons to be clicked ([c29e160](https://github.com/paypal/paypal-checkout-components/commit/c29e160))
+* Clean up responsive styles ([6167dcd](https://github.com/paypal/paypal-checkout-components/commit/6167dcd))
+* Dist ([1b870f8](https://github.com/paypal/paypal-checkout-components/commit/1b870f8))
+* Improve button validation logic ([0ccc9c1](https://github.com/paypal/paypal-checkout-components/commit/0ccc9c1))
+* Improve locale detection logic ([90e6691](https://github.com/paypal/paypal-checkout-components/commit/90e6691))
 
 
 
 ## <small>4.0.141 (2017-10-19)</small>
 
-* Allow maxbuttons 1 for vertical ([c09759b](http://github.paypal.com/paypal/paypal-checkout/commit/c09759b))
-* Button style adjustments ([40ae3f1](http://github.paypal.com/paypal/paypal-checkout/commit/40ae3f1))
-* Dist ([ac2dbc6](http://github.paypal.com/paypal/paypal-checkout/commit/ac2dbc6))
-* Do not show paypal in horizontal dual credit button ([b97b57c](http://github.paypal.com/paypal/paypal-checkout/commit/b97b57c))
-* Fix imgur upload path ([de7802c](http://github.paypal.com/paypal/paypal-checkout/commit/de7802c))
-* Improve button validation messages ([3061b79](http://github.paypal.com/paypal/paypal-checkout/commit/3061b79))
-* Only show ELV by default in vertical mode ([98bd0a5](http://github.paypal.com/paypal/paypal-checkout/commit/98bd0a5))
-* Only show venmo button for mobile devices ([fd78175](http://github.paypal.com/paypal/paypal-checkout/commit/fd78175))
-* Show full credit logo for vertical layout ([fa227b0](http://github.paypal.com/paypal/paypal-checkout/commit/fa227b0))
-* Use Lastschrift in ELV logo ([c33f942](http://github.paypal.com/paypal/paypal-checkout/commit/c33f942))
+* 4.0.141 ([694a1f9](https://github.com/paypal/paypal-checkout-components/commit/694a1f9))
+* Allow maxbuttons 1 for vertical ([c09759b](https://github.com/paypal/paypal-checkout-components/commit/c09759b))
+* Button style adjustments ([40ae3f1](https://github.com/paypal/paypal-checkout-components/commit/40ae3f1))
+* Dist ([ac2dbc6](https://github.com/paypal/paypal-checkout-components/commit/ac2dbc6))
+* Do not show paypal in horizontal dual credit button ([b97b57c](https://github.com/paypal/paypal-checkout-components/commit/b97b57c))
+* Fix imgur upload path ([de7802c](https://github.com/paypal/paypal-checkout-components/commit/de7802c))
+* Improve button validation messages ([3061b79](https://github.com/paypal/paypal-checkout-components/commit/3061b79))
+* Only show ELV by default in vertical mode ([98bd0a5](https://github.com/paypal/paypal-checkout-components/commit/98bd0a5))
+* Only show venmo button for mobile devices ([fd78175](https://github.com/paypal/paypal-checkout-components/commit/fd78175))
+* Show full credit logo for vertical layout ([fa227b0](https://github.com/paypal/paypal-checkout-components/commit/fa227b0))
+* Use Lastschrift in ELV logo ([c33f942](https://github.com/paypal/paypal-checkout-components/commit/c33f942))
 
 
 
 ## <small>4.0.140 (2017-10-18)</small>
 
-* Dist ([954e23e](http://github.paypal.com/paypal/paypal-checkout/commit/954e23e))
-* Fix button instrumentation ([d6bd947](http://github.paypal.com/paypal/paypal-checkout/commit/d6bd947))
+* 4.0.140 ([498bdfb](https://github.com/paypal/paypal-checkout-components/commit/498bdfb))
+* Dist ([954e23e](https://github.com/paypal/paypal-checkout-components/commit/954e23e))
+* Fix button instrumentation ([d6bd947](https://github.com/paypal/paypal-checkout-components/commit/d6bd947))
 
 
 
 ## <small>4.0.139 (2017-10-18)</small>
 
-* Add button screenshot test improvements ([899d4d6](http://github.paypal.com/paypal/paypal-checkout/commit/899d4d6))
-* Add new pill screenshots ([58065ad](http://github.paypal.com/paypal/paypal-checkout/commit/58065ad))
-* Dist ([0b30fb7](http://github.paypal.com/paypal/paypal-checkout/commit/0b30fb7))
-* Fix pill styles ([b7accee](http://github.paypal.com/paypal/paypal-checkout/commit/b7accee))
-* Flush logs from button iframe ([c32e83e](http://github.paypal.com/paypal/paypal-checkout/commit/c32e83e))
-* Redirect to guest app from login page ([684da06](http://github.paypal.com/paypal/paypal-checkout/commit/684da06))
+* 4.0.139 ([aab81a5](https://github.com/paypal/paypal-checkout-components/commit/aab81a5))
+* Add button screenshot test improvements ([899d4d6](https://github.com/paypal/paypal-checkout-components/commit/899d4d6))
+* Add new pill screenshots ([58065ad](https://github.com/paypal/paypal-checkout-components/commit/58065ad))
+* Dist ([0b30fb7](https://github.com/paypal/paypal-checkout-components/commit/0b30fb7))
+* Fix pill styles ([b7accee](https://github.com/paypal/paypal-checkout-components/commit/b7accee))
+* Flush logs from button iframe ([c32e83e](https://github.com/paypal/paypal-checkout-components/commit/c32e83e))
+* Redirect to guest app from login page ([684da06](https://github.com/paypal/paypal-checkout-components/commit/684da06))
 
 
 
 ## <small>4.0.138 (2017-10-17)</small>
 
-* Dist ([663dddf](http://github.paypal.com/paypal/paypal-checkout/commit/663dddf))
-* Ensure credit is only defaulted on for vertical integrations ([2fed7bd](http://github.paypal.com/paypal/paypal-checkout/commit/2fed7bd))
-* Make sure to call original style validation after patching ([06ab4df](http://github.paypal.com/paypal/paypal-checkout/commit/06ab4df))
-* Patch window.Promise in button iframe if not present ([6fa4fde](http://github.paypal.com/paypal/paypal-checkout/commit/6fa4fde))
-* Update screenshot test images ([b9cdc9f](http://github.paypal.com/paypal/paypal-checkout/commit/b9cdc9f))
+* 4.0.138 ([2107bd4](https://github.com/paypal/paypal-checkout-components/commit/2107bd4))
+* Dist ([663dddf](https://github.com/paypal/paypal-checkout-components/commit/663dddf))
+* Ensure credit is only defaulted on for vertical integrations ([2fed7bd](https://github.com/paypal/paypal-checkout-components/commit/2fed7bd))
+* Make sure to call original style validation after patching ([06ab4df](https://github.com/paypal/paypal-checkout-components/commit/06ab4df))
+* Patch window.Promise in button iframe if not present ([6fa4fde](https://github.com/paypal/paypal-checkout-components/commit/6fa4fde))
+* Update screenshot test images ([b9cdc9f](https://github.com/paypal/paypal-checkout-components/commit/b9cdc9f))
 
 
 
 ## <small>4.0.137 (2017-10-17)</small>
 
-* Dist ([d046c72](http://github.paypal.com/paypal/paypal-checkout/commit/d046c72))
-* Enable credit by default for US ([f930ec7](http://github.paypal.com/paypal/paypal-checkout/commit/f930ec7))
-* Fix old style props for framework integrations ([67d8d0f](http://github.paypal.com/paypal/paypal-checkout/commit/67d8d0f))
-* Go to regular checkout for card/elv button ([bf185a9](http://github.paypal.com/paypal/paypal-checkout/commit/bf185a9))
-* Make card button lowest priority ([db4257a](http://github.paypal.com/paypal/paypal-checkout/commit/db4257a))
-* Redirect to guest app if card or elv button clicked ([8103df0](http://github.paypal.com/paypal/paypal-checkout/commit/8103df0))
-* Show PayPal wordmark in small credit button ([bac1fbf](http://github.paypal.com/paypal/paypal-checkout/commit/bac1fbf))
-* Style card button transparently ([47b7096](http://github.paypal.com/paypal/paypal-checkout/commit/47b7096))
-* Update screenshot test images ([49eb2cc](http://github.paypal.com/paypal/paypal-checkout/commit/49eb2cc))
+* 4.0.137 ([aa5ab18](https://github.com/paypal/paypal-checkout-components/commit/aa5ab18))
+* Dist ([d046c72](https://github.com/paypal/paypal-checkout-components/commit/d046c72))
+* Enable credit by default for US ([f930ec7](https://github.com/paypal/paypal-checkout-components/commit/f930ec7))
+* Fix old style props for framework integrations ([67d8d0f](https://github.com/paypal/paypal-checkout-components/commit/67d8d0f))
+* Go to regular checkout for card/elv button ([bf185a9](https://github.com/paypal/paypal-checkout-components/commit/bf185a9))
+* Make card button lowest priority ([db4257a](https://github.com/paypal/paypal-checkout-components/commit/db4257a))
+* Redirect to guest app if card or elv button clicked ([8103df0](https://github.com/paypal/paypal-checkout-components/commit/8103df0))
+* Show PayPal wordmark in small credit button ([bac1fbf](https://github.com/paypal/paypal-checkout-components/commit/bac1fbf))
+* Style card button transparently ([47b7096](https://github.com/paypal/paypal-checkout-components/commit/47b7096))
+* Update screenshot test images ([49eb2cc](https://github.com/paypal/paypal-checkout-components/commit/49eb2cc))
 
 
 
 ## <small>4.0.136 (2017-10-17)</small>
 
-* Add compatibility fixes ([dbd5f42](http://github.paypal.com/paypal/paypal-checkout/commit/dbd5f42))
-* Dist ([2897b08](http://github.paypal.com/paypal/paypal-checkout/commit/2897b08))
+* 4.0.136 ([c54596c](https://github.com/paypal/paypal-checkout-components/commit/c54596c))
+* Add compatibility fixes ([dbd5f42](https://github.com/paypal/paypal-checkout-components/commit/dbd5f42))
+* Dist ([2897b08](https://github.com/paypal/paypal-checkout-components/commit/2897b08))
 
 
 
 ## <small>4.0.135 (2017-10-17)</small>
 
-* Add button count kv ([f5f2b91](http://github.paypal.com/paypal/paypal-checkout/commit/f5f2b91))
-* Add extra window type options ([c6d62f8](http://github.paypal.com/paypal/paypal-checkout/commit/c6d62f8))
-* Add jsx eslint rules ([cdf3301](http://github.paypal.com/paypal/paypal-checkout/commit/cdf3301))
-* Adjust default funding mix ([fcb1b9e](http://github.paypal.com/paypal/paypal-checkout/commit/fcb1b9e))
-* Dist ([16cc801](http://github.paypal.com/paypal/paypal-checkout/commit/16cc801))
-* Instrument button_layout ([d195ad9](http://github.paypal.com/paypal/paypal-checkout/commit/d195ad9))
-* Lock flow to 0.56 ([1f0967c](http://github.paypal.com/paypal/paypal-checkout/commit/1f0967c))
-* Only run timeout for payment in production mode ([3d7652e](http://github.paypal.com/paypal/paypal-checkout/commit/3d7652e))
-* Remove production client id from demos ([249b660](http://github.paypal.com/paypal/paypal-checkout/commit/249b660))
-* Switch to enum for country and lang ([958e4fb](http://github.paypal.com/paypal/paypal-checkout/commit/958e4fb))
-* Temporarily map generic label to paypal in button template ([471a2ff](http://github.paypal.com/paypal/paypal-checkout/commit/471a2ff))
-* Temporarily skip responsive resize test ([6e5c030](http://github.paypal.com/paypal/paypal-checkout/commit/6e5c030))
-* Upgrade post-robot and zalgo-promise and use ifdef-loader ([2b2f000](http://github.paypal.com/paypal/paypal-checkout/commit/2b2f000))
-* Upgrade to latest cross-domain-utils ([9bc5541](http://github.paypal.com/paypal/paypal-checkout/commit/9bc5541))
-* Use latest fpti kv names for buttons rendered and clicked ([f761f88](http://github.paypal.com/paypal/paypal-checkout/commit/f761f88))
+* 4.0.135 ([d6ff268](https://github.com/paypal/paypal-checkout-components/commit/d6ff268))
+* Add button count kv ([f5f2b91](https://github.com/paypal/paypal-checkout-components/commit/f5f2b91))
+* Add extra window type options ([c6d62f8](https://github.com/paypal/paypal-checkout-components/commit/c6d62f8))
+* Add jsx eslint rules ([cdf3301](https://github.com/paypal/paypal-checkout-components/commit/cdf3301))
+* Adjust default funding mix ([fcb1b9e](https://github.com/paypal/paypal-checkout-components/commit/fcb1b9e))
+* Dist ([16cc801](https://github.com/paypal/paypal-checkout-components/commit/16cc801))
+* Instrument button_layout ([d195ad9](https://github.com/paypal/paypal-checkout-components/commit/d195ad9))
+* Lock flow to 0.56 ([1f0967c](https://github.com/paypal/paypal-checkout-components/commit/1f0967c))
+* Only run timeout for payment in production mode ([3d7652e](https://github.com/paypal/paypal-checkout-components/commit/3d7652e))
+* Remove production client id from demos ([249b660](https://github.com/paypal/paypal-checkout-components/commit/249b660))
+* Switch to enum for country and lang ([958e4fb](https://github.com/paypal/paypal-checkout-components/commit/958e4fb))
+* Temporarily map generic label to paypal in button template ([471a2ff](https://github.com/paypal/paypal-checkout-components/commit/471a2ff))
+* Temporarily skip responsive resize test ([6e5c030](https://github.com/paypal/paypal-checkout-components/commit/6e5c030))
+* Upgrade post-robot and zalgo-promise and use ifdef-loader ([2b2f000](https://github.com/paypal/paypal-checkout-components/commit/2b2f000))
+* Upgrade to latest cross-domain-utils ([9bc5541](https://github.com/paypal/paypal-checkout-components/commit/9bc5541))
+* Use latest fpti kv names for buttons rendered and clicked ([f761f88](https://github.com/paypal/paypal-checkout-components/commit/f761f88))
 
 
 
 ## <small>4.0.134 (2017-10-10)</small>
 
-* Add data-merchant-id prop, pass to fpti and muse ([f2bad55](http://github.paypal.com/paypal/paypal-checkout/commit/f2bad55))
-* Add version number to rendered button template ([43e44bd](http://github.paypal.com/paypal/paypal-checkout/commit/43e44bd))
-* Default ELV to guest app ([e6af477](http://github.paypal.com/paypal/paypal-checkout/commit/e6af477))
-* Dist ([912a719](http://github.paypal.com/paypal/paypal-checkout/commit/912a719))
-* Start work on turning enums into flow enums ([ad60c7a](http://github.paypal.com/paypal/paypal-checkout/commit/ad60c7a))
-* Update ISSUE_TEMPLATE.md ([eabcc72](http://github.paypal.com/paypal/paypal-checkout/commit/eabcc72))
-* Upgrade dependencies ([454b582](http://github.paypal.com/paypal/paypal-checkout/commit/454b582))
-* Use style.maxbuttons instead of style.max ([28860ed](http://github.paypal.com/paypal/paypal-checkout/commit/28860ed))
+* 4.0.134 ([76b84b7](https://github.com/paypal/paypal-checkout-components/commit/76b84b7))
+* Add data-merchant-id prop, pass to fpti and muse ([f2bad55](https://github.com/paypal/paypal-checkout-components/commit/f2bad55))
+* Add version number to rendered button template ([43e44bd](https://github.com/paypal/paypal-checkout-components/commit/43e44bd))
+* Default ELV to guest app ([e6af477](https://github.com/paypal/paypal-checkout-components/commit/e6af477))
+* Dist ([912a719](https://github.com/paypal/paypal-checkout-components/commit/912a719))
+* Start work on turning enums into flow enums ([ad60c7a](https://github.com/paypal/paypal-checkout-components/commit/ad60c7a))
+* Update ISSUE_TEMPLATE.md ([eabcc72](https://github.com/paypal/paypal-checkout-components/commit/eabcc72))
+* Upgrade dependencies ([454b582](https://github.com/paypal/paypal-checkout-components/commit/454b582))
+* Use style.maxbuttons instead of style.max ([28860ed](https://github.com/paypal/paypal-checkout-components/commit/28860ed))
 
 
 
 ## <small>4.0.133 (2017-10-04)</small>
 
-* Add dist/checkout.button.render.js to npm package ([4585cd0](http://github.paypal.com/paypal/paypal-checkout/commit/4585cd0))
-* Add option for white overlay ([771aca4](http://github.paypal.com/paypal/paypal-checkout/commit/771aca4))
-* Dist ([caef048](http://github.paypal.com/paypal/paypal-checkout/commit/caef048))
-* Dist ([afad7d3](http://github.paypal.com/paypal/paypal-checkout/commit/afad7d3))
-* Encode key name for jsx-to-html ([6ea180a](http://github.paypal.com/paypal/paypal-checkout/commit/6ea180a))
-* Move out checkout container styles ([3aa05cd](http://github.paypal.com/paypal/paypal-checkout/commit/3aa05cd))
-* Set min width and height for checkout overlay ([768a744](http://github.paypal.com/paypal/paypal-checkout/commit/768a744))
-* Update api.md ([3b134c0](http://github.paypal.com/paypal/paypal-checkout/commit/3b134c0))
-* Upgrade xcomponent with new static typing ([bf276f2](http://github.paypal.com/paypal/paypal-checkout/commit/bf276f2))
-* Use included svgs to render paypal logo on checkout overlay ([8249e3c](http://github.paypal.com/paypal/paypal-checkout/commit/8249e3c))
-* Vertical button arrangement (#472) ([121b09b](http://github.paypal.com/paypal/paypal-checkout/commit/121b09b)), closes [#472](http://github.paypal.com/paypal/paypal-checkout/issues/472)
+* 4.0.132 ([2e6875b](https://github.com/paypal/paypal-checkout-components/commit/2e6875b))
+* 4.0.133 ([daefd65](https://github.com/paypal/paypal-checkout-components/commit/daefd65))
+* Add dist/checkout.button.render.js to npm package ([4585cd0](https://github.com/paypal/paypal-checkout-components/commit/4585cd0))
+* Add option for white overlay ([771aca4](https://github.com/paypal/paypal-checkout-components/commit/771aca4))
+* Dist ([afad7d3](https://github.com/paypal/paypal-checkout-components/commit/afad7d3))
+* Dist ([caef048](https://github.com/paypal/paypal-checkout-components/commit/caef048))
+* Encode key name for jsx-to-html ([6ea180a](https://github.com/paypal/paypal-checkout-components/commit/6ea180a))
+* Move out checkout container styles ([3aa05cd](https://github.com/paypal/paypal-checkout-components/commit/3aa05cd))
+* Set min width and height for checkout overlay ([768a744](https://github.com/paypal/paypal-checkout-components/commit/768a744))
+* Update api.md ([3b134c0](https://github.com/paypal/paypal-checkout-components/commit/3b134c0))
+* Upgrade xcomponent with new static typing ([bf276f2](https://github.com/paypal/paypal-checkout-components/commit/bf276f2))
+* Use included svgs to render paypal logo on checkout overlay ([8249e3c](https://github.com/paypal/paypal-checkout-components/commit/8249e3c))
+* Vertical button arrangement (#472) ([121b09b](https://github.com/paypal/paypal-checkout-components/commit/121b09b)), closes [#472](https://github.com/paypal/paypal-checkout-components/issues/472)
 
 
 
 ## <small>4.0.131 (2017-10-01)</small>
 
-* Add button screenshot tests ([0e1fd70](http://github.paypal.com/paypal/paypal-checkout/commit/0e1fd70))
-* Add new check for facebook webview ([0981791](http://github.paypal.com/paypal/paypal-checkout/commit/0981791))
-* Cache bowser based on user-agent ([e75e7f1](http://github.paypal.com/paypal/paypal-checkout/commit/e75e7f1))
-* Dist ([6976f93](http://github.paypal.com/paypal/paypal-checkout/commit/6976f93))
-* Log experiment click from pre-render click fallback ([2dde8b6](http://github.paypal.com/paypal/paypal-checkout/commit/2dde8b6))
-* Register driver in angular example ([41a3929](http://github.paypal.com/paypal/paypal-checkout/commit/41a3929))
-* Remove Edge 15 eligibility rule ([1181b6f](http://github.paypal.com/paypal/paypal-checkout/commit/1181b6f))
-* Support new-style payment ID with PAYID- prefix ([2db77f2](http://github.paypal.com/paypal/paypal-checkout/commit/2db77f2))
-* Update ISSUE_TEMPLATE.md ([493b428](http://github.paypal.com/paypal/paypal-checkout/commit/493b428))
-* Update performance.md ([3039068](http://github.paypal.com/paypal/paypal-checkout/commit/3039068))
+* 4.0.131 ([280592a](https://github.com/paypal/paypal-checkout-components/commit/280592a))
+* Add button screenshot tests ([0e1fd70](https://github.com/paypal/paypal-checkout-components/commit/0e1fd70))
+* Add new check for facebook webview ([0981791](https://github.com/paypal/paypal-checkout-components/commit/0981791))
+* Cache bowser based on user-agent ([e75e7f1](https://github.com/paypal/paypal-checkout-components/commit/e75e7f1))
+* Dist ([6976f93](https://github.com/paypal/paypal-checkout-components/commit/6976f93))
+* Log experiment click from pre-render click fallback ([2dde8b6](https://github.com/paypal/paypal-checkout-components/commit/2dde8b6))
+* Register driver in angular example ([41a3929](https://github.com/paypal/paypal-checkout-components/commit/41a3929))
+* Remove Edge 15 eligibility rule ([1181b6f](https://github.com/paypal/paypal-checkout-components/commit/1181b6f))
+* Support new-style payment ID with PAYID- prefix ([2db77f2](https://github.com/paypal/paypal-checkout-components/commit/2db77f2))
+* Update ISSUE_TEMPLATE.md ([493b428](https://github.com/paypal/paypal-checkout-components/commit/493b428))
+* Update performance.md ([3039068](https://github.com/paypal/paypal-checkout-components/commit/3039068))
 
 
 
 ## <small>4.0.130 (2017-09-18)</small>
 
-* Add small delay on experiment return log ([18a2b4e](http://github.paypal.com/paypal/paypal-checkout/commit/18a2b4e))
-* Dist ([8ff289b](http://github.paypal.com/paypal/paypal-checkout/commit/8ff289b))
-* Improve resize test ([eae5f16](http://github.paypal.com/paypal/paypal-checkout/commit/eae5f16))
-* Simplify event names ([fa5ff15](http://github.paypal.com/paypal/paypal-checkout/commit/fa5ff15))
+* 4.0.130 ([524385f](https://github.com/paypal/paypal-checkout-components/commit/524385f))
+* Add small delay on experiment return log ([18a2b4e](https://github.com/paypal/paypal-checkout-components/commit/18a2b4e))
+* Dist ([8ff289b](https://github.com/paypal/paypal-checkout-components/commit/8ff289b))
+* Improve resize test ([eae5f16](https://github.com/paypal/paypal-checkout-components/commit/eae5f16))
+* Simplify event names ([fa5ff15](https://github.com/paypal/paypal-checkout-components/commit/fa5ff15))
 
 
 
 ## <small>4.0.129 (2017-09-18)</small>
 
-* Cleanup hacks ([b34d3a8](http://github.paypal.com/paypal/paypal-checkout/commit/b34d3a8))
-* Dist ([1f28789](http://github.paypal.com/paypal/paypal-checkout/commit/1f28789))
-* Immediately flush missing intent logs ([2d4d8ec](http://github.paypal.com/paypal/paypal-checkout/commit/2d4d8ec))
-* Improve button resize test ([afdf8db](http://github.paypal.com/paypal/paypal-checkout/commit/afdf8db))
-* Simplify external experiment instrumentation ([3d2ed05](http://github.paypal.com/paypal/paypal-checkout/commit/3d2ed05))
+* 4.0.129 ([224ea0b](https://github.com/paypal/paypal-checkout-components/commit/224ea0b))
+* Cleanup hacks ([b34d3a8](https://github.com/paypal/paypal-checkout-components/commit/b34d3a8))
+* Dist ([1f28789](https://github.com/paypal/paypal-checkout-components/commit/1f28789))
+* Immediately flush missing intent logs ([2d4d8ec](https://github.com/paypal/paypal-checkout-components/commit/2d4d8ec))
+* Improve button resize test ([afdf8db](https://github.com/paypal/paypal-checkout-components/commit/afdf8db))
+* Simplify external experiment instrumentation ([3d2ed05](https://github.com/paypal/paypal-checkout-components/commit/3d2ed05))
 
 
 
 ## <small>4.0.128 (2017-09-15)</small>
 
-* Destroy entire session after expiry time, not just guid ([fcb00e5](http://github.paypal.com/paypal/paypal-checkout/commit/fcb00e5))
-* Dist ([3f41f74](http://github.paypal.com/paypal/paypal-checkout/commit/3f41f74))
-* Do not send start/complete beacon for experiments which have already been instrumented ([2f240d9](http://github.paypal.com/paypal/paypal-checkout/commit/2f240d9))
+* 4.0.128 ([e87230d](https://github.com/paypal/paypal-checkout-components/commit/e87230d))
+* Destroy entire session after expiry time, not just guid ([fcb00e5](https://github.com/paypal/paypal-checkout-components/commit/fcb00e5))
+* Dist ([3f41f74](https://github.com/paypal/paypal-checkout-components/commit/3f41f74))
+* Do not send start/complete beacon for experiments which have already been instrumented ([2f240d9](https://github.com/paypal/paypal-checkout-components/commit/2f240d9))
 
 
 
 ## <small>4.0.127 (2017-09-14)</small>
 
-* Dist ([a948694](http://github.paypal.com/paypal/paypal-checkout/commit/a948694))
-* Only log complete for external experiment if experiment is active ([504b4ee](http://github.paypal.com/paypal/paypal-checkout/commit/504b4ee))
-* Write new session to storage ([d93f922](http://github.paypal.com/paypal/paypal-checkout/commit/d93f922))
+* 4.0.127 ([4c0a40f](https://github.com/paypal/paypal-checkout-components/commit/4c0a40f))
+* Dist ([a948694](https://github.com/paypal/paypal-checkout-components/commit/a948694))
+* Only log complete for external experiment if experiment is active ([504b4ee](https://github.com/paypal/paypal-checkout-components/commit/504b4ee))
+* Write new session to storage ([d93f922](https://github.com/paypal/paypal-checkout-components/commit/d93f922))
 
 
 
 ## <small>4.0.126 (2017-09-14)</small>
 
-* Always validate props prior to doing template render ([a3d4d0c](http://github.paypal.com/paypal/paypal-checkout/commit/a3d4d0c))
-* Dist ([cbc8965](http://github.paypal.com/paypal/paypal-checkout/commit/cbc8965))
+* 4.0.126 ([8047b86](https://github.com/paypal/paypal-checkout-components/commit/8047b86))
+* Always validate props prior to doing template render ([a3d4d0c](https://github.com/paypal/paypal-checkout-components/commit/a3d4d0c))
+* Dist ([cbc8965](https://github.com/paypal/paypal-checkout-components/commit/cbc8965))
 
 
 
 ## <small>4.0.125 (2017-09-14)</small>
 
-* Add const-immutable eslint plugin ([8c35ecc](http://github.paypal.com/paypal/paypal-checkout/commit/8c35ecc))
-* Add more logs for missing intent ([9447bbf](http://github.paypal.com/paypal/paypal-checkout/commit/9447bbf))
-* Dist ([d0705dd](http://github.paypal.com/paypal/paypal-checkout/commit/d0705dd))
-* Do not default externalExperimentComplete flag to unknown ([565925a](http://github.paypal.com/paypal/paypal-checkout/commit/565925a))
-* For proxy, use last available frame, and fall back to original ([02a1591](http://github.paypal.com/paypal/paypal-checkout/commit/02a1591))
-* Update cdn-npm.md ([9cf71b9](http://github.paypal.com/paypal/paypal-checkout/commit/9cf71b9))
-* Update content.json (#461) ([8edb7df](http://github.paypal.com/paypal/paypal-checkout/commit/8edb7df)), closes [#461](http://github.paypal.com/paypal/paypal-checkout/issues/461)
+* 4.0.125 ([1c0931f](https://github.com/paypal/paypal-checkout-components/commit/1c0931f))
+* Add const-immutable eslint plugin ([8c35ecc](https://github.com/paypal/paypal-checkout-components/commit/8c35ecc))
+* Add more logs for missing intent ([9447bbf](https://github.com/paypal/paypal-checkout-components/commit/9447bbf))
+* Dist ([d0705dd](https://github.com/paypal/paypal-checkout-components/commit/d0705dd))
+* Do not default externalExperimentComplete flag to unknown ([565925a](https://github.com/paypal/paypal-checkout-components/commit/565925a))
+* For proxy, use last available frame, and fall back to original ([02a1591](https://github.com/paypal/paypal-checkout-components/commit/02a1591))
+* Update cdn-npm.md ([9cf71b9](https://github.com/paypal/paypal-checkout-components/commit/9cf71b9))
+* Update content.json (#461) ([8edb7df](https://github.com/paypal/paypal-checkout-components/commit/8edb7df)), closes [#461](https://github.com/paypal/paypal-checkout-components/issues/461)
 
 
 
 ## <small>4.0.124 (2017-09-07)</small>
 
-* (docs) Add missing parameter to callback functions (#456) ([df7926d](http://github.paypal.com/paypal/paypal-checkout/commit/df7926d)), closes [#456](http://github.paypal.com/paypal/paypal-checkout/issues/456)
-* Dist ([2360019](http://github.paypal.com/paypal/paypal-checkout/commit/2360019))
+* (docs) Add missing parameter to callback functions (#456) ([df7926d](https://github.com/paypal/paypal-checkout-components/commit/df7926d)), closes [#456](https://github.com/paypal/paypal-checkout-components/issues/456)
+* 4.0.124 ([1ac1737](https://github.com/paypal/paypal-checkout-components/commit/1ac1737))
+* Dist ([2360019](https://github.com/paypal/paypal-checkout-components/commit/2360019))
 
 
 
 ## <small>4.0.123 (2017-09-07)</small>
 
-* Call onRememberUser prop when user is remembered ([09b5325](http://github.paypal.com/paypal/paypal-checkout/commit/09b5325))
-* Dist ([97fcf20](http://github.paypal.com/paypal/paypal-checkout/commit/97fcf20))
+* 4.0.123 ([5dbf6c0](https://github.com/paypal/paypal-checkout-components/commit/5dbf6c0))
+* Call onRememberUser prop when user is remembered ([09b5325](https://github.com/paypal/paypal-checkout-components/commit/09b5325))
+* Dist ([97fcf20](https://github.com/paypal/paypal-checkout-components/commit/97fcf20))
 
 
 
 ## <small>4.0.122 (2017-09-06)</small>
 
-* Dist ([3a0604d](http://github.paypal.com/paypal/paypal-checkout/commit/3a0604d))
-* Improve late-render test to make sure button iframe is visible ([b254155](http://github.paypal.com/paypal/paypal-checkout/commit/b254155))
-* Log token and payment id with missing intent ([82d3b54](http://github.paypal.com/paypal/paypal-checkout/commit/82d3b54))
-* Revert "Temporarily revert flat buttons" ([c762424](http://github.paypal.com/paypal/paypal-checkout/commit/c762424))
+* 4.0.122 ([1ba36d2](https://github.com/paypal/paypal-checkout-components/commit/1ba36d2))
+* Dist ([3a0604d](https://github.com/paypal/paypal-checkout-components/commit/3a0604d))
+* Improve late-render test to make sure button iframe is visible ([b254155](https://github.com/paypal/paypal-checkout-components/commit/b254155))
+* Log token and payment id with missing intent ([82d3b54](https://github.com/paypal/paypal-checkout-components/commit/82d3b54))
+* Revert "Temporarily revert flat buttons" ([c762424](https://github.com/paypal/paypal-checkout-components/commit/c762424))
 
 
 
 ## <small>4.0.121 (2017-09-02)</small>
 
-* Dist ([6710fbb](http://github.paypal.com/paypal/paypal-checkout/commit/6710fbb))
-* Re-run componentScript when computedStyle is null ([81b3778](http://github.paypal.com/paypal/paypal-checkout/commit/81b3778))
-* Treat null computedStyle as being hidden ([07ede9c](http://github.paypal.com/paypal/paypal-checkout/commit/07ede9c))
+* 4.0.121 ([7d0aa7d](https://github.com/paypal/paypal-checkout-components/commit/7d0aa7d))
+* Dist ([6710fbb](https://github.com/paypal/paypal-checkout-components/commit/6710fbb))
+* Re-run componentScript when computedStyle is null ([81b3778](https://github.com/paypal/paypal-checkout-components/commit/81b3778))
+* Treat null computedStyle as being hidden ([07ede9c](https://github.com/paypal/paypal-checkout-components/commit/07ede9c))
 
 
 
 ## <small>4.0.120 (2017-09-02)</small>
 
-* Add warning for no intent in onAuthorize data ([a45ee01](http://github.paypal.com/paypal/paypal-checkout/commit/a45ee01))
-* Dist ([7172baa](http://github.paypal.com/paypal/paypal-checkout/commit/7172baa))
-* Make interface hacks more resilient ([3fd35ac](http://github.paypal.com/paypal/paypal-checkout/commit/3fd35ac))
-* Temporarily revert flat buttons ([898e51e](http://github.paypal.com/paypal/paypal-checkout/commit/898e51e))
-* Use eslint-plugin-import ([77dc238](http://github.paypal.com/paypal/paypal-checkout/commit/77dc238))
+* 4.0.120 ([8d1889f](https://github.com/paypal/paypal-checkout-components/commit/8d1889f))
+* Add warning for no intent in onAuthorize data ([a45ee01](https://github.com/paypal/paypal-checkout-components/commit/a45ee01))
+* Dist ([7172baa](https://github.com/paypal/paypal-checkout-components/commit/7172baa))
+* Make interface hacks more resilient ([3fd35ac](https://github.com/paypal/paypal-checkout-components/commit/3fd35ac))
+* Temporarily revert flat buttons ([898e51e](https://github.com/paypal/paypal-checkout-components/commit/898e51e))
+* Use eslint-plugin-import ([77dc238](https://github.com/paypal/paypal-checkout-components/commit/77dc238))
 
 
 
 ## <small>4.0.119 (2017-09-01)</small>
 
-* Allow line break in type declarations ([3795f9f](http://github.paypal.com/paypal/paypal-checkout/commit/3795f9f))
-* Dist ([195ba9b](http://github.paypal.com/paypal/paypal-checkout/commit/195ba9b))
-* Fix proxying ([7941d85](http://github.paypal.com/paypal/paypal-checkout/commit/7941d85))
+* 4.0.119 ([0e7a620](https://github.com/paypal/paypal-checkout-components/commit/0e7a620))
+* Allow line break in type declarations ([3795f9f](https://github.com/paypal/paypal-checkout-components/commit/3795f9f))
+* Dist ([195ba9b](https://github.com/paypal/paypal-checkout-components/commit/195ba9b))
+* Fix proxying ([7941d85](https://github.com/paypal/paypal-checkout-components/commit/7941d85))
 
 
 
 ## <small>4.0.118 (2017-08-30)</small>
 
-* Add angular2 demo ([61f1512](http://github.paypal.com/paypal/paypal-checkout/commit/61f1512))
-* Clean up angular2 demo ([b9e89af](http://github.paypal.com/paypal/paypal-checkout/commit/b9e89af))
-* Dist ([8502892](http://github.paypal.com/paypal/paypal-checkout/commit/8502892))
-* Make edge 15 ineligible until issues resolved ([0dfd91e](http://github.paypal.com/paypal/paypal-checkout/commit/0dfd91e))
-* npm run demo point to demo directory ([c03dfa6](http://github.paypal.com/paypal/paypal-checkout/commit/c03dfa6))
-* Remove arrow function from template script ([827de06](http://github.paypal.com/paypal/paypal-checkout/commit/827de06))
-* Require valid flow annotations ([08ec64b](http://github.paypal.com/paypal/paypal-checkout/commit/08ec64b))
-* Simplify storage logic ([ae360fb](http://github.paypal.com/paypal/paypal-checkout/commit/ae360fb))
+* 4.0.118 ([bba32c7](https://github.com/paypal/paypal-checkout-components/commit/bba32c7))
+* Add angular2 demo ([61f1512](https://github.com/paypal/paypal-checkout-components/commit/61f1512))
+* Clean up angular2 demo ([b9e89af](https://github.com/paypal/paypal-checkout-components/commit/b9e89af))
+* Dist ([8502892](https://github.com/paypal/paypal-checkout-components/commit/8502892))
+* Make edge 15 ineligible until issues resolved ([0dfd91e](https://github.com/paypal/paypal-checkout-components/commit/0dfd91e))
+* npm run demo point to demo directory ([c03dfa6](https://github.com/paypal/paypal-checkout-components/commit/c03dfa6))
+* Remove arrow function from template script ([827de06](https://github.com/paypal/paypal-checkout-components/commit/827de06))
+* Require valid flow annotations ([08ec64b](https://github.com/paypal/paypal-checkout-components/commit/08ec64b))
+* Simplify storage logic ([ae360fb](https://github.com/paypal/paypal-checkout-components/commit/ae360fb))
 
 
 
 ## <small>4.0.117 (2017-08-29)</small>
 
-* Add actions.payment.get to Braintree integration ([4c6a8a9](http://github.paypal.com/paypal/paypal-checkout/commit/4c6a8a9))
-* Add window types ([2d9d2fe](http://github.paypal.com/paypal/paypal-checkout/commit/2d9d2fe))
-* Allow actions.payment.create for Braintree integrations ([b184791](http://github.paypal.com/paypal/paypal-checkout/commit/b184791))
-* Dist ([9d7a4c7](http://github.paypal.com/paypal/paypal-checkout/commit/9d7a4c7))
-* Fade in button from prerender template ([bf5157c](http://github.paypal.com/paypal/paypal-checkout/commit/bf5157c))
-* Fail on circular dependencies ([db821da](http://github.paypal.com/paypal/paypal-checkout/commit/db821da))
-* Fix indentation ([6810163](http://github.paypal.com/paypal/paypal-checkout/commit/6810163))
-* Flatten buttons, support any label for dual button, fix dual hover, fix unbranded wide content ([8aae84f](http://github.paypal.com/paypal/paypal-checkout/commit/8aae84f))
-* Have travis run full build ([98274c6](http://github.paypal.com/paypal/paypal-checkout/commit/98274c6))
-* Remove circular dependency ([279fe55](http://github.paypal.com/paypal/paypal-checkout/commit/279fe55))
-* Split out payment hacks ([e5f011d](http://github.paypal.com/paypal/paypal-checkout/commit/e5f011d))
-* Strengthen eslint config ([28ca485](http://github.paypal.com/paypal/paypal-checkout/commit/28ca485))
-* Update performance.md ([c58a44f](http://github.paypal.com/paypal/paypal-checkout/commit/c58a44f))
-* Upgrade build dependencies ([826ba3c](http://github.paypal.com/paypal/paypal-checkout/commit/826ba3c))
+* 4.0.117 ([32faa47](https://github.com/paypal/paypal-checkout-components/commit/32faa47))
+* Add actions.payment.get to Braintree integration ([4c6a8a9](https://github.com/paypal/paypal-checkout-components/commit/4c6a8a9))
+* Add window types ([2d9d2fe](https://github.com/paypal/paypal-checkout-components/commit/2d9d2fe))
+* Allow actions.payment.create for Braintree integrations ([b184791](https://github.com/paypal/paypal-checkout-components/commit/b184791))
+* Dist ([9d7a4c7](https://github.com/paypal/paypal-checkout-components/commit/9d7a4c7))
+* Fade in button from prerender template ([bf5157c](https://github.com/paypal/paypal-checkout-components/commit/bf5157c))
+* Fail on circular dependencies ([db821da](https://github.com/paypal/paypal-checkout-components/commit/db821da))
+* Fix indentation ([6810163](https://github.com/paypal/paypal-checkout-components/commit/6810163))
+* Flatten buttons, support any label for dual button, fix dual hover, fix unbranded wide content ([8aae84f](https://github.com/paypal/paypal-checkout-components/commit/8aae84f))
+* Have travis run full build ([98274c6](https://github.com/paypal/paypal-checkout-components/commit/98274c6))
+* Remove circular dependency ([279fe55](https://github.com/paypal/paypal-checkout-components/commit/279fe55))
+* Split out payment hacks ([e5f011d](https://github.com/paypal/paypal-checkout-components/commit/e5f011d))
+* Strengthen eslint config ([28ca485](https://github.com/paypal/paypal-checkout-components/commit/28ca485))
+* Update performance.md ([c58a44f](https://github.com/paypal/paypal-checkout-components/commit/c58a44f))
+* Upgrade build dependencies ([826ba3c](https://github.com/paypal/paypal-checkout-components/commit/826ba3c))
 
 
 
 ## <small>4.0.116 (2017-08-22)</small>
 
-* Dist ([6f17120](http://github.paypal.com/paypal/paypal-checkout/commit/6f17120))
-* Simplify iframe eligibility ([d2f8436](http://github.paypal.com/paypal/paypal-checkout/commit/d2f8436))
+* 4.0.116 ([5cc0a47](https://github.com/paypal/paypal-checkout-components/commit/5cc0a47))
+* Dist ([6f17120](https://github.com/paypal/paypal-checkout-components/commit/6f17120))
+* Simplify iframe eligibility ([d2f8436](https://github.com/paypal/paypal-checkout-components/commit/d2f8436))
 
 
 
 ## <small>4.0.115 (2017-08-21)</small>
 
-* Dist ([b6f4fd5](http://github.paypal.com/paypal/paypal-checkout/commit/b6f4fd5))
-* Re-enable tests ([cc5ccd4](http://github.paypal.com/paypal/paypal-checkout/commit/cc5ccd4))
+* 4.0.115 ([98beb12](https://github.com/paypal/paypal-checkout-components/commit/98beb12))
+* Dist ([b6f4fd5](https://github.com/paypal/paypal-checkout-components/commit/b6f4fd5))
+* Re-enable tests ([cc5ccd4](https://github.com/paypal/paypal-checkout-components/commit/cc5ccd4))
 
 
 
 ## <small>4.0.114 (2017-08-21)</small>
 
-* Dist ([96326e2](http://github.paypal.com/paypal/paypal-checkout/commit/96326e2))
-* Group together allow-iframe logic ([29eb65b](http://github.paypal.com/paypal/paypal-checkout/commit/29eb65b))
-* Improve allow-iframe logic ([702d85a](http://github.paypal.com/paypal/paypal-checkout/commit/702d85a))
-* Improved button sizing and resizing logic ([b264864](http://github.paypal.com/paypal/paypal-checkout/commit/b264864))
-* Use npm 4 ([962181f](http://github.paypal.com/paypal/paypal-checkout/commit/962181f))
+* 4.0.114 ([2c939f3](https://github.com/paypal/paypal-checkout-components/commit/2c939f3))
+* Dist ([96326e2](https://github.com/paypal/paypal-checkout-components/commit/96326e2))
+* Group together allow-iframe logic ([29eb65b](https://github.com/paypal/paypal-checkout-components/commit/29eb65b))
+* Improve allow-iframe logic ([702d85a](https://github.com/paypal/paypal-checkout-components/commit/702d85a))
+* Improved button sizing and resizing logic ([b264864](https://github.com/paypal/paypal-checkout-components/commit/b264864))
+* Use npm 4 ([962181f](https://github.com/paypal/paypal-checkout-components/commit/962181f))
 
 
 
 ## <small>4.0.113 (2017-08-18)</small>
 
-* Allow getting session and session state ([d9915b6](http://github.paypal.com/paypal/paypal-checkout/commit/d9915b6))
-* Auto convert tiny buttons to small ([cfa5edf](http://github.paypal.com/paypal/paypal-checkout/commit/cfa5edf))
-* Dist ([4526628](http://github.paypal.com/paypal/paypal-checkout/commit/4526628))
-* Position real and sacrifical iframes in the same place ([1bdd5fd](http://github.paypal.com/paypal/paypal-checkout/commit/1bdd5fd))
+* 4.0.113 ([62c4190](https://github.com/paypal/paypal-checkout-components/commit/62c4190))
+* Allow getting session and session state ([d9915b6](https://github.com/paypal/paypal-checkout-components/commit/d9915b6))
+* Auto convert tiny buttons to small ([cfa5edf](https://github.com/paypal/paypal-checkout-components/commit/cfa5edf))
+* Dist ([4526628](https://github.com/paypal/paypal-checkout-components/commit/4526628))
+* Position real and sacrifical iframes in the same place ([1bdd5fd](https://github.com/paypal/paypal-checkout-components/commit/1bdd5fd))
 
 
 
 ## <small>4.0.112 (2017-08-17)</small>
 
-* Allow passing style.tagline=false to disable button tagline ([144e8b5](http://github.paypal.com/paypal/paypal-checkout/commit/144e8b5))
-* Clean up legacy button rendering instrumentation ([771fbbc](http://github.paypal.com/paypal/paypal-checkout/commit/771fbbc))
-* Clean up localStorage and session code ([d2f832b](http://github.paypal.com/paypal/paypal-checkout/commit/d2f832b))
-* Create cdn-npm.md ([433bf1d](http://github.paypal.com/paypal/paypal-checkout/commit/433bf1d))
-* Dist ([c689279](http://github.paypal.com/paypal/paypal-checkout/commit/c689279))
-* Load logging cleanup ([32efbcb](http://github.paypal.com/paypal/paypal-checkout/commit/32efbcb))
-* Move doc images to img directory ([e055fe1](http://github.paypal.com/paypal/paypal-checkout/commit/e055fe1))
-* Remove legacy mobile throttle ([fc4532b](http://github.paypal.com/paypal/paypal-checkout/commit/fc4532b))
-* Remove outliers from resource load time check ([363dc5f](http://github.paypal.com/paypal/paypal-checkout/commit/363dc5f))
-* Store remembered state in parent page so future renders are faster ([afdbd6e](http://github.paypal.com/paypal/paypal-checkout/commit/afdbd6e))
-* Try/catch correlation id header check to avoid CORS error ([a447034](http://github.paypal.com/paypal/paypal-checkout/commit/a447034))
-* Update cdn-npm.md ([c8ceac2](http://github.paypal.com/paypal/paypal-checkout/commit/c8ceac2))
-* Update cdn-npm.md ([75e0a78](http://github.paypal.com/paypal/paypal-checkout/commit/75e0a78))
+* 4.0.112 ([471e66b](https://github.com/paypal/paypal-checkout-components/commit/471e66b))
+* Allow passing style.tagline=false to disable button tagline ([144e8b5](https://github.com/paypal/paypal-checkout-components/commit/144e8b5))
+* Clean up legacy button rendering instrumentation ([771fbbc](https://github.com/paypal/paypal-checkout-components/commit/771fbbc))
+* Clean up localStorage and session code ([d2f832b](https://github.com/paypal/paypal-checkout-components/commit/d2f832b))
+* Create cdn-npm.md ([433bf1d](https://github.com/paypal/paypal-checkout-components/commit/433bf1d))
+* Dist ([c689279](https://github.com/paypal/paypal-checkout-components/commit/c689279))
+* Load logging cleanup ([32efbcb](https://github.com/paypal/paypal-checkout-components/commit/32efbcb))
+* Move doc images to img directory ([e055fe1](https://github.com/paypal/paypal-checkout-components/commit/e055fe1))
+* Remove legacy mobile throttle ([fc4532b](https://github.com/paypal/paypal-checkout-components/commit/fc4532b))
+* Remove outliers from resource load time check ([363dc5f](https://github.com/paypal/paypal-checkout-components/commit/363dc5f))
+* Store remembered state in parent page so future renders are faster ([afdbd6e](https://github.com/paypal/paypal-checkout-components/commit/afdbd6e))
+* Try/catch correlation id header check to avoid CORS error ([a447034](https://github.com/paypal/paypal-checkout-components/commit/a447034))
+* Update cdn-npm.md ([c8ceac2](https://github.com/paypal/paypal-checkout-components/commit/c8ceac2))
+* Update cdn-npm.md ([75e0a78](https://github.com/paypal/paypal-checkout-components/commit/75e0a78))
 
 
 
 ## <small>4.0.111 (2017-08-15)</small>
 
-* Check xprops in forceIframe ([bb0f694](http://github.paypal.com/paypal/paypal-checkout/commit/bb0f694))
-* Dist ([752efbd](http://github.paypal.com/paypal/paypal-checkout/commit/752efbd))
-* Set minimum width of button to 100px ([bc10f86](http://github.paypal.com/paypal/paypal-checkout/commit/bc10f86))
+* 4.0.111 ([0c63c90](https://github.com/paypal/paypal-checkout-components/commit/0c63c90))
+* Check xprops in forceIframe ([bb0f694](https://github.com/paypal/paypal-checkout-components/commit/bb0f694))
+* Dist ([752efbd](https://github.com/paypal/paypal-checkout-components/commit/752efbd))
+* Set minimum width of button to 100px ([bc10f86](https://github.com/paypal/paypal-checkout-components/commit/bc10f86))
 
 
 
 ## <small>4.0.110 (2017-08-11)</small>
 
-* Allow enabling iframe any time prefetchLogin is enabled ([d47f4ea](http://github.paypal.com/paypal/paypal-checkout/commit/d47f4ea))
-* Allow paypal domains to enable checkout iframe with a public method ([f1d5bd1](http://github.paypal.com/paypal/paypal-checkout/commit/f1d5bd1))
-* Blank env prop for login prerender ([53ef96e](http://github.paypal.com/paypal/paypal-checkout/commit/53ef96e))
-* Break out button hacks and tech debt to single place ([6aed79d](http://github.paypal.com/paypal/paypal-checkout/commit/6aed79d))
-* Dist ([cba21bd](http://github.paypal.com/paypal/paypal-checkout/commit/cba21bd))
-* Fix pre-template button click log ([a987da6](http://github.paypal.com/paypal/paypal-checkout/commit/a987da6))
-* Log current script version ([fca12ea](http://github.paypal.com/paypal/paypal-checkout/commit/fca12ea))
-* Update frameworks.md ([a1f5d52](http://github.paypal.com/paypal/paypal-checkout/commit/a1f5d52))
+* 4.0.110 ([f5259b1](https://github.com/paypal/paypal-checkout-components/commit/f5259b1))
+* Allow enabling iframe any time prefetchLogin is enabled ([d47f4ea](https://github.com/paypal/paypal-checkout-components/commit/d47f4ea))
+* Allow paypal domains to enable checkout iframe with a public method ([f1d5bd1](https://github.com/paypal/paypal-checkout-components/commit/f1d5bd1))
+* Blank env prop for login prerender ([53ef96e](https://github.com/paypal/paypal-checkout-components/commit/53ef96e))
+* Break out button hacks and tech debt to single place ([6aed79d](https://github.com/paypal/paypal-checkout-components/commit/6aed79d))
+* Dist ([cba21bd](https://github.com/paypal/paypal-checkout-components/commit/cba21bd))
+* Fix pre-template button click log ([a987da6](https://github.com/paypal/paypal-checkout-components/commit/a987da6))
+* Log current script version ([fca12ea](https://github.com/paypal/paypal-checkout-components/commit/fca12ea))
+* Update frameworks.md ([a1f5d52](https://github.com/paypal/paypal-checkout-components/commit/a1f5d52))
 
 
 
 ## <small>4.0.109 (2017-08-11)</small>
 
-* Add init log for checkout component ([83b7f4c](http://github.paypal.com/paypal/paypal-checkout/commit/83b7f4c))
-* Add process_recieve_payment log the moment the button recieves the token or payment id ([ef2880d](http://github.paypal.com/paypal/paypal-checkout/commit/ef2880d))
-* Add specific log for no token passed ([913fcb0](http://github.paypal.com/paypal/paypal-checkout/commit/913fcb0))
-* Allow falling back to full page on popup failure ([cb3c4e8](http://github.paypal.com/paypal/paypal-checkout/commit/cb3c4e8))
-* Allow forcing iframe after login render ([5f7782b](http://github.paypal.com/paypal/paypal-checkout/commit/5f7782b))
-* Default locale for button component ([c339866](http://github.paypal.com/paypal/paypal-checkout/commit/c339866))
-* Dist ([444f6ee](http://github.paypal.com/paypal/paypal-checkout/commit/444f6ee))
-* Do not hide the button when the viewport is too small ([15c4419](http://github.paypal.com/paypal/paypal-checkout/commit/15c4419))
-* Do not try to access window.performance if it is not available ([01f390c](http://github.paypal.com/paypal/paypal-checkout/commit/01f390c))
-* Domain setting updates ([8ce0a78](http://github.paypal.com/paypal/paypal-checkout/commit/8ce0a78))
-* Fixes for experiment beacons ([1608691](http://github.paypal.com/paypal/paypal-checkout/commit/1608691))
-* Log currentScript download time ([313f3ca](http://github.paypal.com/paypal/paypal-checkout/commit/313f3ca))
-* Pick up jsx files for lint task ([01bdbb9](http://github.paypal.com/paypal/paypal-checkout/commit/01bdbb9))
-* Take whatever size is available for checkout on mobile devices, remove min width ([a4fa9bc](http://github.paypal.com/paypal/paypal-checkout/commit/a4fa9bc))
-* Update frameworks.md ([077575c](http://github.paypal.com/paypal/paypal-checkout/commit/077575c))
-* Use jsx-dom for all templates and upgrade xcomponent ([d0b7ae2](http://github.paypal.com/paypal/paypal-checkout/commit/d0b7ae2))
-* Use only ES5 in dev demo ([2f7da0d](http://github.paypal.com/paypal/paypal-checkout/commit/2f7da0d))
+* 4.0.109 ([846c21b](https://github.com/paypal/paypal-checkout-components/commit/846c21b))
+* Add init log for checkout component ([83b7f4c](https://github.com/paypal/paypal-checkout-components/commit/83b7f4c))
+* Add process_recieve_payment log the moment the button recieves the token or payment id ([ef2880d](https://github.com/paypal/paypal-checkout-components/commit/ef2880d))
+* Add specific log for no token passed ([913fcb0](https://github.com/paypal/paypal-checkout-components/commit/913fcb0))
+* Allow falling back to full page on popup failure ([cb3c4e8](https://github.com/paypal/paypal-checkout-components/commit/cb3c4e8))
+* Allow forcing iframe after login render ([5f7782b](https://github.com/paypal/paypal-checkout-components/commit/5f7782b))
+* Default locale for button component ([c339866](https://github.com/paypal/paypal-checkout-components/commit/c339866))
+* Dist ([444f6ee](https://github.com/paypal/paypal-checkout-components/commit/444f6ee))
+* Do not hide the button when the viewport is too small ([15c4419](https://github.com/paypal/paypal-checkout-components/commit/15c4419))
+* Do not try to access window.performance if it is not available ([01f390c](https://github.com/paypal/paypal-checkout-components/commit/01f390c))
+* Domain setting updates ([8ce0a78](https://github.com/paypal/paypal-checkout-components/commit/8ce0a78))
+* Fixes for experiment beacons ([1608691](https://github.com/paypal/paypal-checkout-components/commit/1608691))
+* Log currentScript download time ([313f3ca](https://github.com/paypal/paypal-checkout-components/commit/313f3ca))
+* Pick up jsx files for lint task ([01bdbb9](https://github.com/paypal/paypal-checkout-components/commit/01bdbb9))
+* Take whatever size is available for checkout on mobile devices, remove min width ([a4fa9bc](https://github.com/paypal/paypal-checkout-components/commit/a4fa9bc))
+* Update frameworks.md ([077575c](https://github.com/paypal/paypal-checkout-components/commit/077575c))
+* Use jsx-dom for all templates and upgrade xcomponent ([d0b7ae2](https://github.com/paypal/paypal-checkout-components/commit/d0b7ae2))
+* Use only ES5 in dev demo ([2f7da0d](https://github.com/paypal/paypal-checkout-components/commit/2f7da0d))
 
 
 
 ## <small>4.0.108 (2017-08-09)</small>
 
-* Add dev demo for in-iframe usecase ([5700e40](http://github.paypal.com/paypal/paypal-checkout/commit/5700e40))
-* Add dev demo for legacy form hijack case ([a0535a3](http://github.paypal.com/paypal/paypal-checkout/commit/a0535a3))
-* Add dev demo for legacy integration ([f74f6fc](http://github.paypal.com/paypal/paypal-checkout/commit/f74f6fc))
-* Add more supported browsers ([176e8a4](http://github.paypal.com/paypal/paypal-checkout/commit/176e8a4))
-* Dist ([3b430f2](http://github.paypal.com/paypal/paypal-checkout/commit/3b430f2))
-* Improve button dev demo ([cca5eb6](http://github.paypal.com/paypal/paypal-checkout/commit/cca5eb6))
-* Only check version if bowser returns it ([2b0e020](http://github.paypal.com/paypal/paypal-checkout/commit/2b0e020))
+* 4.0.108 ([753f32a](https://github.com/paypal/paypal-checkout-components/commit/753f32a))
+* Add dev demo for in-iframe usecase ([5700e40](https://github.com/paypal/paypal-checkout-components/commit/5700e40))
+* Add dev demo for legacy form hijack case ([a0535a3](https://github.com/paypal/paypal-checkout-components/commit/a0535a3))
+* Add dev demo for legacy integration ([f74f6fc](https://github.com/paypal/paypal-checkout-components/commit/f74f6fc))
+* Add more supported browsers ([176e8a4](https://github.com/paypal/paypal-checkout-components/commit/176e8a4))
+* Dist ([3b430f2](https://github.com/paypal/paypal-checkout-components/commit/3b430f2))
+* Improve button dev demo ([cca5eb6](https://github.com/paypal/paypal-checkout-components/commit/cca5eb6))
+* Only check version if bowser returns it ([2b0e020](https://github.com/paypal/paypal-checkout-components/commit/2b0e020))
 
 
 
 ## <small>4.0.107 (2017-08-09)</small>
 
-* Dist ([d165837](http://github.paypal.com/paypal/paypal-checkout/commit/d165837))
-* Use bowser.compareVersions rather than simple lessthan check ([b1ed904](http://github.paypal.com/paypal/paypal-checkout/commit/b1ed904))
+* 4.0.107 ([284b64d](https://github.com/paypal/paypal-checkout-components/commit/284b64d))
+* Dist ([d165837](https://github.com/paypal/paypal-checkout-components/commit/d165837))
+* Use bowser.compareVersions rather than simple lessthan check ([b1ed904](https://github.com/paypal/paypal-checkout-components/commit/b1ed904))
 
 
 
 ## <small>4.0.106 (2017-08-09)</small>
 
-* Add more supported browsers to config ([0b5528b](http://github.paypal.com/paypal/paypal-checkout/commit/0b5528b))
-* Dist ([ac1dd6a](http://github.paypal.com/paypal/paypal-checkout/commit/ac1dd6a))
-* Do not resolve promise for restart cases ([b7cfb1b](http://github.paypal.com/paypal/paypal-checkout/commit/b7cfb1b))
+* 4.0.106 ([92315d5](https://github.com/paypal/paypal-checkout-components/commit/92315d5))
+* Add more supported browsers to config ([0b5528b](https://github.com/paypal/paypal-checkout-components/commit/0b5528b))
+* Dist ([ac1dd6a](https://github.com/paypal/paypal-checkout-components/commit/ac1dd6a))
+* Do not resolve promise for restart cases ([b7cfb1b](https://github.com/paypal/paypal-checkout-components/commit/b7cfb1b))
 
 
 
 ## <small>4.0.105 (2017-08-09)</small>
 
-* Disable checkout iframe in authorize and cancel ([6fabfd9](http://github.paypal.com/paypal/paypal-checkout/commit/6fabfd9))
-* Dist ([8c5a8e0](http://github.paypal.com/paypal/paypal-checkout/commit/8c5a8e0))
-* Move recognized browser check to onAuthorize ([dec382b](http://github.paypal.com/paypal/paypal-checkout/commit/dec382b))
+* 4.0.105 ([cc5d75b](https://github.com/paypal/paypal-checkout-components/commit/cc5d75b))
+* Disable checkout iframe in authorize and cancel ([6fabfd9](https://github.com/paypal/paypal-checkout-components/commit/6fabfd9))
+* Dist ([8c5a8e0](https://github.com/paypal/paypal-checkout-components/commit/8c5a8e0))
+* Move recognized browser check to onAuthorize ([dec382b](https://github.com/paypal/paypal-checkout-components/commit/dec382b))
 
 
 
 ## <small>4.0.104 (2017-08-08)</small>
 
-* Add correlation id to all http error responses ([13f971a](http://github.paypal.com/paypal/paypal-checkout/commit/13f971a))
-* Add logging on return ([bb244e5](http://github.paypal.com/paypal/paypal-checkout/commit/bb244e5))
-* Add setup tests and refactor pptm tests ([95b4b19](http://github.paypal.com/paypal/paypal-checkout/commit/95b4b19))
-* Always call setup at least one, allow multiple configures ([a62d83b](http://github.paypal.com/paypal/paypal-checkout/commit/a62d83b))
-* Dist ([d6deaa8](http://github.paypal.com/paypal/paypal-checkout/commit/d6deaa8))
-* Do not go into headless mode when keep-open passed ([f922035](http://github.paypal.com/paypal/paypal-checkout/commit/f922035))
-* Do not send entire error stack to fpti ([bbe9bc9](http://github.paypal.com/paypal/paypal-checkout/commit/bbe9bc9))
-* Enable headless mode ([4406805](http://github.paypal.com/paypal/paypal-checkout/commit/4406805))
-* Fix button debouncer on close event ([c61d718](http://github.paypal.com/paypal/paypal-checkout/commit/c61d718))
-* Update flow ([7cc2925](http://github.paypal.com/paypal/paypal-checkout/commit/7cc2925))
-* Update performance.md ([83c512d](http://github.paypal.com/paypal/paypal-checkout/commit/83c512d))
-* Update performance.md ([de71661](http://github.paypal.com/paypal/paypal-checkout/commit/de71661))
-* Use bowser for browser detection ([f72ab37](http://github.paypal.com/paypal/paypal-checkout/commit/f72ab37))
-* Use latest ZalgoPromise type rules ([516fa67](http://github.paypal.com/paypal/paypal-checkout/commit/516fa67))
+* 4.0.104 ([ab2fbac](https://github.com/paypal/paypal-checkout-components/commit/ab2fbac))
+* Add correlation id to all http error responses ([13f971a](https://github.com/paypal/paypal-checkout-components/commit/13f971a))
+* Add logging on return ([bb244e5](https://github.com/paypal/paypal-checkout-components/commit/bb244e5))
+* Add setup tests and refactor pptm tests ([95b4b19](https://github.com/paypal/paypal-checkout-components/commit/95b4b19))
+* Always call setup at least one, allow multiple configures ([a62d83b](https://github.com/paypal/paypal-checkout-components/commit/a62d83b))
+* Dist ([d6deaa8](https://github.com/paypal/paypal-checkout-components/commit/d6deaa8))
+* Do not go into headless mode when keep-open passed ([f922035](https://github.com/paypal/paypal-checkout-components/commit/f922035))
+* Do not send entire error stack to fpti ([bbe9bc9](https://github.com/paypal/paypal-checkout-components/commit/bbe9bc9))
+* Enable headless mode ([4406805](https://github.com/paypal/paypal-checkout-components/commit/4406805))
+* Fix button debouncer on close event ([c61d718](https://github.com/paypal/paypal-checkout-components/commit/c61d718))
+* Update flow ([7cc2925](https://github.com/paypal/paypal-checkout-components/commit/7cc2925))
+* Update performance.md ([83c512d](https://github.com/paypal/paypal-checkout-components/commit/83c512d))
+* Update performance.md ([de71661](https://github.com/paypal/paypal-checkout-components/commit/de71661))
+* Use bowser for browser detection ([f72ab37](https://github.com/paypal/paypal-checkout-components/commit/f72ab37))
+* Use latest ZalgoPromise type rules ([516fa67](https://github.com/paypal/paypal-checkout-components/commit/516fa67))
 
 
 
 ## <small>4.0.103 (2017-08-03)</small>
 
-* Dist ([dc11823](http://github.paypal.com/paypal/paypal-checkout/commit/dc11823))
-* Do not open bridge on paypal domain ([f04fa21](http://github.paypal.com/paypal/paypal-checkout/commit/f04fa21))
+* 4.0.103 ([f3ebe58](https://github.com/paypal/paypal-checkout-components/commit/f3ebe58))
+* Dist ([dc11823](https://github.com/paypal/paypal-checkout-components/commit/dc11823))
+* Do not open bridge on paypal domain ([f04fa21](https://github.com/paypal/paypal-checkout-components/commit/f04fa21))
 
 
 
 ## <small>4.0.102 (2017-08-03)</small>
 
-* Dist ([1f54e88](http://github.paypal.com/paypal/paypal-checkout/commit/1f54e88))
-* Fix force bridge loader ([6c96560](http://github.paypal.com/paypal/paypal-checkout/commit/6c96560))
+* 4.0.102 ([ca1240a](https://github.com/paypal/paypal-checkout-components/commit/ca1240a))
+* Dist ([1f54e88](https://github.com/paypal/paypal-checkout-components/commit/1f54e88))
+* Fix force bridge loader ([6c96560](https://github.com/paypal/paypal-checkout-components/commit/6c96560))
 
 
 
 ## <small>4.0.101 (2017-08-03)</small>
 
-* Dist ([fc89a85](http://github.paypal.com/paypal/paypal-checkout/commit/fc89a85))
-* Update ISSUE_TEMPLATE.md ([1a79aa5](http://github.paypal.com/paypal/paypal-checkout/commit/1a79aa5))
-* Update ISSUE_TEMPLATE.md ([294725d](http://github.paypal.com/paypal/paypal-checkout/commit/294725d))
+* 4.0.101 ([3266df2](https://github.com/paypal/paypal-checkout-components/commit/3266df2))
+* Dist ([fc89a85](https://github.com/paypal/paypal-checkout-components/commit/fc89a85))
+* Update ISSUE_TEMPLATE.md ([1a79aa5](https://github.com/paypal/paypal-checkout-components/commit/1a79aa5))
+* Update ISSUE_TEMPLATE.md ([294725d](https://github.com/paypal/paypal-checkout-components/commit/294725d))
 
 
 
 ## <small>4.0.100 (2017-08-03)</small>
 
-* Add tests for cancel on close window ([7c4daf9](http://github.paypal.com/paypal/paypal-checkout/commit/7c4daf9))
-* Allow forcing bridge on per-domain basis ([8de8b83](http://github.paypal.com/paypal/paypal-checkout/commit/8de8b83))
-* Dist ([cc306b3](http://github.paypal.com/paypal/paypal-checkout/commit/cc306b3))
-* Do not override onClose ([d68cc0e](http://github.paypal.com/paypal/paypal-checkout/commit/d68cc0e))
-* Fix log proxying for different envs ([da03504](http://github.paypal.com/paypal/paypal-checkout/commit/da03504))
+* 4.0.100 ([b3b0dc3](https://github.com/paypal/paypal-checkout-components/commit/b3b0dc3))
+* Add tests for cancel on close window ([7c4daf9](https://github.com/paypal/paypal-checkout-components/commit/7c4daf9))
+* Allow forcing bridge on per-domain basis ([8de8b83](https://github.com/paypal/paypal-checkout-components/commit/8de8b83))
+* Dist ([cc306b3](https://github.com/paypal/paypal-checkout-components/commit/cc306b3))
+* Do not override onClose ([d68cc0e](https://github.com/paypal/paypal-checkout-components/commit/d68cc0e))
+* Fix log proxying for different envs ([da03504](https://github.com/paypal/paypal-checkout-components/commit/da03504))
 
 
 
 ## <small>4.0.99 (2017-08-02)</small>
 
-* Add commented auto-devtools chrome option ([d2d71c6](http://github.paypal.com/paypal/paypal-checkout/commit/d2d71c6))
-* Adjust per-domain settings ([6d672ff](http://github.paypal.com/paypal/paypal-checkout/commit/6d672ff))
-* Create performance.md ([2b81ecb](http://github.paypal.com/paypal/paypal-checkout/commit/2b81ecb))
-* Dist ([da4e576](http://github.paypal.com/paypal/paypal-checkout/commit/da4e576))
-* Do not proxy logs to popup opener by default ([bca44aa](http://github.paypal.com/paypal/paypal-checkout/commit/bca44aa))
-* Fix script detection logic ([4c5a449](http://github.paypal.com/paypal/paypal-checkout/commit/4c5a449))
-* Update performance.md ([80d86ad](http://github.paypal.com/paypal/paypal-checkout/commit/80d86ad))
+* 4.0.99 ([5164bdf](https://github.com/paypal/paypal-checkout-components/commit/5164bdf))
+* Add commented auto-devtools chrome option ([d2d71c6](https://github.com/paypal/paypal-checkout-components/commit/d2d71c6))
+* Adjust per-domain settings ([6d672ff](https://github.com/paypal/paypal-checkout-components/commit/6d672ff))
+* Create performance.md ([2b81ecb](https://github.com/paypal/paypal-checkout-components/commit/2b81ecb))
+* Dist ([da4e576](https://github.com/paypal/paypal-checkout-components/commit/da4e576))
+* Do not proxy logs to popup opener by default ([bca44aa](https://github.com/paypal/paypal-checkout-components/commit/bca44aa))
+* Fix script detection logic ([4c5a449](https://github.com/paypal/paypal-checkout-components/commit/4c5a449))
+* Update performance.md ([80d86ad](https://github.com/paypal/paypal-checkout-components/commit/80d86ad))
 
 
 
 ## <small>4.0.98 (2017-07-31)</small>
 
-* Dist ([93c6e38](http://github.paypal.com/paypal/paypal-checkout/commit/93c6e38))
-* Make sure iframe can not be disabled in force-iframe mode ([9b86ccb](http://github.paypal.com/paypal/paypal-checkout/commit/9b86ccb))
+* 4.0.98 ([ea9438e](https://github.com/paypal/paypal-checkout-components/commit/ea9438e))
+* Dist ([93c6e38](https://github.com/paypal/paypal-checkout-components/commit/93c6e38))
+* Make sure iframe can not be disabled in force-iframe mode ([9b86ccb](https://github.com/paypal/paypal-checkout-components/commit/9b86ccb))
 
 
 
 ## <small>4.0.97 (2017-07-28)</small>
 
-* Add legacy dev demo ([009bbbc](http://github.paypal.com/paypal/paypal-checkout/commit/009bbbc))
-* Add option to go to full page for IE ([f4f16d7](http://github.paypal.com/paypal/paypal-checkout/commit/f4f16d7))
-* Add option to go to full page when clicking on prerendered button ([4d92744](http://github.paypal.com/paypal/paypal-checkout/commit/4d92744))
-* Add option to memoize result of button payment call ([7ffc8a9](http://github.paypal.com/paypal/paypal-checkout/commit/7ffc8a9))
-* Catch errors on full page redirects ([cd57e49](http://github.paypal.com/paypal/paypal-checkout/commit/cd57e49))
-* Dist ([b137faa](http://github.paypal.com/paypal/paypal-checkout/commit/b137faa))
-* Do not enable lightbox by default for logged in users ([c207c57](http://github.paypal.com/paypal/paypal-checkout/commit/c207c57))
-* Enable per-domain settings ([cd33efc](http://github.paypal.com/paypal/paypal-checkout/commit/cd33efc))
-* Extend isIE check ([f84fcb3](http://github.paypal.com/paypal/paypal-checkout/commit/f84fcb3))
-* Fix button demo url ([410c12c](http://github.paypal.com/paypal/paypal-checkout/commit/410c12c))
-* Fix intranet check to only apply to older IE versions ([fc59188](http://github.paypal.com/paypal/paypal-checkout/commit/fc59188))
-* Fix merchant settings hashes ([b93a596](http://github.paypal.com/paypal/paypal-checkout/commit/b93a596))
-* Get domain setting from parent domain if available ([8f45af8](http://github.paypal.com/paypal/paypal-checkout/commit/8f45af8))
-* Log ineligible before throwing intranet error ([9a295de](http://github.paypal.com/paypal/paypal-checkout/commit/9a295de))
-* Remove lightbox throttle for legacy ([51b8059](http://github.paypal.com/paypal/paypal-checkout/commit/51b8059))
-* Send proxy regardless of current domain ([5ccb8e0](http://github.paypal.com/paypal/paypal-checkout/commit/5ccb8e0))
+* 4.0.97 ([f9a734e](https://github.com/paypal/paypal-checkout-components/commit/f9a734e))
+* Add legacy dev demo ([009bbbc](https://github.com/paypal/paypal-checkout-components/commit/009bbbc))
+* Add option to go to full page for IE ([f4f16d7](https://github.com/paypal/paypal-checkout-components/commit/f4f16d7))
+* Add option to go to full page when clicking on prerendered button ([4d92744](https://github.com/paypal/paypal-checkout-components/commit/4d92744))
+* Add option to memoize result of button payment call ([7ffc8a9](https://github.com/paypal/paypal-checkout-components/commit/7ffc8a9))
+* Catch errors on full page redirects ([cd57e49](https://github.com/paypal/paypal-checkout-components/commit/cd57e49))
+* Dist ([b137faa](https://github.com/paypal/paypal-checkout-components/commit/b137faa))
+* Do not enable lightbox by default for logged in users ([c207c57](https://github.com/paypal/paypal-checkout-components/commit/c207c57))
+* Enable per-domain settings ([cd33efc](https://github.com/paypal/paypal-checkout-components/commit/cd33efc))
+* Extend isIE check ([f84fcb3](https://github.com/paypal/paypal-checkout-components/commit/f84fcb3))
+* Fix button demo url ([410c12c](https://github.com/paypal/paypal-checkout-components/commit/410c12c))
+* Fix intranet check to only apply to older IE versions ([fc59188](https://github.com/paypal/paypal-checkout-components/commit/fc59188))
+* Fix merchant settings hashes ([b93a596](https://github.com/paypal/paypal-checkout-components/commit/b93a596))
+* Get domain setting from parent domain if available ([8f45af8](https://github.com/paypal/paypal-checkout-components/commit/8f45af8))
+* Log ineligible before throwing intranet error ([9a295de](https://github.com/paypal/paypal-checkout-components/commit/9a295de))
+* Remove lightbox throttle for legacy ([51b8059](https://github.com/paypal/paypal-checkout-components/commit/51b8059))
+* Send proxy regardless of current domain ([5ccb8e0](https://github.com/paypal/paypal-checkout-components/commit/5ccb8e0))
 
 
 
 ## <small>4.0.96 (2017-07-25)</small>
 
-* Add commented headless chrome options ([8c2857c](http://github.paypal.com/paypal/paypal-checkout/commit/8c2857c))
-* Dist ([cad2865](http://github.paypal.com/paypal/paypal-checkout/commit/cad2865))
-* Enable lightbox/popup experiment ([b0a67d4](http://github.paypal.com/paypal/paypal-checkout/commit/b0a67d4))
-* Load pptm script from stage for local env ([fc91f85](http://github.paypal.com/paypal/paypal-checkout/commit/fc91f85))
-* Proxy logger flushes into frames ([379fba7](http://github.paypal.com/paypal/paypal-checkout/commit/379fba7))
-* Reset button debouncer on error ([47ca7eb](http://github.paypal.com/paypal/paypal-checkout/commit/47ca7eb))
-* Use vh and vm for overlay width and height, to fix WKWebView ([1f7d34f](http://github.paypal.com/paypal/paypal-checkout/commit/1f7d34f))
+* 4.0.96 ([581dd55](https://github.com/paypal/paypal-checkout-components/commit/581dd55))
+* Add commented headless chrome options ([8c2857c](https://github.com/paypal/paypal-checkout-components/commit/8c2857c))
+* Dist ([cad2865](https://github.com/paypal/paypal-checkout-components/commit/cad2865))
+* Enable lightbox/popup experiment ([b0a67d4](https://github.com/paypal/paypal-checkout-components/commit/b0a67d4))
+* Load pptm script from stage for local env ([fc91f85](https://github.com/paypal/paypal-checkout-components/commit/fc91f85))
+* Proxy logger flushes into frames ([379fba7](https://github.com/paypal/paypal-checkout-components/commit/379fba7))
+* Reset button debouncer on error ([47ca7eb](https://github.com/paypal/paypal-checkout-components/commit/47ca7eb))
+* Use vh and vm for overlay width and height, to fix WKWebView ([1f7d34f](https://github.com/paypal/paypal-checkout-components/commit/1f7d34f))
 
 
 
 ## <small>4.0.95 (2017-07-20)</small>
 
-* Add log for domain specific custom paypal button ([295e3f9](http://github.paypal.com/paypal/paypal-checkout/commit/295e3f9))
-* Add more instrumentation around repeat button click behavior ([a898286](http://github.paypal.com/paypal/paypal-checkout/commit/a898286))
-* Dist ([fb21712](http://github.paypal.com/paypal/paypal-checkout/commit/fb21712))
-* Do not allow button clicks while the Checkout component is open ([ba43841](http://github.paypal.com/paypal/paypal-checkout/commit/ba43841))
-* Expose paypal.logExperimentTreatment for external experiments ([de4c5ea](http://github.paypal.com/paypal/paypal-checkout/commit/de4c5ea))
+* 4.0.95 ([bb147d6](https://github.com/paypal/paypal-checkout-components/commit/bb147d6))
+* Add log for domain specific custom paypal button ([295e3f9](https://github.com/paypal/paypal-checkout-components/commit/295e3f9))
+* Add more instrumentation around repeat button click behavior ([a898286](https://github.com/paypal/paypal-checkout-components/commit/a898286))
+* Dist ([fb21712](https://github.com/paypal/paypal-checkout-components/commit/fb21712))
+* Do not allow button clicks while the Checkout component is open ([ba43841](https://github.com/paypal/paypal-checkout-components/commit/ba43841))
+* Expose paypal.logExperimentTreatment for external experiments ([de4c5ea](https://github.com/paypal/paypal-checkout-components/commit/de4c5ea))
 
 
 
 ## <small>4.0.94 (2017-07-20)</small>
 
-* Dist ([d163da6](http://github.paypal.com/paypal/paypal-checkout/commit/d163da6))
-* Do not cancel setup for ineligible browsers ([db4b994](http://github.paypal.com/paypal/paypal-checkout/commit/db4b994))
-* Fix z-index ([f1a438c](http://github.paypal.com/paypal/paypal-checkout/commit/f1a438c))
-* Log pptm load error ([d2a32ca](http://github.paypal.com/paypal/paypal-checkout/commit/d2a32ca))
+* 4.0.94 ([a24b1e1](https://github.com/paypal/paypal-checkout-components/commit/a24b1e1))
+* Dist ([d163da6](https://github.com/paypal/paypal-checkout-components/commit/d163da6))
+* Do not cancel setup for ineligible browsers ([db4b994](https://github.com/paypal/paypal-checkout-components/commit/db4b994))
+* Fix z-index ([f1a438c](https://github.com/paypal/paypal-checkout-components/commit/f1a438c))
+* Log pptm load error ([d2a32ca](https://github.com/paypal/paypal-checkout-components/commit/d2a32ca))
 
 
 
 ## <small>4.0.93 (2017-07-20)</small>
 
-* Add log for onAuthorize in ineligible browser ([78a0b11](http://github.paypal.com/paypal/paypal-checkout/commit/78a0b11))
-* Dist ([8da7785](http://github.paypal.com/paypal/paypal-checkout/commit/8da7785))
-* Log warning for ineligible button render ([2263d07](http://github.paypal.com/paypal/paypal-checkout/commit/2263d07))
+* 4.0.93 ([8368630](https://github.com/paypal/paypal-checkout-components/commit/8368630))
+* Add log for onAuthorize in ineligible browser ([78a0b11](https://github.com/paypal/paypal-checkout-components/commit/78a0b11))
+* Dist ([8da7785](https://github.com/paypal/paypal-checkout-components/commit/8da7785))
+* Log warning for ineligible button render ([2263d07](https://github.com/paypal/paypal-checkout-components/commit/2263d07))
 
 
 
 ## <small>4.0.92 (2017-07-20)</small>
 
-* Add domain specific setting for logger prefix ([23aeed1](http://github.paypal.com/paypal/paypal-checkout/commit/23aeed1))
-* Add domain specific setting util ([2dccb0c](http://github.paypal.com/paypal/paypal-checkout/commit/2dccb0c))
-* Add log for button clicked after cancel ([70abccd](http://github.paypal.com/paypal/paypal-checkout/commit/70abccd))
-* Add log for multiple clicks ([72d9504](http://github.paypal.com/paypal/paypal-checkout/commit/72d9504))
-* Add logs for button cancel ([4258f33](http://github.paypal.com/paypal/paypal-checkout/commit/4258f33))
-* Add some intranet docs ([49c782d](http://github.paypal.com/paypal/paypal-checkout/commit/49c782d))
-* CAL log for button click ([e2d7677](http://github.paypal.com/paypal/paypal-checkout/commit/e2d7677))
-* CAL warning for ineligible ([141a6df](http://github.paypal.com/paypal/paypal-checkout/commit/141a6df))
-* Dist ([08d3810](http://github.paypal.com/paypal/paypal-checkout/commit/08d3810))
-* Do not render button in ineligible browser ([b83773d](http://github.paypal.com/paypal/paypal-checkout/commit/b83773d))
-* Fix doc images ([0f56317](http://github.paypal.com/paypal/paypal-checkout/commit/0f56317))
-* FPTI log for authorize ([bbc2be4](http://github.paypal.com/paypal/paypal-checkout/commit/bbc2be4))
-* Log if button clicked before fully loaded ([11350b0](http://github.paypal.com/paypal/paypal-checkout/commit/11350b0))
-* Update frameworks.md ([e620629](http://github.paypal.com/paypal/paypal-checkout/commit/e620629))
-* Update frameworks.md ([733b52b](http://github.paypal.com/paypal/paypal-checkout/commit/733b52b))
-* Use latest example for React doc ([6dd3618](http://github.paypal.com/paypal/paypal-checkout/commit/6dd3618))
+* 4.0.92 ([4b9ed77](https://github.com/paypal/paypal-checkout-components/commit/4b9ed77))
+* Add domain specific setting for logger prefix ([23aeed1](https://github.com/paypal/paypal-checkout-components/commit/23aeed1))
+* Add domain specific setting util ([2dccb0c](https://github.com/paypal/paypal-checkout-components/commit/2dccb0c))
+* Add log for button clicked after cancel ([70abccd](https://github.com/paypal/paypal-checkout-components/commit/70abccd))
+* Add log for multiple clicks ([72d9504](https://github.com/paypal/paypal-checkout-components/commit/72d9504))
+* Add logs for button cancel ([4258f33](https://github.com/paypal/paypal-checkout-components/commit/4258f33))
+* Add some intranet docs ([49c782d](https://github.com/paypal/paypal-checkout-components/commit/49c782d))
+* CAL log for button click ([e2d7677](https://github.com/paypal/paypal-checkout-components/commit/e2d7677))
+* CAL warning for ineligible ([141a6df](https://github.com/paypal/paypal-checkout-components/commit/141a6df))
+* Dist ([08d3810](https://github.com/paypal/paypal-checkout-components/commit/08d3810))
+* Do not render button in ineligible browser ([b83773d](https://github.com/paypal/paypal-checkout-components/commit/b83773d))
+* Fix doc images ([0f56317](https://github.com/paypal/paypal-checkout-components/commit/0f56317))
+* FPTI log for authorize ([bbc2be4](https://github.com/paypal/paypal-checkout-components/commit/bbc2be4))
+* Log if button clicked before fully loaded ([11350b0](https://github.com/paypal/paypal-checkout-components/commit/11350b0))
+* Update frameworks.md ([e620629](https://github.com/paypal/paypal-checkout-components/commit/e620629))
+* Update frameworks.md ([733b52b](https://github.com/paypal/paypal-checkout-components/commit/733b52b))
+* Use latest example for React doc ([6dd3618](https://github.com/paypal/paypal-checkout-components/commit/6dd3618))
 
 
 
 ## <small>4.0.91 (2017-07-18)</small>
 
-* Add an accessToken prop to checkout ([8b3e505](http://github.paypal.com/paypal/paypal-checkout/commit/8b3e505))
-* Add cross-domain-utils and zalgo-promise to quickbuild script ([0bb128d](http://github.paypal.com/paypal/paypal-checkout/commit/0bb128d))
-* Add dev demo ([05eac5e](http://github.paypal.com/paypal/paypal-checkout/commit/05eac5e))
-* Add flow declaration for __IE_POPUP_SUPPORT__ ([d444a52](http://github.paypal.com/paypal/paypal-checkout/commit/d444a52))
-* Add issue template ([73562e1](http://github.paypal.com/paypal/paypal-checkout/commit/73562e1))
-* Buy Now Button bug fix (#391) ([386a271](http://github.paypal.com/paypal/paypal-checkout/commit/386a271)), closes [#391](http://github.paypal.com/paypal/paypal-checkout/issues/391)
-* Convert checkout component template to jsx ([b4781ec](http://github.paypal.com/paypal/paypal-checkout/commit/b4781ec))
-* Correct alt-text for button svgs ([e479db0](http://github.paypal.com/paypal/paypal-checkout/commit/e479db0))
-* Dist ([85c3a94](http://github.paypal.com/paypal/paypal-checkout/commit/85c3a94))
-* Dist ([02fbcd1](http://github.paypal.com/paypal/paypal-checkout/commit/02fbcd1))
-* Fix button size test assertions ([d3cb9c6](http://github.paypal.com/paypal/paypal-checkout/commit/d3cb9c6))
-* Login component ([82586b5](http://github.paypal.com/paypal/paypal-checkout/commit/82586b5))
-* Paypal venmo button logic (#406) ([9c23921](http://github.paypal.com/paypal/paypal-checkout/commit/9c23921)), closes [#406](http://github.paypal.com/paypal/paypal-checkout/issues/406)
-* Prevent infinite loop from log flushing ([309059b](http://github.paypal.com/paypal/paypal-checkout/commit/309059b))
-* Set up no-tagline experiment ([9b07b9d](http://github.paypal.com/paypal/paypal-checkout/commit/9b07b9d))
-* Simplify responsive button container styles ([eb04403](http://github.paypal.com/paypal/paypal-checkout/commit/eb04403))
-* Use jsx for templates ([7a67a39](http://github.paypal.com/paypal/paypal-checkout/commit/7a67a39))
+* 4.0.90 ([d5639b8](https://github.com/paypal/paypal-checkout-components/commit/d5639b8))
+* 4.0.91 ([69808e9](https://github.com/paypal/paypal-checkout-components/commit/69808e9))
+* Add an accessToken prop to checkout ([8b3e505](https://github.com/paypal/paypal-checkout-components/commit/8b3e505))
+* Add cross-domain-utils and zalgo-promise to quickbuild script ([0bb128d](https://github.com/paypal/paypal-checkout-components/commit/0bb128d))
+* Add dev demo ([05eac5e](https://github.com/paypal/paypal-checkout-components/commit/05eac5e))
+* Add flow declaration for __IE_POPUP_SUPPORT__ ([d444a52](https://github.com/paypal/paypal-checkout-components/commit/d444a52))
+* Add issue template ([73562e1](https://github.com/paypal/paypal-checkout-components/commit/73562e1))
+* Buy Now Button bug fix (#391) ([386a271](https://github.com/paypal/paypal-checkout-components/commit/386a271)), closes [#391](https://github.com/paypal/paypal-checkout-components/issues/391)
+* Convert checkout component template to jsx ([b4781ec](https://github.com/paypal/paypal-checkout-components/commit/b4781ec))
+* Correct alt-text for button svgs ([e479db0](https://github.com/paypal/paypal-checkout-components/commit/e479db0))
+* Dist ([02fbcd1](https://github.com/paypal/paypal-checkout-components/commit/02fbcd1))
+* Dist ([85c3a94](https://github.com/paypal/paypal-checkout-components/commit/85c3a94))
+* Fix button size test assertions ([d3cb9c6](https://github.com/paypal/paypal-checkout-components/commit/d3cb9c6))
+* Login component ([82586b5](https://github.com/paypal/paypal-checkout-components/commit/82586b5))
+* Paypal venmo button logic (#406) ([9c23921](https://github.com/paypal/paypal-checkout-components/commit/9c23921)), closes [#406](https://github.com/paypal/paypal-checkout-components/issues/406)
+* Prevent infinite loop from log flushing ([309059b](https://github.com/paypal/paypal-checkout-components/commit/309059b))
+* Set up no-tagline experiment ([9b07b9d](https://github.com/paypal/paypal-checkout-components/commit/9b07b9d))
+* Simplify responsive button container styles ([eb04403](https://github.com/paypal/paypal-checkout-components/commit/eb04403))
+* Use jsx for templates ([7a67a39](https://github.com/paypal/paypal-checkout-components/commit/7a67a39))
 
 
 
 ## <small>4.0.89 (2017-06-27)</small>
 
-* Dist ([0fcb805](http://github.paypal.com/paypal/paypal-checkout/commit/0fcb805))
-* Re-start tagline experiment ([96f459a](http://github.paypal.com/paypal/paypal-checkout/commit/96f459a))
+* 4.0.89 ([a14e1ae](https://github.com/paypal/paypal-checkout-components/commit/a14e1ae))
+* Dist ([0fcb805](https://github.com/paypal/paypal-checkout-components/commit/0fcb805))
+* Re-start tagline experiment ([96f459a](https://github.com/paypal/paypal-checkout-components/commit/96f459a))
 
 
 
 ## <small>4.0.88 (2017-06-27)</small>
 
-* Add timing log for button render ([0b4bfb9](http://github.paypal.com/paypal/paypal-checkout/commit/0b4bfb9))
-* Dist ([81a4920](http://github.paypal.com/paypal/paypal-checkout/commit/81a4920))
-* Fix memoize typing ([50fe9df](http://github.paypal.com/paypal/paypal-checkout/commit/50fe9df))
-* Fix zalgo-promise ref ([fecff14](http://github.paypal.com/paypal/paypal-checkout/commit/fecff14))
-* More throttle potential fixes ([04d9924](http://github.paypal.com/paypal/paypal-checkout/commit/04d9924))
+* 4.0.88 ([0713403](https://github.com/paypal/paypal-checkout-components/commit/0713403))
+* Add timing log for button render ([0b4bfb9](https://github.com/paypal/paypal-checkout-components/commit/0b4bfb9))
+* Dist ([81a4920](https://github.com/paypal/paypal-checkout-components/commit/81a4920))
+* Fix memoize typing ([50fe9df](https://github.com/paypal/paypal-checkout-components/commit/50fe9df))
+* Fix zalgo-promise ref ([fecff14](https://github.com/paypal/paypal-checkout-components/commit/fecff14))
+* More throttle potential fixes ([04d9924](https://github.com/paypal/paypal-checkout-components/commit/04d9924))
 
 
 
 ## <small>4.0.87 (2017-06-26)</small>
 
-* Dist ([1a8f727](http://github.paypal.com/paypal/paypal-checkout/commit/1a8f727))
+* 4.0.87 ([0e2eda9](https://github.com/paypal/paypal-checkout-components/commit/0e2eda9))
+* Dist ([1a8f727](https://github.com/paypal/paypal-checkout-components/commit/1a8f727))
 
 
 
 ## <small>4.0.86 (2017-06-26)</small>
 
-* Advanced session logic, throttle fixes and verifications ([b3a0851](http://github.paypal.com/paypal/paypal-checkout/commit/b3a0851))
-* Dist ([2bcc94a](http://github.paypal.com/paypal/paypal-checkout/commit/2bcc94a))
-* Fix legacy env setting regression ([c050dbb](http://github.paypal.com/paypal/paypal-checkout/commit/c050dbb))
-* Upgrade post-robot ([1161447](http://github.paypal.com/paypal/paypal-checkout/commit/1161447))
+* 4.0.86 ([cc2c472](https://github.com/paypal/paypal-checkout-components/commit/cc2c472))
+* Advanced session logic, throttle fixes and verifications ([b3a0851](https://github.com/paypal/paypal-checkout-components/commit/b3a0851))
+* Dist ([2bcc94a](https://github.com/paypal/paypal-checkout-components/commit/2bcc94a))
+* Fix legacy env setting regression ([c050dbb](https://github.com/paypal/paypal-checkout-components/commit/c050dbb))
+* Upgrade post-robot ([1161447](https://github.com/paypal/paypal-checkout-components/commit/1161447))
 
 
 
 ## <small>4.0.85 (2017-06-22)</small>
 
-* Add Gitter Badge (#378) ([a7894a0](http://github.paypal.com/paypal/paypal-checkout/commit/a7894a0)), closes [#378](http://github.paypal.com/paypal/paypal-checkout/issues/378)
-* Create NOOP pptm.js script upon setup (#385) ([b425166](http://github.paypal.com/paypal/paypal-checkout/commit/b425166)), closes [#385](http://github.paypal.com/paypal/paypal-checkout/issues/385)
-* Disable ModuleConcatenationPlugin for now ([86f2eca](http://github.paypal.com/paypal/paypal-checkout/commit/86f2eca))
-* Dist ([50e3cc9](http://github.paypal.com/paypal/paypal-checkout/commit/50e3cc9))
-* Fixes for buy now button ([1e2fd59](http://github.paypal.com/paypal/paypal-checkout/commit/1e2fd59))
-* If not button or container passed to legacy, assume custom button for instrumentation ([61245f3](http://github.paypal.com/paypal/paypal-checkout/commit/61245f3))
-* Legacy button options normalization and cleanup ([dc12deb](http://github.paypal.com/paypal/paypal-checkout/commit/dc12deb))
-* Set 5 minute lifespan for session id, across multiple tabs ([89940b1](http://github.paypal.com/paypal/paypal-checkout/commit/89940b1))
-* Switch to validate for intranet check ([4cc641e](http://github.paypal.com/paypal/paypal-checkout/commit/4cc641e))
-* Type safety fix ([c8733d6](http://github.paypal.com/paypal/paypal-checkout/commit/c8733d6))
-* Upgrade to webpack 3 with scope hoisting (#382) ([2afa78b](http://github.paypal.com/paypal/paypal-checkout/commit/2afa78b)), closes [#382](http://github.paypal.com/paypal/paypal-checkout/issues/382)
-* Use user_session_guid rather than user_guid for fpti logging ([d933966](http://github.paypal.com/paypal/paypal-checkout/commit/d933966))
+* 4.0.85 ([d48aab9](https://github.com/paypal/paypal-checkout-components/commit/d48aab9))
+* Add Gitter Badge (#378) ([a7894a0](https://github.com/paypal/paypal-checkout-components/commit/a7894a0)), closes [#378](https://github.com/paypal/paypal-checkout-components/issues/378)
+* Create NOOP pptm.js script upon setup (#385) ([b425166](https://github.com/paypal/paypal-checkout-components/commit/b425166)), closes [#385](https://github.com/paypal/paypal-checkout-components/issues/385)
+* Disable ModuleConcatenationPlugin for now ([86f2eca](https://github.com/paypal/paypal-checkout-components/commit/86f2eca))
+* Dist ([50e3cc9](https://github.com/paypal/paypal-checkout-components/commit/50e3cc9))
+* Fixes for buy now button ([1e2fd59](https://github.com/paypal/paypal-checkout-components/commit/1e2fd59))
+* If not button or container passed to legacy, assume custom button for instrumentation ([61245f3](https://github.com/paypal/paypal-checkout-components/commit/61245f3))
+* Legacy button options normalization and cleanup ([dc12deb](https://github.com/paypal/paypal-checkout-components/commit/dc12deb))
+* Set 5 minute lifespan for session id, across multiple tabs ([89940b1](https://github.com/paypal/paypal-checkout-components/commit/89940b1))
+* Switch to validate for intranet check ([4cc641e](https://github.com/paypal/paypal-checkout-components/commit/4cc641e))
+* Type safety fix ([c8733d6](https://github.com/paypal/paypal-checkout-components/commit/c8733d6))
+* Upgrade to webpack 3 with scope hoisting (#382) ([2afa78b](https://github.com/paypal/paypal-checkout-components/commit/2afa78b)), closes [#382](https://github.com/paypal/paypal-checkout-components/issues/382)
+* Use user_session_guid rather than user_guid for fpti logging ([d933966](https://github.com/paypal/paypal-checkout-components/commit/d933966))
 
 
 
 ## <small>4.0.84 (2017-06-17)</small>
 
-* Add button_source enum and fpti log ([12036ca](http://github.paypal.com/paypal/paypal-checkout/commit/12036ca))
-* Add fpti error logging ([8af47e6](http://github.paypal.com/paypal/paypal-checkout/commit/8af47e6))
-* Allow passing partnerAttributionID in payment create ([effd944](http://github.paypal.com/paypal/paypal-checkout/commit/effd944))
-* Api tests and fixes ([bc17e0d](http://github.paypal.com/paypal/paypal-checkout/commit/bc17e0d))
-* Dist ([747e39c](http://github.paypal.com/paypal/paypal-checkout/commit/747e39c))
-* Dist ([42cdc45](http://github.paypal.com/paypal/paypal-checkout/commit/42cdc45))
-* Do not allow rendering button in IE intranet mode ([d68dd60](http://github.paypal.com/paypal/paypal-checkout/commit/d68dd60))
-* Do not try to parse non-json responses ([b1872a4](http://github.paypal.com/paypal/paypal-checkout/commit/b1872a4))
-* Export isCheckoutXComponent from loader script ([0225d57](http://github.paypal.com/paypal/paypal-checkout/commit/0225d57))
-* Fix media queries for zooming subpixel issues ([7646eee](http://github.paypal.com/paypal/paypal-checkout/commit/7646eee))
-* Fix typos in tests ([4913fc2](http://github.paypal.com/paypal/paypal-checkout/commit/4913fc2))
-* Make initial height 535px for mobile rather than 100% ([c906bc7](http://github.paypal.com/paypal/paypal-checkout/commit/c906bc7))
-* Make logger state checkoutjs ([273bd5f](http://github.paypal.com/paypal/paypal-checkout/commit/273bd5f))
-* Temporarily use cors api urls for sandbox ([5b1b84b](http://github.paypal.com/paypal/paypal-checkout/commit/5b1b84b))
-* Update all buttons to Checkout from Check out ([c652687](http://github.paypal.com/paypal/paypal-checkout/commit/c652687))
-* Use configuration for all button differences and validations (#366) ([bd67d55](http://github.paypal.com/paypal/paypal-checkout/commit/bd67d55)), closes [#366](http://github.paypal.com/paypal/paypal-checkout/issues/366)
-* Use getSessionID rather than getPageID ([0444add](http://github.paypal.com/paypal/paypal-checkout/commit/0444add))
-* Use ZalgoPromise ([c7d6632](http://github.paypal.com/paypal/paypal-checkout/commit/c7d6632))
+* 4.0.83 ([fa9c86e](https://github.com/paypal/paypal-checkout-components/commit/fa9c86e))
+* 4.0.84 ([0079f6f](https://github.com/paypal/paypal-checkout-components/commit/0079f6f))
+* Add button_source enum and fpti log ([12036ca](https://github.com/paypal/paypal-checkout-components/commit/12036ca))
+* Add fpti error logging ([8af47e6](https://github.com/paypal/paypal-checkout-components/commit/8af47e6))
+* Allow passing partnerAttributionID in payment create ([effd944](https://github.com/paypal/paypal-checkout-components/commit/effd944))
+* Api tests and fixes ([bc17e0d](https://github.com/paypal/paypal-checkout-components/commit/bc17e0d))
+* Dist ([42cdc45](https://github.com/paypal/paypal-checkout-components/commit/42cdc45))
+* Dist ([747e39c](https://github.com/paypal/paypal-checkout-components/commit/747e39c))
+* Do not allow rendering button in IE intranet mode ([d68dd60](https://github.com/paypal/paypal-checkout-components/commit/d68dd60))
+* Do not try to parse non-json responses ([b1872a4](https://github.com/paypal/paypal-checkout-components/commit/b1872a4))
+* Export isCheckoutXComponent from loader script ([0225d57](https://github.com/paypal/paypal-checkout-components/commit/0225d57))
+* Fix media queries for zooming subpixel issues ([7646eee](https://github.com/paypal/paypal-checkout-components/commit/7646eee))
+* Fix typos in tests ([4913fc2](https://github.com/paypal/paypal-checkout-components/commit/4913fc2))
+* Make initial height 535px for mobile rather than 100% ([c906bc7](https://github.com/paypal/paypal-checkout-components/commit/c906bc7))
+* Make logger state checkoutjs ([273bd5f](https://github.com/paypal/paypal-checkout-components/commit/273bd5f))
+* Temporarily use cors api urls for sandbox ([5b1b84b](https://github.com/paypal/paypal-checkout-components/commit/5b1b84b))
+* Update all buttons to Checkout from Check out ([c652687](https://github.com/paypal/paypal-checkout-components/commit/c652687))
+* Use configuration for all button differences and validations (#366) ([bd67d55](https://github.com/paypal/paypal-checkout-components/commit/bd67d55)), closes [#366](https://github.com/paypal/paypal-checkout-components/issues/366)
+* Use getSessionID rather than getPageID ([0444add](https://github.com/paypal/paypal-checkout-components/commit/0444add))
+* Use ZalgoPromise ([c7d6632](https://github.com/paypal/paypal-checkout-components/commit/c7d6632))
 
 
 
 ## <small>4.0.82 (2017-06-07)</small>
 
-* Dist ([bcda8b5](http://github.paypal.com/paypal/paypal-checkout/commit/bcda8b5))
-* Fix typo ([7cf69a9](http://github.paypal.com/paypal/paypal-checkout/commit/7cf69a9))
+* 4.0.82 ([5afb22c](https://github.com/paypal/paypal-checkout-components/commit/5afb22c))
+* Dist ([bcda8b5](https://github.com/paypal/paypal-checkout-components/commit/bcda8b5))
+* Fix typo ([7cf69a9](https://github.com/paypal/paypal-checkout-components/commit/7cf69a9))
 
 
 
 ## <small>4.0.81 (2017-06-07)</small>
 
-* Dist ([f716746](http://github.paypal.com/paypal/paypal-checkout/commit/f716746))
-* Fix fpti logging for payment create ([e22bede](http://github.paypal.com/paypal/paypal-checkout/commit/e22bede))
-* Use latest cross-domain-utils on publish ([56c50d3](http://github.paypal.com/paypal/paypal-checkout/commit/56c50d3))
+* 4.0.81 ([26082d9](https://github.com/paypal/paypal-checkout-components/commit/26082d9))
+* Dist ([f716746](https://github.com/paypal/paypal-checkout-components/commit/f716746))
+* Fix fpti logging for payment create ([e22bede](https://github.com/paypal/paypal-checkout-components/commit/e22bede))
+* Use latest cross-domain-utils on publish ([56c50d3](https://github.com/paypal/paypal-checkout-components/commit/56c50d3))
 
 
 
 ## <small>4.0.80 (2017-06-06)</small>
 
-* Better hash function for test groups ([41f2e97](http://github.paypal.com/paypal/paypal-checkout/commit/41f2e97))
-* branded buy now button (#343) ([369075c](http://github.paypal.com/paypal/paypal-checkout/commit/369075c)), closes [#343](http://github.paypal.com/paypal/paypal-checkout/issues/343)
-* Dist ([2d0ce1e](http://github.paypal.com/paypal/paypal-checkout/commit/2d0ce1e))
-* Dist ([cb6e8b5](http://github.paypal.com/paypal/paypal-checkout/commit/cb6e8b5))
-* Fix checkout iframe scrolling ([dd24889](http://github.paypal.com/paypal/paypal-checkout/commit/dd24889))
-* Run tag content test as AA test ([564544f](http://github.paypal.com/paypal/paypal-checkout/commit/564544f))
-* feat(http): Add XHR Timeout configuration (#360) ([e01b747](http://github.paypal.com/paypal/paypal-checkout/commit/e01b747)), closes [#360](http://github.paypal.com/paypal/paypal-checkout/issues/360)
+* 4.0.79 ([02470d1](https://github.com/paypal/paypal-checkout-components/commit/02470d1))
+* 4.0.80 ([e5bea95](https://github.com/paypal/paypal-checkout-components/commit/e5bea95))
+* Better hash function for test groups ([41f2e97](https://github.com/paypal/paypal-checkout-components/commit/41f2e97))
+* branded buy now button (#343) ([369075c](https://github.com/paypal/paypal-checkout-components/commit/369075c)), closes [#343](https://github.com/paypal/paypal-checkout-components/issues/343)
+* Dist ([2d0ce1e](https://github.com/paypal/paypal-checkout-components/commit/2d0ce1e))
+* Dist ([cb6e8b5](https://github.com/paypal/paypal-checkout-components/commit/cb6e8b5))
+* Fix checkout iframe scrolling ([dd24889](https://github.com/paypal/paypal-checkout-components/commit/dd24889))
+* Run tag content test as AA test ([564544f](https://github.com/paypal/paypal-checkout-components/commit/564544f))
+* feat(http): Add XHR Timeout configuration (#360) ([e01b747](https://github.com/paypal/paypal-checkout-components/commit/e01b747)), closes [#360](https://github.com/paypal/paypal-checkout-components/issues/360)
 
 
 
 ## <small>4.0.78 (2017-05-23)</small>
 
-* Dist ([42f659f](http://github.paypal.com/paypal/paypal-checkout/commit/42f659f))
+* 4.0.78 ([c4fdb4d](https://github.com/paypal/paypal-checkout-components/commit/c4fdb4d))
+* Dist ([42f659f](https://github.com/paypal/paypal-checkout-components/commit/42f659f))
 
 
 
 ## <small>4.0.77 (2017-05-23)</small>
 
-* Dist ([68ff0b4](http://github.paypal.com/paypal/paypal-checkout/commit/68ff0b4))
-* Fix minimum widths ([73981e7](http://github.paypal.com/paypal/paypal-checkout/commit/73981e7))
+* 4.0.77 ([8bad22c](https://github.com/paypal/paypal-checkout-components/commit/8bad22c))
+* Dist ([68ff0b4](https://github.com/paypal/paypal-checkout-components/commit/68ff0b4))
+* Fix minimum widths ([73981e7](https://github.com/paypal/paypal-checkout-components/commit/73981e7))
 
 
 
 ## <small>4.0.76 (2017-05-23)</small>
 
-* Dist ([d226263](http://github.paypal.com/paypal/paypal-checkout/commit/d226263))
-* Fix typo in data.braintree ([889ccf7](http://github.paypal.com/paypal/paypal-checkout/commit/889ccf7))
-* Lightbox size fixes for mobile ([e8ec09c](http://github.paypal.com/paypal/paypal-checkout/commit/e8ec09c))
+* 4.0.76 ([b474cb3](https://github.com/paypal/paypal-checkout-components/commit/b474cb3))
+* Dist ([d226263](https://github.com/paypal/paypal-checkout-components/commit/d226263))
+* Fix typo in data.braintree ([889ccf7](https://github.com/paypal/paypal-checkout-components/commit/889ccf7))
+* Lightbox size fixes for mobile ([e8ec09c](https://github.com/paypal/paypal-checkout-components/commit/e8ec09c))
 
 
 
 ## <small>4.0.75 (2017-05-19)</small>
 
-* Dist ([6ddf865](http://github.paypal.com/paypal/paypal-checkout/commit/6ddf865))
-* Doc fixes ([2f6a770](http://github.paypal.com/paypal/paypal-checkout/commit/2f6a770))
-* Downgrade `uglify-js` version to work properly with webpack 2 (#348) ([4c07751](http://github.paypal.com/paypal/paypal-checkout/commit/4c07751)), closes [#348](http://github.paypal.com/paypal/paypal-checkout/issues/348)
-* Expose data.braintree in payment ([9a8544f](http://github.paypal.com/paypal/paypal-checkout/commit/9a8544f))
-* Improve react demo for button ([762cff3](http://github.paypal.com/paypal/paypal-checkout/commit/762cff3))
-* Switch lightbox to animation which does not break centering in safari ([ac8e104](http://github.paypal.com/paypal/paypal-checkout/commit/ac8e104))
+* 4.0.75 ([0176d09](https://github.com/paypal/paypal-checkout-components/commit/0176d09))
+* Dist ([6ddf865](https://github.com/paypal/paypal-checkout-components/commit/6ddf865))
+* Doc fixes ([2f6a770](https://github.com/paypal/paypal-checkout-components/commit/2f6a770))
+* Downgrade `uglify-js` version to work properly with webpack 2 (#348) ([4c07751](https://github.com/paypal/paypal-checkout-components/commit/4c07751)), closes [#348](https://github.com/paypal/paypal-checkout-components/issues/348)
+* Expose data.braintree in payment ([9a8544f](https://github.com/paypal/paypal-checkout-components/commit/9a8544f))
+* Improve react demo for button ([762cff3](https://github.com/paypal/paypal-checkout-components/commit/762cff3))
+* Switch lightbox to animation which does not break centering in safari ([ac8e104](https://github.com/paypal/paypal-checkout-components/commit/ac8e104))
 
 
 
 ## <small>4.0.74 (2017-05-18)</small>
 
-* Add experience prop for paypal.Checkout ([2031888](http://github.paypal.com/paypal/paypal-checkout/commit/2031888))
-* Change to payment(data, actions) to match onAuthorize ([b5119a6](http://github.paypal.com/paypal/paypal-checkout/commit/b5119a6))
-* Dist ([18e9133](http://github.paypal.com/paypal/paypal-checkout/commit/18e9133))
+* 4.0.74 ([6ea5a0f](https://github.com/paypal/paypal-checkout-components/commit/6ea5a0f))
+* Add experience prop for paypal.Checkout ([2031888](https://github.com/paypal/paypal-checkout-components/commit/2031888))
+* Change to payment(data, actions) to match onAuthorize ([b5119a6](https://github.com/paypal/paypal-checkout-components/commit/b5119a6))
+* Dist ([18e9133](https://github.com/paypal/paypal-checkout-components/commit/18e9133))
 
 
 
 ## <small>4.0.73 (2017-05-16)</small>
 
-* Add hoverstate for button ([0ca304b](http://github.paypal.com/paypal/paypal-checkout/commit/0ca304b))
-* Adjust tagline experiment ([8e31d76](http://github.paypal.com/paypal/paypal-checkout/commit/8e31d76))
-* buy now button (#338) ([594c282](http://github.paypal.com/paypal/paypal-checkout/commit/594c282)), closes [#338](http://github.paypal.com/paypal/paypal-checkout/issues/338)
-* Change Check out to Checkout ([2de8bb2](http://github.paypal.com/paypal/paypal-checkout/commit/2de8bb2))
-* Dist ([bb489dc](http://github.paypal.com/paypal/paypal-checkout/commit/bb489dc))
-* Instrumentation fixes ([2a8ac49](http://github.paypal.com/paypal/paypal-checkout/commit/2a8ac49))
-* Remove button fix hacks ([84cd2c8](http://github.paypal.com/paypal/paypal-checkout/commit/84cd2c8))
-* User onRemember rather than onAuth ([abd6df4](http://github.paypal.com/paypal/paypal-checkout/commit/abd6df4))
-* docs(http): Add HTTP function documentation and features section on README. (#340) ([4ba2908](http://github.paypal.com/paypal/paypal-checkout/commit/4ba2908)), closes [#340](http://github.paypal.com/paypal/paypal-checkout/issues/340)
+* 4.0.73 ([38bfd98](https://github.com/paypal/paypal-checkout-components/commit/38bfd98))
+* Add hoverstate for button ([0ca304b](https://github.com/paypal/paypal-checkout-components/commit/0ca304b))
+* Adjust tagline experiment ([8e31d76](https://github.com/paypal/paypal-checkout-components/commit/8e31d76))
+* buy now button (#338) ([594c282](https://github.com/paypal/paypal-checkout-components/commit/594c282)), closes [#338](https://github.com/paypal/paypal-checkout-components/issues/338)
+* Change Check out to Checkout ([2de8bb2](https://github.com/paypal/paypal-checkout-components/commit/2de8bb2))
+* Dist ([bb489dc](https://github.com/paypal/paypal-checkout-components/commit/bb489dc))
+* Instrumentation fixes ([2a8ac49](https://github.com/paypal/paypal-checkout-components/commit/2a8ac49))
+* Remove button fix hacks ([84cd2c8](https://github.com/paypal/paypal-checkout-components/commit/84cd2c8))
+* User onRemember rather than onAuth ([abd6df4](https://github.com/paypal/paypal-checkout-components/commit/abd6df4))
+* docs(http): Add HTTP function documentation and features section on README. (#340) ([4ba2908](https://github.com/paypal/paypal-checkout-components/commit/4ba2908)), closes [#340](https://github.com/paypal/paypal-checkout-components/issues/340)
 
 
 
 ## <small>4.0.72 (2017-05-15)</small>
 
-* David-DM badges and devDependency updates. (#328) ([8488720](http://github.paypal.com/paypal/paypal-checkout/commit/8488720)), closes [#328](http://github.paypal.com/paypal/paypal-checkout/issues/328)
-* Dist ([9e8935e](http://github.paypal.com/paypal/paypal-checkout/commit/9e8935e))
+* 4.0.72 ([24559c2](https://github.com/paypal/paypal-checkout-components/commit/24559c2))
+* David-DM badges and devDependency updates. (#328) ([8488720](https://github.com/paypal/paypal-checkout-components/commit/8488720)), closes [#328](https://github.com/paypal/paypal-checkout-components/issues/328)
+* Dist ([9e8935e](https://github.com/paypal/paypal-checkout-components/commit/9e8935e))
 
 
 
 ## <small>4.0.71 (2017-05-11)</small>
 
-* Add additional fpti keys ([6c71567](http://github.paypal.com/paypal/paypal-checkout/commit/6c71567))
-* Dist ([3b6a53d](http://github.paypal.com/paypal/paypal-checkout/commit/3b6a53d))
-* Revert "Remove old prop aliases" ([5defb27](http://github.paypal.com/paypal/paypal-checkout/commit/5defb27))
+* 4.0.71 ([fedebe1](https://github.com/paypal/paypal-checkout-components/commit/fedebe1))
+* Add additional fpti keys ([6c71567](https://github.com/paypal/paypal-checkout-components/commit/6c71567))
+* Dist ([3b6a53d](https://github.com/paypal/paypal-checkout-components/commit/3b6a53d))
+* Revert "Remove old prop aliases" ([5defb27](https://github.com/paypal/paypal-checkout-components/commit/5defb27))
 
 
 
 ## <small>4.0.70 (2017-05-11)</small>
 
-* Add additional FPTI instrumentation ([b6de15f](http://github.paypal.com/paypal/paypal-checkout/commit/b6de15f))
-* Dist ([7ea090e](http://github.paypal.com/paypal/paypal-checkout/commit/7ea090e))
-* Remove old prop aliases ([84dc3a0](http://github.paypal.com/paypal/paypal-checkout/commit/84dc3a0))
-* Remove redundant css ([a3fe690](http://github.paypal.com/paypal/paypal-checkout/commit/a3fe690))
-* Return better error for ajax failures ([de6d31b](http://github.paypal.com/paypal/paypal-checkout/commit/de6d31b))
+* 4.0.70 ([054d8de](https://github.com/paypal/paypal-checkout-components/commit/054d8de))
+* Add additional FPTI instrumentation ([b6de15f](https://github.com/paypal/paypal-checkout-components/commit/b6de15f))
+* Dist ([7ea090e](https://github.com/paypal/paypal-checkout-components/commit/7ea090e))
+* Remove old prop aliases ([84dc3a0](https://github.com/paypal/paypal-checkout-components/commit/84dc3a0))
+* Remove redundant css ([a3fe690](https://github.com/paypal/paypal-checkout-components/commit/a3fe690))
+* Return better error for ajax failures ([de6d31b](https://github.com/paypal/paypal-checkout-components/commit/de6d31b))
 
 
 
 ## <small>4.0.69 (2017-05-10)</small>
 
-* Add experiment for tag content ([b504b3c](http://github.paypal.com/paypal/paypal-checkout/commit/b504b3c))
-* Add test for button rendered before element ready ([ffa9fbf](http://github.paypal.com/paypal/paypal-checkout/commit/ffa9fbf))
-* Add test for window.open iframe name case ([ce22472](http://github.paypal.com/paypal/paypal-checkout/commit/ce22472))
-* Better error handling and tests for error cases ([9427918](http://github.paypal.com/paypal/paypal-checkout/commit/9427918))
-* Break out isElementVisible util ([03f825b](http://github.paypal.com/paypal/paypal-checkout/commit/03f825b))
-* Bump test memory thresholds ([d5cb1d2](http://github.paypal.com/paypal/paypal-checkout/commit/d5cb1d2))
-* Display button as inline-block so it can be centered ([e31328c](http://github.paypal.com/paypal/paypal-checkout/commit/e31328c))
-* Dist ([6381121](http://github.paypal.com/paypal/paypal-checkout/commit/6381121))
-* Dist ([2f3b4a8](http://github.paypal.com/paypal/paypal-checkout/commit/2f3b4a8))
-* Fixed formatting formatting of README (#317) ([c18cedd](http://github.paypal.com/paypal/paypal-checkout/commit/c18cedd)), closes [#317](http://github.paypal.com/paypal/paypal-checkout/issues/317) [#316](http://github.paypal.com/paypal/paypal-checkout/issues/316)
-* Have popout tests render to parentRenderWindow ([03e3f58](http://github.paypal.com/paypal/paypal-checkout/commit/03e3f58))
-* Remove incorrect semi-colon in example (#324) ([d328452](http://github.paypal.com/paypal/paypal-checkout/commit/d328452)), closes [#324](http://github.paypal.com/paypal/paypal-checkout/issues/324)
-* Set default log level to "warn" (#316) ([67866b2](http://github.paypal.com/paypal/paypal-checkout/commit/67866b2)), closes [#316](http://github.paypal.com/paypal/paypal-checkout/issues/316)
-* Show that response can be obtained after successful promise (#320) ([01ab5dd](http://github.paypal.com/paypal/paypal-checkout/commit/01ab5dd)), closes [#320](http://github.paypal.com/paypal/paypal-checkout/issues/320)
-* Tests and fixes for centered buttons ([6821962](http://github.paypal.com/paypal/paypal-checkout/commit/6821962))
-* Update SECURITY.md to reference bug bounty program (Issue #314) (#327) ([e91870b](http://github.paypal.com/paypal/paypal-checkout/commit/e91870b)), closes [#314](http://github.paypal.com/paypal/paypal-checkout/issues/314) [#327](http://github.paypal.com/paypal/paypal-checkout/issues/327)
-* Upgrade post-robot ([c23a49a](http://github.paypal.com/paypal/paypal-checkout/commit/c23a49a))
-* Use actions.payment.create in docs ([5dced8f](http://github.paypal.com/paypal/paypal-checkout/commit/5dced8f))
-* Use logLevel info by default when keeping browser open for debugging ([093b5e9](http://github.paypal.com/paypal/paypal-checkout/commit/093b5e9))
+* 4.0.68 ([ac0b6f0](https://github.com/paypal/paypal-checkout-components/commit/ac0b6f0))
+* 4.0.69 ([0989fe1](https://github.com/paypal/paypal-checkout-components/commit/0989fe1))
+* Add experiment for tag content ([b504b3c](https://github.com/paypal/paypal-checkout-components/commit/b504b3c))
+* Add test for button rendered before element ready ([ffa9fbf](https://github.com/paypal/paypal-checkout-components/commit/ffa9fbf))
+* Add test for window.open iframe name case ([ce22472](https://github.com/paypal/paypal-checkout-components/commit/ce22472))
+* Better error handling and tests for error cases ([9427918](https://github.com/paypal/paypal-checkout-components/commit/9427918))
+* Break out isElementVisible util ([03f825b](https://github.com/paypal/paypal-checkout-components/commit/03f825b))
+* Bump test memory thresholds ([d5cb1d2](https://github.com/paypal/paypal-checkout-components/commit/d5cb1d2))
+* Display button as inline-block so it can be centered ([e31328c](https://github.com/paypal/paypal-checkout-components/commit/e31328c))
+* Dist ([2f3b4a8](https://github.com/paypal/paypal-checkout-components/commit/2f3b4a8))
+* Dist ([6381121](https://github.com/paypal/paypal-checkout-components/commit/6381121))
+* Fixed formatting formatting of README (#317) ([c18cedd](https://github.com/paypal/paypal-checkout-components/commit/c18cedd)), closes [#317](https://github.com/paypal/paypal-checkout-components/issues/317) [#316](https://github.com/paypal/paypal-checkout-components/issues/316)
+* Have popout tests render to parentRenderWindow ([03e3f58](https://github.com/paypal/paypal-checkout-components/commit/03e3f58))
+* Remove incorrect semi-colon in example (#324) ([d328452](https://github.com/paypal/paypal-checkout-components/commit/d328452)), closes [#324](https://github.com/paypal/paypal-checkout-components/issues/324)
+* Set default log level to "warn" (#316) ([67866b2](https://github.com/paypal/paypal-checkout-components/commit/67866b2)), closes [#316](https://github.com/paypal/paypal-checkout-components/issues/316)
+* Show that response can be obtained after successful promise (#320) ([01ab5dd](https://github.com/paypal/paypal-checkout-components/commit/01ab5dd)), closes [#320](https://github.com/paypal/paypal-checkout-components/issues/320)
+* Tests and fixes for centered buttons ([6821962](https://github.com/paypal/paypal-checkout-components/commit/6821962))
+* Update SECURITY.md to reference bug bounty program (Issue #314) (#327) ([e91870b](https://github.com/paypal/paypal-checkout-components/commit/e91870b)), closes [#314](https://github.com/paypal/paypal-checkout-components/issues/314) [#327](https://github.com/paypal/paypal-checkout-components/issues/327)
+* Upgrade post-robot ([c23a49a](https://github.com/paypal/paypal-checkout-components/commit/c23a49a))
+* Use actions.payment.create in docs ([5dced8f](https://github.com/paypal/paypal-checkout-components/commit/5dced8f))
+* Use logLevel info by default when keeping browser open for debugging ([093b5e9](https://github.com/paypal/paypal-checkout-components/commit/093b5e9))
 
 
 
 ## <small>4.0.67 (2017-05-03)</small>
 
-* Determine initial dimensions in container template ([b8431b4](http://github.paypal.com/paypal/paypal-checkout/commit/b8431b4))
-* Dist ([c913e1b](http://github.paypal.com/paypal/paypal-checkout/commit/c913e1b))
-* Do not use css classes for svgs ([1b90e68](http://github.paypal.com/paypal/paypal-checkout/commit/1b90e68))
-* Fix logo color ([e42b694](http://github.paypal.com/paypal/paypal-checkout/commit/e42b694))
-* Responsive button fixes and tests ([353262f](http://github.paypal.com/paypal/paypal-checkout/commit/353262f))
+* 4.0.67 ([db1d6c3](https://github.com/paypal/paypal-checkout-components/commit/db1d6c3))
+* Determine initial dimensions in container template ([b8431b4](https://github.com/paypal/paypal-checkout-components/commit/b8431b4))
+* Dist ([c913e1b](https://github.com/paypal/paypal-checkout-components/commit/c913e1b))
+* Do not use css classes for svgs ([1b90e68](https://github.com/paypal/paypal-checkout-components/commit/1b90e68))
+* Fix logo color ([e42b694](https://github.com/paypal/paypal-checkout-components/commit/e42b694))
+* Responsive button fixes and tests ([353262f](https://github.com/paypal/paypal-checkout-components/commit/353262f))
 
 
 
 ## <small>4.0.66 (2017-05-02)</small>
 
-* Break button dimensions to separate file ([ffce18d](http://github.paypal.com/paypal/paypal-checkout/commit/ffce18d))
-* Dist ([5b73a08](http://github.paypal.com/paypal/paypal-checkout/commit/5b73a08))
-* Improve responsive button ([5bcf7af](http://github.paypal.com/paypal/paypal-checkout/commit/5bcf7af))
-* Pass element for auto-resizing button ([ab538c2](http://github.paypal.com/paypal/paypal-checkout/commit/ab538c2))
-* Simplified Braintree Integration (#309) ([d8ecf69](http://github.paypal.com/paypal/paypal-checkout/commit/d8ecf69)), closes [#309](http://github.paypal.com/paypal/paypal-checkout/issues/309)
+* 4.0.66 ([a8433a2](https://github.com/paypal/paypal-checkout-components/commit/a8433a2))
+* Break button dimensions to separate file ([ffce18d](https://github.com/paypal/paypal-checkout-components/commit/ffce18d))
+* Dist ([5b73a08](https://github.com/paypal/paypal-checkout-components/commit/5b73a08))
+* Improve responsive button ([5bcf7af](https://github.com/paypal/paypal-checkout-components/commit/5bcf7af))
+* Pass element for auto-resizing button ([ab538c2](https://github.com/paypal/paypal-checkout-components/commit/ab538c2))
+* Simplified Braintree Integration (#309) ([d8ecf69](https://github.com/paypal/paypal-checkout-components/commit/d8ecf69)), closes [#309](https://github.com/paypal/paypal-checkout-components/issues/309)
 
 
 
 ## <small>4.0.65 (2017-04-27)</small>
 
-* Add tests for button sizes ([fdecf02](http://github.paypal.com/paypal/paypal-checkout/commit/fdecf02))
-* Dist ([5e7b942](http://github.paypal.com/paypal/paypal-checkout/commit/5e7b942))
-* Safeguard for button logo not displaying in button frame ([7abb7fc](http://github.paypal.com/paypal/paypal-checkout/commit/7abb7fc))
-* Send actions to payment() method ([dbfc713](http://github.paypal.com/paypal/paypal-checkout/commit/dbfc713))
-* Upgrade flow and flow-runtime ([1492477](http://github.paypal.com/paypal/paypal-checkout/commit/1492477))
+* 4.0.65 ([70f7ef6](https://github.com/paypal/paypal-checkout-components/commit/70f7ef6))
+* Add tests for button sizes ([fdecf02](https://github.com/paypal/paypal-checkout-components/commit/fdecf02))
+* Dist ([5e7b942](https://github.com/paypal/paypal-checkout-components/commit/5e7b942))
+* Safeguard for button logo not displaying in button frame ([7abb7fc](https://github.com/paypal/paypal-checkout-components/commit/7abb7fc))
+* Send actions to payment() method ([dbfc713](https://github.com/paypal/paypal-checkout-components/commit/dbfc713))
+* Upgrade flow and flow-runtime ([1492477](https://github.com/paypal/paypal-checkout-components/commit/1492477))
 
 
 
 ## <small>4.0.64 (2017-04-26)</small>
 
-* Disable auto-resize on the button ([311d615](http://github.paypal.com/paypal/paypal-checkout/commit/311d615))
-* Dist ([66a0ca2](http://github.paypal.com/paypal/paypal-checkout/commit/66a0ca2))
-* Log button size ([4395fb0](http://github.paypal.com/paypal/paypal-checkout/commit/4395fb0))
-* Move out demo app ([f47b3a9](http://github.paypal.com/paypal/paypal-checkout/commit/f47b3a9))
+* 4.0.64 ([9a7930c](https://github.com/paypal/paypal-checkout-components/commit/9a7930c))
+* Disable auto-resize on the button ([311d615](https://github.com/paypal/paypal-checkout-components/commit/311d615))
+* Dist ([66a0ca2](https://github.com/paypal/paypal-checkout-components/commit/66a0ca2))
+* Log button size ([4395fb0](https://github.com/paypal/paypal-checkout-components/commit/4395fb0))
+* Move out demo app ([f47b3a9](https://github.com/paypal/paypal-checkout-components/commit/f47b3a9))
 
 
 
 ## <small>4.0.63 (2017-04-25)</small>
 
-* Dist ([7c9d1be](http://github.paypal.com/paypal/paypal-checkout/commit/7c9d1be))
-* Re-allow setting Checkout.contexts.lightbox manually ([c6c87b7](http://github.paypal.com/paypal/paypal-checkout/commit/c6c87b7))
+* 4.0.63 ([07c18d4](https://github.com/paypal/paypal-checkout-components/commit/07c18d4))
+* Dist ([7c9d1be](https://github.com/paypal/paypal-checkout-components/commit/7c9d1be))
+* Re-allow setting Checkout.contexts.lightbox manually ([c6c87b7](https://github.com/paypal/paypal-checkout-components/commit/c6c87b7))
 
 
 
 ## <small>4.0.62 (2017-04-25)</small>
 
-* Call error from child not onError ([ef8c186](http://github.paypal.com/paypal/paypal-checkout/commit/ef8c186))
-* Dist ([ff1dd2f](http://github.paypal.com/paypal/paypal-checkout/commit/ff1dd2f))
+* 4.0.62 ([67388c5](https://github.com/paypal/paypal-checkout-components/commit/67388c5))
+* Call error from child not onError ([ef8c186](https://github.com/paypal/paypal-checkout-components/commit/ef8c186))
+* Dist ([ff1dd2f](https://github.com/paypal/paypal-checkout-components/commit/ff1dd2f))
 
 
 
 ## <small>4.0.61 (2017-04-25)</small>
 
-* Add event for window having opener and parent ([69cbd79](http://github.paypal.com/paypal/paypal-checkout/commit/69cbd79))
-* Add fpti feed name ([72e7f31](http://github.paypal.com/paypal/paypal-checkout/commit/72e7f31))
-* Add tests for error cases in payment method ([30de0eb](http://github.paypal.com/paypal/paypal-checkout/commit/30de0eb))
-* Check out dist before publish ([9bb0520](http://github.paypal.com/paypal/paypal-checkout/commit/9bb0520))
-* Dist ([c460a23](http://github.paypal.com/paypal/paypal-checkout/commit/c460a23))
-* Fix console.karma ([673a2fc](http://github.paypal.com/paypal/paypal-checkout/commit/673a2fc))
-* Fix publish script ([9cef40b](http://github.paypal.com/paypal/paypal-checkout/commit/9cef40b))
-* Have popout tests ensure payment is only called once ([1e9c193](http://github.paypal.com/paypal/paypal-checkout/commit/1e9c193))
-* Prevent publish with uncommited changes ([f7893d7](http://github.paypal.com/paypal/paypal-checkout/commit/f7893d7))
-* Remove only ([e675aa3](http://github.paypal.com/paypal/paypal-checkout/commit/e675aa3))
+* 4.0.61 ([2ad3c8d](https://github.com/paypal/paypal-checkout-components/commit/2ad3c8d))
+* Add event for window having opener and parent ([69cbd79](https://github.com/paypal/paypal-checkout-components/commit/69cbd79))
+* Add fpti feed name ([72e7f31](https://github.com/paypal/paypal-checkout-components/commit/72e7f31))
+* Add tests for error cases in payment method ([30de0eb](https://github.com/paypal/paypal-checkout-components/commit/30de0eb))
+* Check out dist before publish ([9bb0520](https://github.com/paypal/paypal-checkout-components/commit/9bb0520))
+* Dist ([c460a23](https://github.com/paypal/paypal-checkout-components/commit/c460a23))
+* Fix console.karma ([673a2fc](https://github.com/paypal/paypal-checkout-components/commit/673a2fc))
+* Fix publish script ([9cef40b](https://github.com/paypal/paypal-checkout-components/commit/9cef40b))
+* Have popout tests ensure payment is only called once ([1e9c193](https://github.com/paypal/paypal-checkout-components/commit/1e9c193))
+* Prevent publish with uncommited changes ([f7893d7](https://github.com/paypal/paypal-checkout-components/commit/f7893d7))
+* Remove only ([e675aa3](https://github.com/paypal/paypal-checkout-components/commit/e675aa3))
 
 
 
 ## <small>4.0.60 (2017-04-22)</small>
 
-* Dist ([34cdd2d](http://github.paypal.com/paypal/paypal-checkout/commit/34cdd2d))
+* 4.0.60 ([3782fda](https://github.com/paypal/paypal-checkout-components/commit/3782fda))
+* Dist ([34cdd2d](https://github.com/paypal/paypal-checkout-components/commit/34cdd2d))
 
 
 
 ## <small>4.0.59 (2017-04-21)</small>
 
-* Dist ([57572f6](http://github.paypal.com/paypal/paypal-checkout/commit/57572f6))
+* 4.0.59 ([dc80ee8](https://github.com/paypal/paypal-checkout-components/commit/dc80ee8))
+* Dist ([57572f6](https://github.com/paypal/paypal-checkout-components/commit/57572f6))
 
 
 
 ## <small>4.0.58 (2017-04-21)</small>
 
-* Dist ([a57d790](http://github.paypal.com/paypal/paypal-checkout/commit/a57d790))
+* 4.0.58 ([38adb13](https://github.com/paypal/paypal-checkout-components/commit/38adb13))
+* Dist ([a57d790](https://github.com/paypal/paypal-checkout-components/commit/a57d790))
 
 
 
 ## <small>4.0.57 (2017-04-20)</small>
 
-* Dist ([6c7e078](http://github.paypal.com/paypal/paypal-checkout/commit/6c7e078))
-* Make Chrome default test browser ([b4564e7](http://github.paypal.com/paypal/paypal-checkout/commit/b4564e7))
-* Re-add window.ppxo to exports ([78ee834](http://github.paypal.com/paypal/paypal-checkout/commit/78ee834))
+* 4.0.57 ([b5ae0da](https://github.com/paypal/paypal-checkout-components/commit/b5ae0da))
+* Dist ([6c7e078](https://github.com/paypal/paypal-checkout-components/commit/6c7e078))
+* Make Chrome default test browser ([b4564e7](https://github.com/paypal/paypal-checkout-components/commit/b4564e7))
+* Re-add window.ppxo to exports ([78ee834](https://github.com/paypal/paypal-checkout-components/commit/78ee834))
 
 
 
 ## <small>4.0.56 (2017-04-20)</small>
 
-* Add a v4 build without legacy support ([86212d0](http://github.paypal.com/paypal/paypal-checkout/commit/86212d0))
-* Add flag to exclude legacy support ([2f600be](http://github.paypal.com/paypal/paypal-checkout/commit/2f600be))
-* Add FPTI tracking ([f8a3ca8](http://github.paypal.com/paypal/paypal-checkout/commit/f8a3ca8))
-* Add paypal-button id ([866abf2](http://github.paypal.com/paypal/paypal-checkout/commit/866abf2))
-* Dist ([b0c57c9](http://github.paypal.com/paypal/paypal-checkout/commit/b0c57c9))
-* Dist ([a8b47ca](http://github.paypal.com/paypal/paypal-checkout/commit/a8b47ca))
-* Enable feature flags for xcomponent ([b421516](http://github.paypal.com/paypal/paypal-checkout/commit/b421516))
-* Fix quickbuild script ([68e44f1](http://github.paypal.com/paypal/paypal-checkout/commit/68e44f1))
-* Fix svg buttons to work for all supported browsers ([a58c9e4](http://github.paypal.com/paypal/paypal-checkout/commit/a58c9e4))
-* Give button hover state and aria role ([95db867](http://github.paypal.com/paypal/paypal-checkout/commit/95db867))
-* Kick babel plugins into loose mode ([83d093e](http://github.paypal.com/paypal/paypal-checkout/commit/83d093e))
-* Move bridge and meta listener to legacy ([56c698f](http://github.paypal.com/paypal/paypal-checkout/commit/56c698f))
-* Remove polyfills ([c072da9](http://github.paypal.com/paypal/paypal-checkout/commit/c072da9))
-* Simplify child loader ([1461248](http://github.paypal.com/paypal/paypal-checkout/commit/1461248))
-* Upgrade beaver-logger ([919d296](http://github.paypal.com/paypal/paypal-checkout/commit/919d296))
-* Use raw svg code for button logos ([df58673](http://github.paypal.com/paypal/paypal-checkout/commit/df58673))
-* Use wordmark for pay button ([d3a8e3e](http://github.paypal.com/paypal/paypal-checkout/commit/d3a8e3e))
+* 4.0.56 ([4b2536e](https://github.com/paypal/paypal-checkout-components/commit/4b2536e))
+* Add a v4 build without legacy support ([86212d0](https://github.com/paypal/paypal-checkout-components/commit/86212d0))
+* Add flag to exclude legacy support ([2f600be](https://github.com/paypal/paypal-checkout-components/commit/2f600be))
+* Add FPTI tracking ([f8a3ca8](https://github.com/paypal/paypal-checkout-components/commit/f8a3ca8))
+* Add paypal-button id ([866abf2](https://github.com/paypal/paypal-checkout-components/commit/866abf2))
+* Dist ([b0c57c9](https://github.com/paypal/paypal-checkout-components/commit/b0c57c9))
+* Dist ([a8b47ca](https://github.com/paypal/paypal-checkout-components/commit/a8b47ca))
+* Enable feature flags for xcomponent ([b421516](https://github.com/paypal/paypal-checkout-components/commit/b421516))
+* Fix quickbuild script ([68e44f1](https://github.com/paypal/paypal-checkout-components/commit/68e44f1))
+* Fix svg buttons to work for all supported browsers ([a58c9e4](https://github.com/paypal/paypal-checkout-components/commit/a58c9e4))
+* Give button hover state and aria role ([95db867](https://github.com/paypal/paypal-checkout-components/commit/95db867))
+* Kick babel plugins into loose mode ([83d093e](https://github.com/paypal/paypal-checkout-components/commit/83d093e))
+* Move bridge and meta listener to legacy ([56c698f](https://github.com/paypal/paypal-checkout-components/commit/56c698f))
+* Remove polyfills ([c072da9](https://github.com/paypal/paypal-checkout-components/commit/c072da9))
+* Simplify child loader ([1461248](https://github.com/paypal/paypal-checkout-components/commit/1461248))
+* Upgrade beaver-logger ([919d296](https://github.com/paypal/paypal-checkout-components/commit/919d296))
+* Use raw svg code for button logos ([df58673](https://github.com/paypal/paypal-checkout-components/commit/df58673))
+* Use wordmark for pay button ([d3a8e3e](https://github.com/paypal/paypal-checkout-components/commit/d3a8e3e))
 
 
 
 ## <small>4.0.55 (2017-04-14)</small>
 
-* Add cross-domain-safe-weakmap to publish script ([32f4d21](http://github.paypal.com/paypal/paypal-checkout/commit/32f4d21))
-* Add data-paypal-checkout to test child scripts ([23aa9df](http://github.paypal.com/paypal/paypal-checkout/commit/23aa9df))
-* Add loglevel karma commandline option ([3dabeea](http://github.paypal.com/paypal/paypal-checkout/commit/3dabeea))
-* Add logs for remembered button ([816fd3f](http://github.paypal.com/paypal/paypal-checkout/commit/816fd3f))
-* Add pay content ([1971d47](http://github.paypal.com/paypal/paypal-checkout/commit/1971d47))
-* Add validation demo ([f0018d2](http://github.paypal.com/paypal/paypal-checkout/commit/f0018d2))
-* Add validation for button locale ([b5821d4](http://github.paypal.com/paypal/paypal-checkout/commit/b5821d4))
-* Add validation for buttons ([2c377fa](http://github.paypal.com/paypal/paypal-checkout/commit/2c377fa))
-* Add warning for bind breaking function arrity ([af15a8c](http://github.paypal.com/paypal/paypal-checkout/commit/af15a8c))
-* Add YouTube deep-dive to readme ([e68d7b8](http://github.paypal.com/paypal/paypal-checkout/commit/e68d7b8))
-* Allow publish script to take semver major/minor/patch ([3890041](http://github.paypal.com/paypal/paypal-checkout/commit/3890041))
-* Clean up iframe for button-in-iframe test ([ccc7efe](http://github.paypal.com/paypal/paypal-checkout/commit/ccc7efe))
-* content and validations for pay with button (#293) ([9076fbb](http://github.paypal.com/paypal/paypal-checkout/commit/9076fbb)), closes [#293](http://github.paypal.com/paypal/paypal-checkout/issues/293)
-* Disable phantom exitOnResourceError ([2e2c0e8](http://github.paypal.com/paypal/paypal-checkout/commit/2e2c0e8))
-* Dist ([c429908](http://github.paypal.com/paypal/paypal-checkout/commit/c429908))
-* Do not comma-separate sequences for non-minified build ([6b97143](http://github.paypal.com/paypal/paypal-checkout/commit/6b97143))
-* Do not warn about multiple legacy setup in test mode ([6d954bc](http://github.paypal.com/paypal/paypal-checkout/commit/6d954bc))
-* Enable babel caching for karma tests ([fae403d](http://github.paypal.com/paypal/paypal-checkout/commit/fae403d))
-* Enable caching for babel-loader ([50b9537](http://github.paypal.com/paypal/paypal-checkout/commit/50b9537))
-* Enable lightbox on parent when button returns onAuth ([8f8df03](http://github.paypal.com/paypal/paypal-checkout/commit/8f8df03))
-* Expose paypal.forceIframe for child windows to prevent frame-bust ([cb23b8e](http://github.paypal.com/paypal/paypal-checkout/commit/cb23b8e))
-* Fail when memory crosses over a certain threshold ([baf6ea5](http://github.paypal.com/paypal/paypal-checkout/commit/baf6ea5))
-* Fix flow errors ([515ad9e](http://github.paypal.com/paypal/paypal-checkout/commit/515ad9e))
-* Fix flow type errors ([6052dbe](http://github.paypal.com/paypal/paypal-checkout/commit/6052dbe))
-* Fix priorities of languages for each country  (#279) ([e654a3d](http://github.paypal.com/paypal/paypal-checkout/commit/e654a3d)), closes [#279](http://github.paypal.com/paypal/paypal-checkout/issues/279)
-* Flow errors should fail the build ([3a7efb1](http://github.paypal.com/paypal/paypal-checkout/commit/3a7efb1))
-* Flow type and lint fixes ([d0c167d](http://github.paypal.com/paypal/paypal-checkout/commit/d0c167d))
-* IE Compatible Header Detection (#277) ([b366106](http://github.paypal.com/paypal/paypal-checkout/commit/b366106)), closes [#277](http://github.paypal.com/paypal/paypal-checkout/issues/277)
-* IE Intranet Ineligibility Test (#283) ([801bbd8](http://github.paypal.com/paypal/paypal-checkout/commit/801bbd8)), closes [#283](http://github.paypal.com/paypal/paypal-checkout/issues/283)
-* Karma cleanup / fixes ([fa0fe27](http://github.paypal.com/paypal/paypal-checkout/commit/fa0fe27))
-* Karma Debug (#290) ([bf0850e](http://github.paypal.com/paypal/paypal-checkout/commit/bf0850e)), closes [#290](http://github.paypal.com/paypal/paypal-checkout/issues/290)
-* Make demo app faster to eval code on page changes ([037eff2](http://github.paypal.com/paypal/paypal-checkout/commit/037eff2))
-* Make logging clearer for startFlow token matching ([b6774f8](http://github.paypal.com/paypal/paypal-checkout/commit/b6774f8))
-* Only log multiple redirects for full-page redirects ([45abcc7](http://github.paypal.com/paypal/paypal-checkout/commit/45abcc7))
-* Organize checkout component templates ([18c878f](http://github.paypal.com/paypal/paypal-checkout/commit/18c878f))
-* Populate missing keys ([2a3c27f](http://github.paypal.com/paypal/paypal-checkout/commit/2a3c27f))
-* Pre-render entire button into sacrifical iframe for instant button renders ([ee713b8](http://github.paypal.com/paypal/paypal-checkout/commit/ee713b8))
-* Remove remoteRenderDomain ([1ceb779](http://github.paypal.com/paypal/paypal-checkout/commit/1ceb779))
-* Set client-side demo to use commit by default ([c97810f](http://github.paypal.com/paypal/paypal-checkout/commit/c97810f))
-* Set logLevel to warn for tests by default ([44a8ec2](http://github.paypal.com/paypal/paypal-checkout/commit/44a8ec2))
-* Support for latest xcomponent and post-robot ([f011e99](http://github.paypal.com/paypal/paypal-checkout/commit/f011e99))
-* Update README.md ([fc6d07a](http://github.paypal.com/paypal/paypal-checkout/commit/fc6d07a))
-* Update README.md ([6c1f373](http://github.paypal.com/paypal/paypal-checkout/commit/6c1f373))
-* Upgrade karma ([1c59846](http://github.paypal.com/paypal/paypal-checkout/commit/1c59846))
-* Use babel-preset-env ([2ae0fb3](http://github.paypal.com/paypal/paypal-checkout/commit/2ae0fb3))
-* Use browser locale to determine button language for pre-render ([01dbf03](http://github.paypal.com/paypal/paypal-checkout/commit/01dbf03))
+* 4.0.55 ([682e6d6](https://github.com/paypal/paypal-checkout-components/commit/682e6d6))
+* Add cross-domain-safe-weakmap to publish script ([32f4d21](https://github.com/paypal/paypal-checkout-components/commit/32f4d21))
+* Add data-paypal-checkout to test child scripts ([23aa9df](https://github.com/paypal/paypal-checkout-components/commit/23aa9df))
+* Add loglevel karma commandline option ([3dabeea](https://github.com/paypal/paypal-checkout-components/commit/3dabeea))
+* Add logs for remembered button ([816fd3f](https://github.com/paypal/paypal-checkout-components/commit/816fd3f))
+* Add pay content ([1971d47](https://github.com/paypal/paypal-checkout-components/commit/1971d47))
+* Add validation demo ([f0018d2](https://github.com/paypal/paypal-checkout-components/commit/f0018d2))
+* Add validation for button locale ([b5821d4](https://github.com/paypal/paypal-checkout-components/commit/b5821d4))
+* Add validation for buttons ([2c377fa](https://github.com/paypal/paypal-checkout-components/commit/2c377fa))
+* Add warning for bind breaking function arrity ([af15a8c](https://github.com/paypal/paypal-checkout-components/commit/af15a8c))
+* Add YouTube deep-dive to readme ([e68d7b8](https://github.com/paypal/paypal-checkout-components/commit/e68d7b8))
+* Allow publish script to take semver major/minor/patch ([3890041](https://github.com/paypal/paypal-checkout-components/commit/3890041))
+* Clean up iframe for button-in-iframe test ([ccc7efe](https://github.com/paypal/paypal-checkout-components/commit/ccc7efe))
+* content and validations for pay with button (#293) ([9076fbb](https://github.com/paypal/paypal-checkout-components/commit/9076fbb)), closes [#293](https://github.com/paypal/paypal-checkout-components/issues/293)
+* Disable phantom exitOnResourceError ([2e2c0e8](https://github.com/paypal/paypal-checkout-components/commit/2e2c0e8))
+* Dist ([c429908](https://github.com/paypal/paypal-checkout-components/commit/c429908))
+* Do not comma-separate sequences for non-minified build ([6b97143](https://github.com/paypal/paypal-checkout-components/commit/6b97143))
+* Do not warn about multiple legacy setup in test mode ([6d954bc](https://github.com/paypal/paypal-checkout-components/commit/6d954bc))
+* Enable babel caching for karma tests ([fae403d](https://github.com/paypal/paypal-checkout-components/commit/fae403d))
+* Enable caching for babel-loader ([50b9537](https://github.com/paypal/paypal-checkout-components/commit/50b9537))
+* Enable lightbox on parent when button returns onAuth ([8f8df03](https://github.com/paypal/paypal-checkout-components/commit/8f8df03))
+* Expose paypal.forceIframe for child windows to prevent frame-bust ([cb23b8e](https://github.com/paypal/paypal-checkout-components/commit/cb23b8e))
+* Fail when memory crosses over a certain threshold ([baf6ea5](https://github.com/paypal/paypal-checkout-components/commit/baf6ea5))
+* Fix flow errors ([515ad9e](https://github.com/paypal/paypal-checkout-components/commit/515ad9e))
+* Fix flow type errors ([6052dbe](https://github.com/paypal/paypal-checkout-components/commit/6052dbe))
+* Fix priorities of languages for each country  (#279) ([e654a3d](https://github.com/paypal/paypal-checkout-components/commit/e654a3d)), closes [#279](https://github.com/paypal/paypal-checkout-components/issues/279)
+* Flow errors should fail the build ([3a7efb1](https://github.com/paypal/paypal-checkout-components/commit/3a7efb1))
+* Flow type and lint fixes ([d0c167d](https://github.com/paypal/paypal-checkout-components/commit/d0c167d))
+* IE Compatible Header Detection (#277) ([b366106](https://github.com/paypal/paypal-checkout-components/commit/b366106)), closes [#277](https://github.com/paypal/paypal-checkout-components/issues/277)
+* IE Intranet Ineligibility Test (#283) ([801bbd8](https://github.com/paypal/paypal-checkout-components/commit/801bbd8)), closes [#283](https://github.com/paypal/paypal-checkout-components/issues/283)
+* Karma cleanup / fixes ([fa0fe27](https://github.com/paypal/paypal-checkout-components/commit/fa0fe27))
+* Karma Debug (#290) ([bf0850e](https://github.com/paypal/paypal-checkout-components/commit/bf0850e)), closes [#290](https://github.com/paypal/paypal-checkout-components/issues/290)
+* Make demo app faster to eval code on page changes ([037eff2](https://github.com/paypal/paypal-checkout-components/commit/037eff2))
+* Make logging clearer for startFlow token matching ([b6774f8](https://github.com/paypal/paypal-checkout-components/commit/b6774f8))
+* Only log multiple redirects for full-page redirects ([45abcc7](https://github.com/paypal/paypal-checkout-components/commit/45abcc7))
+* Organize checkout component templates ([18c878f](https://github.com/paypal/paypal-checkout-components/commit/18c878f))
+* Populate missing keys ([2a3c27f](https://github.com/paypal/paypal-checkout-components/commit/2a3c27f))
+* Pre-render entire button into sacrifical iframe for instant button renders ([ee713b8](https://github.com/paypal/paypal-checkout-components/commit/ee713b8))
+* Remove remoteRenderDomain ([1ceb779](https://github.com/paypal/paypal-checkout-components/commit/1ceb779))
+* Set client-side demo to use commit by default ([c97810f](https://github.com/paypal/paypal-checkout-components/commit/c97810f))
+* Set logLevel to warn for tests by default ([44a8ec2](https://github.com/paypal/paypal-checkout-components/commit/44a8ec2))
+* Support for latest xcomponent and post-robot ([f011e99](https://github.com/paypal/paypal-checkout-components/commit/f011e99))
+* Update README.md ([6c1f373](https://github.com/paypal/paypal-checkout-components/commit/6c1f373))
+* Update README.md ([fc6d07a](https://github.com/paypal/paypal-checkout-components/commit/fc6d07a))
+* Upgrade karma ([1c59846](https://github.com/paypal/paypal-checkout-components/commit/1c59846))
+* Use babel-preset-env ([2ae0fb3](https://github.com/paypal/paypal-checkout-components/commit/2ae0fb3))
+* Use browser locale to determine button language for pre-render ([01dbf03](https://github.com/paypal/paypal-checkout-components/commit/01dbf03))
 
 
 
 ## <small>4.0.54 (2017-03-20)</small>
 
-* Add DS_Store to gitignore ([f46114c](http://github.paypal.com/paypal/paypal-checkout/commit/f46114c))
-* Build and use checkout.js once for all tests windows ([324cb91](http://github.paypal.com/paypal/paypal-checkout/commit/324cb91))
-* Button window responsible for clicking button during tests ([d260310](http://github.paypal.com/paypal/paypal-checkout/commit/d260310))
-* Change testAction to object with test.action key ([8615f22](http://github.paypal.com/paypal/paypal-checkout/commit/8615f22))
-* Disable lonely if lint rule ([c2900ba](http://github.paypal.com/paypal/paypal-checkout/commit/c2900ba))
-* Dist ([ea592a6](http://github.paypal.com/paypal/paypal-checkout/commit/ea592a6))
-* Make karma not depend on lint ([265acf9](http://github.paypal.com/paypal/paypal-checkout/commit/265acf9))
-* Migrate to babel-plugin-istanbul from babel-plugin-__coverage__ ([fa21614](http://github.paypal.com/paypal/paypal-checkout/commit/fa21614))
-* Minor test cleanup and fixes ([873c3f5](http://github.paypal.com/paypal/paypal-checkout/commit/873c3f5))
-* Only give checkout.lib.js a module name ([de787cb](http://github.paypal.com/paypal/paypal-checkout/commit/de787cb))
-* Pass down flow in test object, to selectively enable lightbox ([2a76920](http://github.paypal.com/paypal/paypal-checkout/commit/2a76920))
-* Prevent minifying on all files (#268) ([8a5aa36](http://github.paypal.com/paypal/paypal-checkout/commit/8a5aa36)), closes [#268](http://github.paypal.com/paypal/paypal-checkout/issues/268)
-* Prevent uglify warnings ([43a111d](http://github.paypal.com/paypal/paypal-checkout/commit/43a111d))
-* Render iFrame if Firefox Mobile is detected (#269) ([c6c9573](http://github.paypal.com/paypal/paypal-checkout/commit/c6c9573)), closes [#269](http://github.paypal.com/paypal/paypal-checkout/issues/269)
-* Use correct ES6 semantics and enable tree-shaking ([b3ca908](http://github.paypal.com/paypal/paypal-checkout/commit/b3ca908))
-* Webpack 2 (#267) ([2eafd55](http://github.paypal.com/paypal/paypal-checkout/commit/2eafd55)), closes [#267](http://github.paypal.com/paypal/paypal-checkout/issues/267)
+* 4.0.54 ([3af979f](https://github.com/paypal/paypal-checkout-components/commit/3af979f))
+* Add DS_Store to gitignore ([f46114c](https://github.com/paypal/paypal-checkout-components/commit/f46114c))
+* Build and use checkout.js once for all tests windows ([324cb91](https://github.com/paypal/paypal-checkout-components/commit/324cb91))
+* Button window responsible for clicking button during tests ([d260310](https://github.com/paypal/paypal-checkout-components/commit/d260310))
+* Change testAction to object with test.action key ([8615f22](https://github.com/paypal/paypal-checkout-components/commit/8615f22))
+* Disable lonely if lint rule ([c2900ba](https://github.com/paypal/paypal-checkout-components/commit/c2900ba))
+* Dist ([ea592a6](https://github.com/paypal/paypal-checkout-components/commit/ea592a6))
+* Make karma not depend on lint ([265acf9](https://github.com/paypal/paypal-checkout-components/commit/265acf9))
+* Migrate to babel-plugin-istanbul from babel-plugin-__coverage__ ([fa21614](https://github.com/paypal/paypal-checkout-components/commit/fa21614))
+* Minor test cleanup and fixes ([873c3f5](https://github.com/paypal/paypal-checkout-components/commit/873c3f5))
+* Only give checkout.lib.js a module name ([de787cb](https://github.com/paypal/paypal-checkout-components/commit/de787cb))
+* Pass down flow in test object, to selectively enable lightbox ([2a76920](https://github.com/paypal/paypal-checkout-components/commit/2a76920))
+* Prevent minifying on all files (#268) ([8a5aa36](https://github.com/paypal/paypal-checkout-components/commit/8a5aa36)), closes [#268](https://github.com/paypal/paypal-checkout-components/issues/268)
+* Prevent uglify warnings ([43a111d](https://github.com/paypal/paypal-checkout-components/commit/43a111d))
+* Render iFrame if Firefox Mobile is detected (#269) ([c6c9573](https://github.com/paypal/paypal-checkout-components/commit/c6c9573)), closes [#269](https://github.com/paypal/paypal-checkout-components/issues/269)
+* Use correct ES6 semantics and enable tree-shaking ([b3ca908](https://github.com/paypal/paypal-checkout-components/commit/b3ca908))
+* Webpack 2 (#267) ([2eafd55](https://github.com/paypal/paypal-checkout-components/commit/2eafd55)), closes [#267](https://github.com/paypal/paypal-checkout-components/issues/267)
 
 
 
 ## <small>4.0.53 (2017-03-16)</small>
 
-* Add correct props to child loader script ([c282c38](http://github.paypal.com/paypal/paypal-checkout/commit/c282c38))
-* Clean up dependencies ([8b7c411](http://github.paypal.com/paypal/paypal-checkout/commit/8b7c411))
-* Disable Braintree demo ([545b8e3](http://github.paypal.com/paypal/paypal-checkout/commit/545b8e3))
-* Dist ([5d20c23](http://github.paypal.com/paypal/paypal-checkout/commit/5d20c23))
+* 4.0.53 ([20fa334](https://github.com/paypal/paypal-checkout-components/commit/20fa334))
+* Add correct props to child loader script ([c282c38](https://github.com/paypal/paypal-checkout-components/commit/c282c38))
+* Clean up dependencies ([8b7c411](https://github.com/paypal/paypal-checkout-components/commit/8b7c411))
+* Disable Braintree demo ([545b8e3](https://github.com/paypal/paypal-checkout-components/commit/545b8e3))
+* Dist ([5d20c23](https://github.com/paypal/paypal-checkout-components/commit/5d20c23))
 
 
 
 ## <small>4.0.52 (2017-03-15)</small>
 
-* Add checkout.child.loader.js to load the correct version of checkout.js on a child window ([b01833a](http://github.paypal.com/paypal/paypal-checkout/commit/b01833a))
-* Add parent template for button to enforce minimum width ([6790419](http://github.paypal.com/paypal/paypal-checkout/commit/6790419))
-* Allow setting different base-url for demo app ([495265f](http://github.paypal.com/paypal/paypal-checkout/commit/495265f))
-* Always refer to popup bridge as popupBridge rather than just bridge ([e3a84ee](http://github.paypal.com/paypal/paypal-checkout/commit/e3a84ee))
-* Better validation around payment prop ([5f117c2](http://github.paypal.com/paypal/paypal-checkout/commit/5f117c2))
-* Cache-bust for retried child loader ([6d3e593](http://github.paypal.com/paypal/paypal-checkout/commit/6d3e593))
-* Credit Button Demo (#261) ([abbcc62](http://github.paypal.com/paypal/paypal-checkout/commit/abbcc62)), closes [#261](http://github.paypal.com/paypal/paypal-checkout/issues/261)
-* Dist ([0157ae5](http://github.paypal.com/paypal/paypal-checkout/commit/0157ae5))
-* Dist ([2c3d8f5](http://github.paypal.com/paypal/paypal-checkout/commit/2c3d8f5))
-* Do all validation inline in props ([c1c1df0](http://github.paypal.com/paypal/paypal-checkout/commit/c1c1df0))
-* Exclude .idea universally in gitignore ([509c392](http://github.paypal.com/paypal/paypal-checkout/commit/509c392))
-* Make typecheck task depend on lint ([77f088c](http://github.paypal.com/paypal/paypal-checkout/commit/77f088c))
-* Reduce timeout for running tests locally ([0b9ea52](http://github.paypal.com/paypal/paypal-checkout/commit/0b9ea52))
-* Remove build.sh ([42d7b0a](http://github.paypal.com/paypal/paypal-checkout/commit/42d7b0a))
-* Remove renderPopupTo hack ([b36adf2](http://github.paypal.com/paypal/paypal-checkout/commit/b36adf2))
-* Revert "fix(Logger): Point client-side logs at /xoplatform/logger, not /webapps/hermes (#237)" ([ca5e395](http://github.paypal.com/paypal/paypal-checkout/commit/ca5e395)), closes [#237](http://github.paypal.com/paypal/paypal-checkout/issues/237)
-* Run tests in parent window (and maybe speed up on travis?) ([7d7a922](http://github.paypal.com/paypal/paypal-checkout/commit/7d7a922))
-* Use postBridge to refer to postRobot bridge ([b66ce11](http://github.paypal.com/paypal/paypal-checkout/commit/b66ce11))
-* Use rsync for quickbuild script ([633dd4c](http://github.paypal.com/paypal/paypal-checkout/commit/633dd4c))
+* 4.0.52 ([7497f23](https://github.com/paypal/paypal-checkout-components/commit/7497f23))
+* Add checkout.child.loader.js to load the correct version of checkout.js on a child window ([b01833a](https://github.com/paypal/paypal-checkout-components/commit/b01833a))
+* Add parent template for button to enforce minimum width ([6790419](https://github.com/paypal/paypal-checkout-components/commit/6790419))
+* Allow setting different base-url for demo app ([495265f](https://github.com/paypal/paypal-checkout-components/commit/495265f))
+* Always refer to popup bridge as popupBridge rather than just bridge ([e3a84ee](https://github.com/paypal/paypal-checkout-components/commit/e3a84ee))
+* Better validation around payment prop ([5f117c2](https://github.com/paypal/paypal-checkout-components/commit/5f117c2))
+* Cache-bust for retried child loader ([6d3e593](https://github.com/paypal/paypal-checkout-components/commit/6d3e593))
+* Credit Button Demo (#261) ([abbcc62](https://github.com/paypal/paypal-checkout-components/commit/abbcc62)), closes [#261](https://github.com/paypal/paypal-checkout-components/issues/261)
+* Dist ([0157ae5](https://github.com/paypal/paypal-checkout-components/commit/0157ae5))
+* Dist ([2c3d8f5](https://github.com/paypal/paypal-checkout-components/commit/2c3d8f5))
+* Do all validation inline in props ([c1c1df0](https://github.com/paypal/paypal-checkout-components/commit/c1c1df0))
+* Exclude .idea universally in gitignore ([509c392](https://github.com/paypal/paypal-checkout-components/commit/509c392))
+* Make typecheck task depend on lint ([77f088c](https://github.com/paypal/paypal-checkout-components/commit/77f088c))
+* Reduce timeout for running tests locally ([0b9ea52](https://github.com/paypal/paypal-checkout-components/commit/0b9ea52))
+* Remove build.sh ([42d7b0a](https://github.com/paypal/paypal-checkout-components/commit/42d7b0a))
+* Remove renderPopupTo hack ([b36adf2](https://github.com/paypal/paypal-checkout-components/commit/b36adf2))
+* Revert "fix(Logger): Point client-side logs at /xoplatform/logger, not /webapps/hermes (#237)" ([ca5e395](https://github.com/paypal/paypal-checkout-components/commit/ca5e395)), closes [#237](https://github.com/paypal/paypal-checkout-components/issues/237)
+* Run tests in parent window (and maybe speed up on travis?) ([7d7a922](https://github.com/paypal/paypal-checkout-components/commit/7d7a922))
+* Use postBridge to refer to postRobot bridge ([b66ce11](https://github.com/paypal/paypal-checkout-components/commit/b66ce11))
+* Use rsync for quickbuild script ([633dd4c](https://github.com/paypal/paypal-checkout-components/commit/633dd4c))
 
 
 
 ## <small>4.0.51 (2017-03-09)</small>
 
-* Add postinstall script to npm package ([0f9ed65](http://github.paypal.com/paypal/paypal-checkout/commit/0f9ed65))
+* 4.0.51 ([f461030](https://github.com/paypal/paypal-checkout-components/commit/f461030))
+* Add postinstall script to npm package ([0f9ed65](https://github.com/paypal/paypal-checkout-components/commit/0f9ed65))
 
 
 
 ## <small>4.0.50 (2017-03-09)</small>
 
+* 4.0.50 ([3c3c8a5](https://github.com/paypal/paypal-checkout-components/commit/3c3c8a5))
 
 
 
 ## <small>4.0.49 (2017-03-09)</small>
 
-* Add more robust post-install script to resolve flow-bin version issue ([db0b89d](http://github.paypal.com/paypal/paypal-checkout/commit/db0b89d))
-* Demo app only takes $0.01 and no-op execute in production mode ([3ac6980](http://github.paypal.com/paypal/paypal-checkout/commit/3ac6980))
-* Dist ([35430ab](http://github.paypal.com/paypal/paypal-checkout/commit/35430ab))
-* Log if same-page button is visible after render ([5bb49b0](http://github.paypal.com/paypal/paypal-checkout/commit/5bb49b0))
-* Remove v3 preventDefault for form integrations with condition ([4911fe2](http://github.paypal.com/paypal/paypal-checkout/commit/4911fe2))
-* Use correct redirect_uri for popup-bridge flow ([7c27c85](http://github.paypal.com/paypal/paypal-checkout/commit/7c27c85))
-* fix(Logger): Point client-side logs at /xoplatform/logger, not /webapps/hermes (#237) ([8111868](http://github.paypal.com/paypal/paypal-checkout/commit/8111868)), closes [#237](http://github.paypal.com/paypal/paypal-checkout/issues/237)
+* 4.0.49 ([bc3f978](https://github.com/paypal/paypal-checkout-components/commit/bc3f978))
+* Add more robust post-install script to resolve flow-bin version issue ([db0b89d](https://github.com/paypal/paypal-checkout-components/commit/db0b89d))
+* Demo app only takes $0.01 and no-op execute in production mode ([3ac6980](https://github.com/paypal/paypal-checkout-components/commit/3ac6980))
+* Dist ([35430ab](https://github.com/paypal/paypal-checkout-components/commit/35430ab))
+* Log if same-page button is visible after render ([5bb49b0](https://github.com/paypal/paypal-checkout-components/commit/5bb49b0))
+* Remove v3 preventDefault for form integrations with condition ([4911fe2](https://github.com/paypal/paypal-checkout-components/commit/4911fe2))
+* Use correct redirect_uri for popup-bridge flow ([7c27c85](https://github.com/paypal/paypal-checkout-components/commit/7c27c85))
+* fix(Logger): Point client-side logs at /xoplatform/logger, not /webapps/hermes (#237) ([8111868](https://github.com/paypal/paypal-checkout-components/commit/8111868)), closes [#237](https://github.com/paypal/paypal-checkout-components/issues/237)
 
 
 
 ## <small>4.0.48 (2017-03-08)</small>
 
-* Dist ([4b8a7f5](http://github.paypal.com/paypal/paypal-checkout/commit/4b8a7f5))
+* 4.0.48 ([ccb1594](https://github.com/paypal/paypal-checkout-components/commit/ccb1594))
+* Dist ([4b8a7f5](https://github.com/paypal/paypal-checkout-components/commit/4b8a7f5))
 
 
 
 ## <small>4.0.47 (2017-03-08)</small>
 
-* Add development quickstart docs ([524fb61](http://github.paypal.com/paypal/paypal-checkout/commit/524fb61))
-* Add tests for condition for hijack cases, and stub out tests for hybrid cases ([bae9713](http://github.paypal.com/paypal/paypal-checkout/commit/bae9713))
-* Add Travis build status on README.md (#218) ([c11a2cd](http://github.paypal.com/paypal/paypal-checkout/commit/c11a2cd)), closes [#218](http://github.paypal.com/paypal/paypal-checkout/issues/218)
-* Clear old version of flow-bin before publishing ([a02e2e9](http://github.paypal.com/paypal/paypal-checkout/commit/a02e2e9))
-* Credit button validations (#223) ([8f82206](http://github.paypal.com/paypal/paypal-checkout/commit/8f82206)), closes [#223](http://github.paypal.com/paypal/paypal-checkout/issues/223)
-* Dist ([93c20ef](http://github.paypal.com/paypal/paypal-checkout/commit/93c20ef))
-* Dockerize and document demo app (#224) ([a767c59](http://github.paypal.com/paypal/paypal-checkout/commit/a767c59)), closes [#224](http://github.paypal.com/paypal/paypal-checkout/issues/224)
-* Enable Braintree demo and use latest published scripts ([c029ab0](http://github.paypal.com/paypal/paypal-checkout/commit/c029ab0))
-* Fix indentation for build files ([a501073](http://github.paypal.com/paypal/paypal-checkout/commit/a501073))
-* Fix package.json formatting ([84b2714](http://github.paypal.com/paypal/paypal-checkout/commit/84b2714))
-* Fix WARN on npm install command (#219) ([264ef5a](http://github.paypal.com/paypal/paypal-checkout/commit/264ef5a)), closes [#219](http://github.paypal.com/paypal/paypal-checkout/issues/219)
-* Log any errors from popup bridge render ([484be97](http://github.paypal.com/paypal/paypal-checkout/commit/484be97))
-* Normalize spinner css ([446ef45](http://github.paypal.com/paypal/paypal-checkout/commit/446ef45))
-* Pass minify parameter so minimization will happen in build. (#221) ([44e1321](http://github.paypal.com/paypal/paypal-checkout/commit/44e1321)), closes [#221](http://github.paypal.com/paypal/paypal-checkout/issues/221)
-* Remove unicode line-separator characters ([c2ada02](http://github.paypal.com/paypal/paypal-checkout/commit/c2ada02))
-* Render iframe when unable to render popup from button ([66e7e68](http://github.paypal.com/paypal/paypal-checkout/commit/66e7e68))
-* Set default logLevel to info ([a3296b1](http://github.paypal.com/paypal/paypal-checkout/commit/a3296b1))
-* Use gulp-flowtype to run flow, with latest flow-bin ([e02f361](http://github.paypal.com/paypal/paypal-checkout/commit/e02f361))
-* Use vmin to size button spinner, remove sizing javascript ([6355190](http://github.paypal.com/paypal/paypal-checkout/commit/6355190))
+* 4.0.47 ([e29c180](https://github.com/paypal/paypal-checkout-components/commit/e29c180))
+* Add development quickstart docs ([524fb61](https://github.com/paypal/paypal-checkout-components/commit/524fb61))
+* Add tests for condition for hijack cases, and stub out tests for hybrid cases ([bae9713](https://github.com/paypal/paypal-checkout-components/commit/bae9713))
+* Add Travis build status on README.md (#218) ([c11a2cd](https://github.com/paypal/paypal-checkout-components/commit/c11a2cd)), closes [#218](https://github.com/paypal/paypal-checkout-components/issues/218)
+* Clear old version of flow-bin before publishing ([a02e2e9](https://github.com/paypal/paypal-checkout-components/commit/a02e2e9))
+* Credit button validations (#223) ([8f82206](https://github.com/paypal/paypal-checkout-components/commit/8f82206)), closes [#223](https://github.com/paypal/paypal-checkout-components/issues/223)
+* Dist ([93c20ef](https://github.com/paypal/paypal-checkout-components/commit/93c20ef))
+* Dockerize and document demo app (#224) ([a767c59](https://github.com/paypal/paypal-checkout-components/commit/a767c59)), closes [#224](https://github.com/paypal/paypal-checkout-components/issues/224)
+* Enable Braintree demo and use latest published scripts ([c029ab0](https://github.com/paypal/paypal-checkout-components/commit/c029ab0))
+* Fix indentation for build files ([a501073](https://github.com/paypal/paypal-checkout-components/commit/a501073))
+* Fix package.json formatting ([84b2714](https://github.com/paypal/paypal-checkout-components/commit/84b2714))
+* Fix WARN on npm install command (#219) ([264ef5a](https://github.com/paypal/paypal-checkout-components/commit/264ef5a)), closes [#219](https://github.com/paypal/paypal-checkout-components/issues/219)
+* Log any errors from popup bridge render ([484be97](https://github.com/paypal/paypal-checkout-components/commit/484be97))
+* Normalize spinner css ([446ef45](https://github.com/paypal/paypal-checkout-components/commit/446ef45))
+* Pass minify parameter so minimization will happen in build. (#221) ([44e1321](https://github.com/paypal/paypal-checkout-components/commit/44e1321)), closes [#221](https://github.com/paypal/paypal-checkout-components/issues/221)
+* Remove unicode line-separator characters ([c2ada02](https://github.com/paypal/paypal-checkout-components/commit/c2ada02))
+* Render iframe when unable to render popup from button ([66e7e68](https://github.com/paypal/paypal-checkout-components/commit/66e7e68))
+* Set default logLevel to info ([a3296b1](https://github.com/paypal/paypal-checkout-components/commit/a3296b1))
+* Use gulp-flowtype to run flow, with latest flow-bin ([e02f361](https://github.com/paypal/paypal-checkout-components/commit/e02f361))
+* Use vmin to size button spinner, remove sizing javascript ([6355190](https://github.com/paypal/paypal-checkout-components/commit/6355190))
 
 
 
 ## <small>4.0.46 (2017-03-03)</small>
 
-* Abstract out onKey method to wait for props to be set ([afde30f](http://github.paypal.com/paypal/paypal-checkout/commit/afde30f))
-* Adopt popupBridge api for webviews ([d994b41](http://github.paypal.com/paypal/paypal-checkout/commit/d994b41))
-* Allow window.ppnativexo to be set at any time, and used for any webview ([28d2c05](http://github.paypal.com/paypal/paypal-checkout/commit/28d2c05))
-* Dist ([3575f0e](http://github.paypal.com/paypal/paypal-checkout/commit/3575f0e))
-* Fix flow error ([d355c31](http://github.paypal.com/paypal/paypal-checkout/commit/d355c31))
-* Improve mark demo ([8e1f842](http://github.paypal.com/paypal/paypal-checkout/commit/8e1f842))
+* 4.0.46 ([ab0befc](https://github.com/paypal/paypal-checkout-components/commit/ab0befc))
+* Abstract out onKey method to wait for props to be set ([afde30f](https://github.com/paypal/paypal-checkout-components/commit/afde30f))
+* Adopt popupBridge api for webviews ([d994b41](https://github.com/paypal/paypal-checkout-components/commit/d994b41))
+* Allow window.ppnativexo to be set at any time, and used for any webview ([28d2c05](https://github.com/paypal/paypal-checkout-components/commit/28d2c05))
+* Dist ([3575f0e](https://github.com/paypal/paypal-checkout-components/commit/3575f0e))
+* Fix flow error ([d355c31](https://github.com/paypal/paypal-checkout-components/commit/d355c31))
+* Improve mark demo ([8e1f842](https://github.com/paypal/paypal-checkout-components/commit/8e1f842))
 
 
 
 ## <small>4.0.45 (2017-02-28)</small>
 
-* Dist ([3bb8a02](http://github.paypal.com/paypal/paypal-checkout/commit/3bb8a02))
+* 4.0.45 ([71c9e47](https://github.com/paypal/paypal-checkout-components/commit/71c9e47))
+* Dist ([3bb8a02](https://github.com/paypal/paypal-checkout-components/commit/3bb8a02))
 
 
 
 ## <small>4.0.44 (2017-02-28)</small>
 
-* Add large and responsive button sizes ([491d987](http://github.paypal.com/paypal/paypal-checkout/commit/491d987))
-* Cleanup ([ca7fd36](http://github.paypal.com/paypal/paypal-checkout/commit/ca7fd36))
-* Dist ([72f284b](http://github.paypal.com/paypal/paypal-checkout/commit/72f284b))
-* Only allow autoResize for height, for button and checkout ([402ee0f](http://github.paypal.com/paypal/paypal-checkout/commit/402ee0f))
-* Pass logLevel down as a prop ([a675143](http://github.paypal.com/paypal/paypal-checkout/commit/a675143))
-* Set initial size of small button to 42px ([99b1ea1](http://github.paypal.com/paypal/paypal-checkout/commit/99b1ea1))
-* Update to latest flow-runtime with fixed arrow function argument issue ([f92d11a](http://github.paypal.com/paypal/paypal-checkout/commit/f92d11a))
+* 4.0.44 ([367adfc](https://github.com/paypal/paypal-checkout-components/commit/367adfc))
+* Add large and responsive button sizes ([491d987](https://github.com/paypal/paypal-checkout-components/commit/491d987))
+* Cleanup ([ca7fd36](https://github.com/paypal/paypal-checkout-components/commit/ca7fd36))
+* Dist ([72f284b](https://github.com/paypal/paypal-checkout-components/commit/72f284b))
+* Only allow autoResize for height, for button and checkout ([402ee0f](https://github.com/paypal/paypal-checkout-components/commit/402ee0f))
+* Pass logLevel down as a prop ([a675143](https://github.com/paypal/paypal-checkout-components/commit/a675143))
+* Set initial size of small button to 42px ([99b1ea1](https://github.com/paypal/paypal-checkout-components/commit/99b1ea1))
+* Update to latest flow-runtime with fixed arrow function argument issue ([f92d11a](https://github.com/paypal/paypal-checkout-components/commit/f92d11a))
 
 
 
 ## <small>4.0.43 (2017-02-16)</small>
 
-* Dist ([057d42d](http://github.paypal.com/paypal/paypal-checkout/commit/057d42d))
-* Fix typo ([178c2ab](http://github.paypal.com/paypal/paypal-checkout/commit/178c2ab))
-* Fixing repo in `git remote add upstream` call (#195) ([b08298e](http://github.paypal.com/paypal/paypal-checkout/commit/b08298e)), closes [#195](http://github.paypal.com/paypal/paypal-checkout/issues/195)
-* Removed direct lint calls in instructions (#196) ([0548c9b](http://github.paypal.com/paypal/paypal-checkout/commit/0548c9b)), closes [#196](http://github.paypal.com/paypal/paypal-checkout/issues/196)
+* 4.0.43 ([a45b46b](https://github.com/paypal/paypal-checkout-components/commit/a45b46b))
+* Dist ([057d42d](https://github.com/paypal/paypal-checkout-components/commit/057d42d))
+* Fix typo ([178c2ab](https://github.com/paypal/paypal-checkout-components/commit/178c2ab))
+* Fixing repo in `git remote add upstream` call (#195) ([b08298e](https://github.com/paypal/paypal-checkout-components/commit/b08298e)), closes [#195](https://github.com/paypal/paypal-checkout-components/issues/195)
+* Removed direct lint calls in instructions (#196) ([0548c9b](https://github.com/paypal/paypal-checkout-components/commit/0548c9b)), closes [#196](https://github.com/paypal/paypal-checkout-components/issues/196)
 
 
 
 ## <small>4.0.42 (2017-02-15)</small>
 
-* Add body-parser dependency ([86232ea](http://github.paypal.com/paypal/paypal-checkout/commit/86232ea))
-* Add demo page for experience profiles ([1f6696c](http://github.paypal.com/paypal/paypal-checkout/commit/1f6696c))
-* Comment out agreements and braintree demo ([f3b1296](http://github.paypal.com/paypal/paypal-checkout/commit/f3b1296))
-* Correctly fail for json parse error in http call ([d6280f6](http://github.paypal.com/paypal/paypal-checkout/commit/d6280f6))
-* Dist ([f0636b4](http://github.paypal.com/paypal/paypal-checkout/commit/f0636b4))
-* Fix type errors ([7cfa592](http://github.paypal.com/paypal/paypal-checkout/commit/7cfa592))
-* Propagate window.ppxonative.start to child windows and frames ([8c1f686](http://github.paypal.com/paypal/paypal-checkout/commit/8c1f686))
+* 4.0.42 ([5a03afc](https://github.com/paypal/paypal-checkout-components/commit/5a03afc))
+* Add body-parser dependency ([86232ea](https://github.com/paypal/paypal-checkout-components/commit/86232ea))
+* Add demo page for experience profiles ([1f6696c](https://github.com/paypal/paypal-checkout-components/commit/1f6696c))
+* Comment out agreements and braintree demo ([f3b1296](https://github.com/paypal/paypal-checkout-components/commit/f3b1296))
+* Correctly fail for json parse error in http call ([d6280f6](https://github.com/paypal/paypal-checkout-components/commit/d6280f6))
+* Dist ([f0636b4](https://github.com/paypal/paypal-checkout-components/commit/f0636b4))
+* Fix type errors ([7cfa592](https://github.com/paypal/paypal-checkout-components/commit/7cfa592))
+* Propagate window.ppxonative.start to child windows and frames ([8c1f686](https://github.com/paypal/paypal-checkout-components/commit/8c1f686))
 
 
 
 ## <small>4.0.41 (2017-02-14)</small>
 
-* Accept a logLevel option ([f5a9a71](http://github.paypal.com/paypal/paypal-checkout/commit/f5a9a71))
-* Add demo app to build/publish jobs ([b591bb3](http://github.paypal.com/paypal/paypal-checkout/commit/b591bb3))
-* Add onRemembered callback prop to button ([7365580](http://github.paypal.com/paypal/paypal-checkout/commit/7365580))
-* Bump up default timeout for onHashChange in tests ([bcc57bf](http://github.paypal.com/paypal/paypal-checkout/commit/bcc57bf))
-* Demo app - add env toggle, css fixes ([cb211ea](http://github.paypal.com/paypal/paypal-checkout/commit/cb211ea))
-* Demo app - display button above description ([44437dc](http://github.paypal.com/paypal/paypal-checkout/commit/44437dc))
-* Dist ([69a1ee3](http://github.paypal.com/paypal/paypal-checkout/commit/69a1ee3))
-* Ensure button is correctly centered in demo ([4dcf4b6](http://github.paypal.com/paypal/paypal-checkout/commit/4dcf4b6))
-* IE css fixes for demo ([be445da](http://github.paypal.com/paypal/paypal-checkout/commit/be445da))
-* Include latest versioned file in dist ([36f02cf](http://github.paypal.com/paypal/paypal-checkout/commit/36f02cf))
-* Make intranet IE ineligible, with a warning ([b655af7](http://github.paypal.com/paypal/paypal-checkout/commit/b655af7))
-* Move demo app to react, with new design ([f9cb317](http://github.paypal.com/paypal/paypal-checkout/commit/f9cb317))
-* Remove duplicate babel preset from package.json ([498abe9](http://github.paypal.com/paypal/paypal-checkout/commit/498abe9))
-* Render js errors to page ([27718df](http://github.paypal.com/paypal/paypal-checkout/commit/27718df))
-* Set up demo app to be mounted on other express servers ([bdec9e7](http://github.paypal.com/paypal/paypal-checkout/commit/bdec9e7))
-* Test fixes for Chrome ([a76c2a4](http://github.paypal.com/paypal/paypal-checkout/commit/a76c2a4))
-* Use flow-runtime for runtime type validations in karma tests ([6f5202a](http://github.paypal.com/paypal/paypal-checkout/commit/6f5202a))
+* 4.0.41 ([b53468a](https://github.com/paypal/paypal-checkout-components/commit/b53468a))
+* Accept a logLevel option ([f5a9a71](https://github.com/paypal/paypal-checkout-components/commit/f5a9a71))
+* Add demo app to build/publish jobs ([b591bb3](https://github.com/paypal/paypal-checkout-components/commit/b591bb3))
+* Add onRemembered callback prop to button ([7365580](https://github.com/paypal/paypal-checkout-components/commit/7365580))
+* Bump up default timeout for onHashChange in tests ([bcc57bf](https://github.com/paypal/paypal-checkout-components/commit/bcc57bf))
+* Demo app - add env toggle, css fixes ([cb211ea](https://github.com/paypal/paypal-checkout-components/commit/cb211ea))
+* Demo app - display button above description ([44437dc](https://github.com/paypal/paypal-checkout-components/commit/44437dc))
+* Dist ([69a1ee3](https://github.com/paypal/paypal-checkout-components/commit/69a1ee3))
+* Ensure button is correctly centered in demo ([4dcf4b6](https://github.com/paypal/paypal-checkout-components/commit/4dcf4b6))
+* IE css fixes for demo ([be445da](https://github.com/paypal/paypal-checkout-components/commit/be445da))
+* Include latest versioned file in dist ([36f02cf](https://github.com/paypal/paypal-checkout-components/commit/36f02cf))
+* Make intranet IE ineligible, with a warning ([b655af7](https://github.com/paypal/paypal-checkout-components/commit/b655af7))
+* Move demo app to react, with new design ([f9cb317](https://github.com/paypal/paypal-checkout-components/commit/f9cb317))
+* Remove duplicate babel preset from package.json ([498abe9](https://github.com/paypal/paypal-checkout-components/commit/498abe9))
+* Render js errors to page ([27718df](https://github.com/paypal/paypal-checkout-components/commit/27718df))
+* Set up demo app to be mounted on other express servers ([bdec9e7](https://github.com/paypal/paypal-checkout-components/commit/bdec9e7))
+* Test fixes for Chrome ([a76c2a4](https://github.com/paypal/paypal-checkout-components/commit/a76c2a4))
+* Use flow-runtime for runtime type validations in karma tests ([6f5202a](https://github.com/paypal/paypal-checkout-components/commit/6f5202a))
 
 
 
 ## <small>4.0.40 (2017-02-09)</small>
 
-* Add files param to package.json to reduce file size of npm package (#184) ([fba3e45](http://github.paypal.com/paypal/paypal-checkout/commit/fba3e45)), closes [#184](http://github.paypal.com/paypal/paypal-checkout/issues/184)
-* Allow all v3 mobile users to throttle, but disable lightbox if no meta viewport ([e9968c2](http://github.paypal.com/paypal/paypal-checkout/commit/e9968c2))
-* Dist ([7c567fe](http://github.paypal.com/paypal/paypal-checkout/commit/7c567fe))
-* Simplify and comment code examples ([c114803](http://github.paypal.com/paypal/paypal-checkout/commit/c114803))
+* 4.0.40 ([b935033](https://github.com/paypal/paypal-checkout-components/commit/b935033))
+* Add files param to package.json to reduce file size of npm package (#184) ([fba3e45](https://github.com/paypal/paypal-checkout-components/commit/fba3e45)), closes [#184](https://github.com/paypal/paypal-checkout-components/issues/184)
+* Allow all v3 mobile users to throttle, but disable lightbox if no meta viewport ([e9968c2](https://github.com/paypal/paypal-checkout-components/commit/e9968c2))
+* Dist ([7c567fe](https://github.com/paypal/paypal-checkout-components/commit/7c567fe))
+* Simplify and comment code examples ([c114803](https://github.com/paypal/paypal-checkout-components/commit/c114803))
 
 
 
 ## <small>4.0.39 (2017-02-03)</small>
 
-* Add billingAgreement as alias for payment to Checkout component ([2c9fd47](http://github.paypal.com/paypal/paypal-checkout/commit/2c9fd47))
-* Add debugging docs ([240a67a](http://github.paypal.com/paypal/paypal-checkout/commit/240a67a))
-* Add displayTo tests ([6c1caa0](http://github.paypal.com/paypal/paypal-checkout/commit/6c1caa0))
-* Add karma browser timeouts ([da9c014](http://github.paypal.com/paypal/paypal-checkout/commit/da9c014))
-* Add native sdk bindings ([f752acb](http://github.paypal.com/paypal/paypal-checkout/commit/f752acb))
-* Add SlimerJS as karma option ([ae04e0a](http://github.paypal.com/paypal/paypal-checkout/commit/ae04e0a))
-* Add tests to ensure billingAgreement prop works ([e898437](http://github.paypal.com/paypal/paypal-checkout/commit/e898437))
-* Add travis retry ([6bd198a](http://github.paypal.com/paypal/paypal-checkout/commit/6bd198a))
-* Cleanup and refactoring ([3c4f954](http://github.paypal.com/paypal/paypal-checkout/commit/3c4f954))
-* Dist ([3db3c3f](http://github.paypal.com/paypal/paypal-checkout/commit/3db3c3f))
-* Do not pass stage prop when not in stage env ([57d0ef9](http://github.paypal.com/paypal/paypal-checkout/commit/57d0ef9))
-* Do not pipe out eslint result, causes a bug which deletes file contents ([9922f42](http://github.paypal.com/paypal/paypal-checkout/commit/9922f42))
-* Enable source maps ([83914e6](http://github.paypal.com/paypal/paypal-checkout/commit/83914e6))
-* Enable sourcemaps for tests ([5c2a9e1](http://github.paypal.com/paypal/paypal-checkout/commit/5c2a9e1))
-* Export PopupOpenError to be consumed by public callers ([db28533](http://github.paypal.com/paypal/paypal-checkout/commit/db28533))
-* Fix case when hijack button is rendered inside a link, inside a form ([457c2c6](http://github.paypal.com/paypal/paypal-checkout/commit/457c2c6))
-* Fix document.body type errors ([0c2c8c1](http://github.paypal.com/paypal/paypal-checkout/commit/0c2c8c1))
-* Fix error and restart tests ([a42c918](http://github.paypal.com/paypal/paypal-checkout/commit/a42c918))
-* Force checkout child to render popup to parentRenderWindow ([33f142e](http://github.paypal.com/paypal/paypal-checkout/commit/33f142e))
-* Improve memoize type checking ([ecb4e8f](http://github.paypal.com/paypal/paypal-checkout/commit/ecb4e8f))
-* Make onCancel a noop by default ([bac0d3e](http://github.paypal.com/paypal/paypal-checkout/commit/bac0d3e))
-* More tests and fixes for native integration ([cc2f843](http://github.paypal.com/paypal/paypal-checkout/commit/cc2f843))
-* Normalize headers to lowercase for request() ([a4ebfda](http://github.paypal.com/paypal/paypal-checkout/commit/a4ebfda))
-* Only log authorize checkpoint for device group ([be04fe3](http://github.paypal.com/paypal/paypal-checkout/commit/be04fe3))
-* Only run mobile throttle when the site has the correct meta viewport ([891c626](http://github.paypal.com/paypal/paypal-checkout/commit/891c626))
-* preliminary sample app to show case the different kinds of palpal-checkout integrations (#159) ([f87bfd4](http://github.paypal.com/paypal/paypal-checkout/commit/f87bfd4)), closes [#159](http://github.paypal.com/paypal/paypal-checkout/issues/159)
-* Ramp v3 mobile to 10% ([c63e08b](http://github.paypal.com/paypal/paypal-checkout/commit/c63e08b))
-* Remove hacks to enable lightbox, leave this up to button ([adefdd6](http://github.paypal.com/paypal/paypal-checkout/commit/adefdd6))
-* Remove logReturnUrl code ([81d45a6](http://github.paypal.com/paypal/paypal-checkout/commit/81d45a6))
-* Remove onPayment* aliases ([46f1ff6](http://github.paypal.com/paypal/paypal-checkout/commit/46f1ff6))
-* Remove redundant window.console.karma ([e88a11e](http://github.paypal.com/paypal/paypal-checkout/commit/e88a11e))
-* Remove separate billingAgreement field ([fa05da1](http://github.paypal.com/paypal/paypal-checkout/commit/fa05da1))
-* Send stage prop for local env as well as stage ([2d22755](http://github.paypal.com/paypal/paypal-checkout/commit/2d22755))
-* Set Travis to use Chrome ([02642e9](http://github.paypal.com/paypal/paypal-checkout/commit/02642e9))
-* Support renderTo prop to show button to remembered users ([34cfb3f](http://github.paypal.com/paypal/paypal-checkout/commit/34cfb3f))
-* Type fixes ([5849d32](http://github.paypal.com/paypal/paypal-checkout/commit/5849d32))
-* Type safety in tests ([3746bf5](http://github.paypal.com/paypal/paypal-checkout/commit/3746bf5))
-* Use vanilla js for mark example ([8b56a9f](http://github.paypal.com/paypal/paypal-checkout/commit/8b56a9f))
+* 4.0.39 ([9a2a487](https://github.com/paypal/paypal-checkout-components/commit/9a2a487))
+* Add billingAgreement as alias for payment to Checkout component ([2c9fd47](https://github.com/paypal/paypal-checkout-components/commit/2c9fd47))
+* Add debugging docs ([240a67a](https://github.com/paypal/paypal-checkout-components/commit/240a67a))
+* Add displayTo tests ([6c1caa0](https://github.com/paypal/paypal-checkout-components/commit/6c1caa0))
+* Add karma browser timeouts ([da9c014](https://github.com/paypal/paypal-checkout-components/commit/da9c014))
+* Add native sdk bindings ([f752acb](https://github.com/paypal/paypal-checkout-components/commit/f752acb))
+* Add SlimerJS as karma option ([ae04e0a](https://github.com/paypal/paypal-checkout-components/commit/ae04e0a))
+* Add tests to ensure billingAgreement prop works ([e898437](https://github.com/paypal/paypal-checkout-components/commit/e898437))
+* Add travis retry ([6bd198a](https://github.com/paypal/paypal-checkout-components/commit/6bd198a))
+* Cleanup and refactoring ([3c4f954](https://github.com/paypal/paypal-checkout-components/commit/3c4f954))
+* Dist ([3db3c3f](https://github.com/paypal/paypal-checkout-components/commit/3db3c3f))
+* Do not pass stage prop when not in stage env ([57d0ef9](https://github.com/paypal/paypal-checkout-components/commit/57d0ef9))
+* Do not pipe out eslint result, causes a bug which deletes file contents ([9922f42](https://github.com/paypal/paypal-checkout-components/commit/9922f42))
+* Enable source maps ([83914e6](https://github.com/paypal/paypal-checkout-components/commit/83914e6))
+* Enable sourcemaps for tests ([5c2a9e1](https://github.com/paypal/paypal-checkout-components/commit/5c2a9e1))
+* Export PopupOpenError to be consumed by public callers ([db28533](https://github.com/paypal/paypal-checkout-components/commit/db28533))
+* Fix case when hijack button is rendered inside a link, inside a form ([457c2c6](https://github.com/paypal/paypal-checkout-components/commit/457c2c6))
+* Fix document.body type errors ([0c2c8c1](https://github.com/paypal/paypal-checkout-components/commit/0c2c8c1))
+* Fix error and restart tests ([a42c918](https://github.com/paypal/paypal-checkout-components/commit/a42c918))
+* Force checkout child to render popup to parentRenderWindow ([33f142e](https://github.com/paypal/paypal-checkout-components/commit/33f142e))
+* Improve memoize type checking ([ecb4e8f](https://github.com/paypal/paypal-checkout-components/commit/ecb4e8f))
+* Make onCancel a noop by default ([bac0d3e](https://github.com/paypal/paypal-checkout-components/commit/bac0d3e))
+* More tests and fixes for native integration ([cc2f843](https://github.com/paypal/paypal-checkout-components/commit/cc2f843))
+* Normalize headers to lowercase for request() ([a4ebfda](https://github.com/paypal/paypal-checkout-components/commit/a4ebfda))
+* Only log authorize checkpoint for device group ([be04fe3](https://github.com/paypal/paypal-checkout-components/commit/be04fe3))
+* Only run mobile throttle when the site has the correct meta viewport ([891c626](https://github.com/paypal/paypal-checkout-components/commit/891c626))
+* preliminary sample app to show case the different kinds of palpal-checkout integrations (#159) ([f87bfd4](https://github.com/paypal/paypal-checkout-components/commit/f87bfd4)), closes [#159](https://github.com/paypal/paypal-checkout-components/issues/159)
+* Ramp v3 mobile to 10% ([c63e08b](https://github.com/paypal/paypal-checkout-components/commit/c63e08b))
+* Remove hacks to enable lightbox, leave this up to button ([adefdd6](https://github.com/paypal/paypal-checkout-components/commit/adefdd6))
+* Remove logReturnUrl code ([81d45a6](https://github.com/paypal/paypal-checkout-components/commit/81d45a6))
+* Remove onPayment* aliases ([46f1ff6](https://github.com/paypal/paypal-checkout-components/commit/46f1ff6))
+* Remove redundant window.console.karma ([e88a11e](https://github.com/paypal/paypal-checkout-components/commit/e88a11e))
+* Remove separate billingAgreement field ([fa05da1](https://github.com/paypal/paypal-checkout-components/commit/fa05da1))
+* Send stage prop for local env as well as stage ([2d22755](https://github.com/paypal/paypal-checkout-components/commit/2d22755))
+* Set Travis to use Chrome ([02642e9](https://github.com/paypal/paypal-checkout-components/commit/02642e9))
+* Support renderTo prop to show button to remembered users ([34cfb3f](https://github.com/paypal/paypal-checkout-components/commit/34cfb3f))
+* Type fixes ([5849d32](https://github.com/paypal/paypal-checkout-components/commit/5849d32))
+* Type safety in tests ([3746bf5](https://github.com/paypal/paypal-checkout-components/commit/3746bf5))
+* Use vanilla js for mark example ([8b56a9f](https://github.com/paypal/paypal-checkout-components/commit/8b56a9f))
 
 
 
 ## <small>4.0.38 (2017-01-13)</small>
 
-* Add AB test for legacy mobile in popup/lightbox ([d06517e](http://github.paypal.com/paypal/paypal-checkout/commit/d06517e))
-* Add flow annotations ([dcba31a](http://github.paypal.com/paypal/paypal-checkout/commit/dcba31a))
-* Add flow-typed and type check /test ([0c890bc](http://github.paypal.com/paypal/paypal-checkout/commit/0c890bc))
-* Add flow-typed to .flowconfig ([3a6e86f](http://github.paypal.com/paypal/paypal-checkout/commit/3a6e86f))
-* Add index.js ([7532b63](http://github.paypal.com/paypal/paypal-checkout/commit/7532b63))
-* Add return types ([73c6e75](http://github.paypal.com/paypal/paypal-checkout/commit/73c6e75))
-* Add set of flow eslint rules ([7e0b65e](http://github.paypal.com/paypal/paypal-checkout/commit/7e0b65e))
-* Add support for flow ([beb4c27](http://github.paypal.com/paypal/paypal-checkout/commit/beb4c27))
-* Add support for gulp lint --fix ([8b8c9f4](http://github.paypal.com/paypal/paypal-checkout/commit/8b8c9f4))
-* Better type safety for memoize ([6d86d2c](http://github.paypal.com/paypal/paypal-checkout/commit/6d86d2c))
-* Chai fix ([90b2b7f](http://github.paypal.com/paypal/paypal-checkout/commit/90b2b7f))
-* Dist ([c92fd96](http://github.paypal.com/paypal/paypal-checkout/commit/c92fd96))
-* Do not allow any type ([5e6dc4e](http://github.paypal.com/paypal/paypal-checkout/commit/5e6dc4e))
-* Do not use flow loose mode ([7e28f78](http://github.paypal.com/paypal/paypal-checkout/commit/7e28f78))
-* Fix flow type error ([cb6001a](http://github.paypal.com/paypal/paypal-checkout/commit/cb6001a))
-* Fix legacy fallback test ([fcd21e3](http://github.paypal.com/paypal/paypal-checkout/commit/fcd21e3))
-* Fix typechecks and tests ([2c442bb](http://github.paypal.com/paypal/paypal-checkout/commit/2c442bb))
-* Fix typo ([809aea6](http://github.paypal.com/paypal/paypal-checkout/commit/809aea6))
-* Flow fixes ([6afdc88](http://github.paypal.com/paypal/paypal-checkout/commit/6afdc88))
-* Have redirect/fallback in legacy return a non-resolving promise ([5a20519](http://github.paypal.com/paypal/paypal-checkout/commit/5a20519))
-* Lint fixes ([a4d29b8](http://github.paypal.com/paypal/paypal-checkout/commit/a4d29b8))
-* Lint src and test separately ([c034fc1](http://github.paypal.com/paypal/paypal-checkout/commit/c034fc1))
-* Remove console logs from tests ([19525c1](http://github.paypal.com/paypal/paypal-checkout/commit/19525c1))
-* Set karma mocha test timeout to 5000ms ([9db35d5](http://github.paypal.com/paypal/paypal-checkout/commit/9db35d5))
-* Statically include button.js for tests ([e93f869](http://github.paypal.com/paypal/paypal-checkout/commit/e93f869))
-* Typing and lint fixes ([b4ce633](http://github.paypal.com/paypal/paypal-checkout/commit/b4ce633))
-* Use absolute urls in README so images and links work on NPM (#155) ([e816e30](http://github.paypal.com/paypal/paypal-checkout/commit/e816e30)), closes [#155](http://github.paypal.com/paypal/paypal-checkout/issues/155)
-* Use GenericFunction rather than MemoizedFunction ([c1abdae](http://github.paypal.com/paypal/paypal-checkout/commit/c1abdae))
-* Use SyncPromise directly to play nicely with type system ([12b2cc0](http://github.paypal.com/paypal/paypal-checkout/commit/12b2cc0))
-* Use typeof window rather than window for type checks ([46e3b5d](http://github.paypal.com/paypal/paypal-checkout/commit/46e3b5d))
+* 4.0.38 ([cfbe66c](https://github.com/paypal/paypal-checkout-components/commit/cfbe66c))
+* Add AB test for legacy mobile in popup/lightbox ([d06517e](https://github.com/paypal/paypal-checkout-components/commit/d06517e))
+* Add flow annotations ([dcba31a](https://github.com/paypal/paypal-checkout-components/commit/dcba31a))
+* Add flow-typed and type check /test ([0c890bc](https://github.com/paypal/paypal-checkout-components/commit/0c890bc))
+* Add flow-typed to .flowconfig ([3a6e86f](https://github.com/paypal/paypal-checkout-components/commit/3a6e86f))
+* Add index.js ([7532b63](https://github.com/paypal/paypal-checkout-components/commit/7532b63))
+* Add return types ([73c6e75](https://github.com/paypal/paypal-checkout-components/commit/73c6e75))
+* Add set of flow eslint rules ([7e0b65e](https://github.com/paypal/paypal-checkout-components/commit/7e0b65e))
+* Add support for flow ([beb4c27](https://github.com/paypal/paypal-checkout-components/commit/beb4c27))
+* Add support for gulp lint --fix ([8b8c9f4](https://github.com/paypal/paypal-checkout-components/commit/8b8c9f4))
+* Better type safety for memoize ([6d86d2c](https://github.com/paypal/paypal-checkout-components/commit/6d86d2c))
+* Chai fix ([90b2b7f](https://github.com/paypal/paypal-checkout-components/commit/90b2b7f))
+* Dist ([c92fd96](https://github.com/paypal/paypal-checkout-components/commit/c92fd96))
+* Do not allow any type ([5e6dc4e](https://github.com/paypal/paypal-checkout-components/commit/5e6dc4e))
+* Do not use flow loose mode ([7e28f78](https://github.com/paypal/paypal-checkout-components/commit/7e28f78))
+* Fix flow type error ([cb6001a](https://github.com/paypal/paypal-checkout-components/commit/cb6001a))
+* Fix legacy fallback test ([fcd21e3](https://github.com/paypal/paypal-checkout-components/commit/fcd21e3))
+* Fix typechecks and tests ([2c442bb](https://github.com/paypal/paypal-checkout-components/commit/2c442bb))
+* Fix typo ([809aea6](https://github.com/paypal/paypal-checkout-components/commit/809aea6))
+* Flow fixes ([6afdc88](https://github.com/paypal/paypal-checkout-components/commit/6afdc88))
+* Have redirect/fallback in legacy return a non-resolving promise ([5a20519](https://github.com/paypal/paypal-checkout-components/commit/5a20519))
+* Lint fixes ([a4d29b8](https://github.com/paypal/paypal-checkout-components/commit/a4d29b8))
+* Lint src and test separately ([c034fc1](https://github.com/paypal/paypal-checkout-components/commit/c034fc1))
+* Remove console logs from tests ([19525c1](https://github.com/paypal/paypal-checkout-components/commit/19525c1))
+* Set karma mocha test timeout to 5000ms ([9db35d5](https://github.com/paypal/paypal-checkout-components/commit/9db35d5))
+* Statically include button.js for tests ([e93f869](https://github.com/paypal/paypal-checkout-components/commit/e93f869))
+* Typing and lint fixes ([b4ce633](https://github.com/paypal/paypal-checkout-components/commit/b4ce633))
+* Use absolute urls in README so images and links work on NPM (#155) ([e816e30](https://github.com/paypal/paypal-checkout-components/commit/e816e30)), closes [#155](https://github.com/paypal/paypal-checkout-components/issues/155)
+* Use GenericFunction rather than MemoizedFunction ([c1abdae](https://github.com/paypal/paypal-checkout-components/commit/c1abdae))
+* Use SyncPromise directly to play nicely with type system ([12b2cc0](https://github.com/paypal/paypal-checkout-components/commit/12b2cc0))
+* Use typeof window rather than window for type checks ([46e3b5d](https://github.com/paypal/paypal-checkout-components/commit/46e3b5d))
 
 
 
 ## <small>4.0.37 (2016-12-16)</small>
 
-* Add a test for checkout with no click event error case ([0ad6562](http://github.paypal.com/paypal/paypal-checkout/commit/0ad6562))
-* Add cancel tests for each use case ([c35afe2](http://github.paypal.com/paypal/paypal-checkout/commit/c35afe2))
-* Add karma to build task ([4909ceb](http://github.paypal.com/paypal/paypal-checkout/commit/4909ceb))
-* Add logging to REST calls ([626c2c5](http://github.paypal.com/paypal/paypal-checkout/commit/626c2c5))
-* Add test for embedded frame renderTo ([3d5595e](http://github.paypal.com/paypal/paypal-checkout/commit/3d5595e))
-* Build dist/checkout.lib.js with UMD and point index.js towards it ([3378465](http://github.paypal.com/paypal/paypal-checkout/commit/3378465))
-* Cleanup and tests ([96d2a26](http://github.paypal.com/paypal/paypal-checkout/commit/96d2a26))
-* Disallow opening window outside of click event ([af2fa35](http://github.paypal.com/paypal/paypal-checkout/commit/af2fa35))
-* Dist ([e4a05c3](http://github.paypal.com/paypal/paypal-checkout/commit/e4a05c3))
-* Handle fullpage-redirect-on-error for multiple use cases ([30a7d66](http://github.paypal.com/paypal/paypal-checkout/commit/30a7d66))
-* Legacy error cases tests and fixes ([727e6cd](http://github.paypal.com/paypal/paypal-checkout/commit/727e6cd))
-* More cleanup ([387c221](http://github.paypal.com/paypal/paypal-checkout/commit/387c221))
-* More legacy error test cases ([0493941](http://github.paypal.com/paypal/paypal-checkout/commit/0493941))
-* Refactoring and cleanup ([f5e5c45](http://github.paypal.com/paypal/paypal-checkout/commit/f5e5c45))
-* Remove test from publish.sh ([313c14c](http://github.paypal.com/paypal/paypal-checkout/commit/313c14c))
-* Run legacy error cases on both context types ([b7dd15f](http://github.paypal.com/paypal/paypal-checkout/commit/b7dd15f))
-* Test for full-page redirect for invalid env ([be01c79](http://github.paypal.com/paypal/paypal-checkout/commit/be01c79))
-* Tests and fixes for legacy onError cases ([79cb017](http://github.paypal.com/paypal/paypal-checkout/commit/79cb017))
+* 4.0.37 ([5e6760e](https://github.com/paypal/paypal-checkout-components/commit/5e6760e))
+* Add a test for checkout with no click event error case ([0ad6562](https://github.com/paypal/paypal-checkout-components/commit/0ad6562))
+* Add cancel tests for each use case ([c35afe2](https://github.com/paypal/paypal-checkout-components/commit/c35afe2))
+* Add karma to build task ([4909ceb](https://github.com/paypal/paypal-checkout-components/commit/4909ceb))
+* Add logging to REST calls ([626c2c5](https://github.com/paypal/paypal-checkout-components/commit/626c2c5))
+* Add test for embedded frame renderTo ([3d5595e](https://github.com/paypal/paypal-checkout-components/commit/3d5595e))
+* Build dist/checkout.lib.js with UMD and point index.js towards it ([3378465](https://github.com/paypal/paypal-checkout-components/commit/3378465))
+* Cleanup and tests ([96d2a26](https://github.com/paypal/paypal-checkout-components/commit/96d2a26))
+* Disallow opening window outside of click event ([af2fa35](https://github.com/paypal/paypal-checkout-components/commit/af2fa35))
+* Dist ([e4a05c3](https://github.com/paypal/paypal-checkout-components/commit/e4a05c3))
+* Handle fullpage-redirect-on-error for multiple use cases ([30a7d66](https://github.com/paypal/paypal-checkout-components/commit/30a7d66))
+* Legacy error cases tests and fixes ([727e6cd](https://github.com/paypal/paypal-checkout-components/commit/727e6cd))
+* More cleanup ([387c221](https://github.com/paypal/paypal-checkout-components/commit/387c221))
+* More legacy error test cases ([0493941](https://github.com/paypal/paypal-checkout-components/commit/0493941))
+* Refactoring and cleanup ([f5e5c45](https://github.com/paypal/paypal-checkout-components/commit/f5e5c45))
+* Remove test from publish.sh ([313c14c](https://github.com/paypal/paypal-checkout-components/commit/313c14c))
+* Run legacy error cases on both context types ([b7dd15f](https://github.com/paypal/paypal-checkout-components/commit/b7dd15f))
+* Test for full-page redirect for invalid env ([be01c79](https://github.com/paypal/paypal-checkout-components/commit/be01c79))
+* Tests and fixes for legacy onError cases ([79cb017](https://github.com/paypal/paypal-checkout-components/commit/79cb017))
 
 
 
 ## <small>4.0.36 (2016-12-09)</small>
 
-* Add throttle code to AB test full-page vs in-context ([1a8a950](http://github.paypal.com/paypal/paypal-checkout/commit/1a8a950))
-* Dist ([43e41cd](http://github.paypal.com/paypal/paypal-checkout/commit/43e41cd))
-* Update README.md ([0cb17cc](http://github.paypal.com/paypal/paypal-checkout/commit/0cb17cc))
+* 4.0.36 ([46c4349](https://github.com/paypal/paypal-checkout-components/commit/46c4349))
+* Add throttle code to AB test full-page vs in-context ([1a8a950](https://github.com/paypal/paypal-checkout-components/commit/1a8a950))
+* Dist ([43e41cd](https://github.com/paypal/paypal-checkout-components/commit/43e41cd))
+* Update README.md ([0cb17cc](https://github.com/paypal/paypal-checkout-components/commit/0cb17cc))
 
 
 
 ## <small>4.0.35 (2016-12-08)</small>
 
-* Dist ([31ac3f1](http://github.paypal.com/paypal/paypal-checkout/commit/31ac3f1))
-* Fix link to checkout.js in demos ([610c4bf](http://github.paypal.com/paypal/paypal-checkout/commit/610c4bf))
+* 4.0.35 ([8b79a82](https://github.com/paypal/paypal-checkout-components/commit/8b79a82))
+* Dist ([31ac3f1](https://github.com/paypal/paypal-checkout-components/commit/31ac3f1))
+* Fix link to checkout.js in demos ([610c4bf](https://github.com/paypal/paypal-checkout-components/commit/610c4bf))
 
 
 
 ## <small>4.0.34 (2016-12-08)</small>
 
-* Add angular demo ([0de2e67](http://github.paypal.com/paypal/paypal-checkout/commit/0de2e67))
-* Add default xcomponent timeout of 500ms for tests ([034e5c9](http://github.paypal.com/paypal/paypal-checkout/commit/034e5c9))
-* Add popout redirect tests to button ([9869a49](http://github.paypal.com/paypal/paypal-checkout/commit/9869a49))
-* Add React demo ([bbb0099](http://github.paypal.com/paypal/paypal-checkout/commit/bbb0099))
-* Add restart tests ([794d7f6](http://github.paypal.com/paypal/paypal-checkout/commit/794d7f6))
-* Add test cases for onError ([c57d113](http://github.paypal.com/paypal/paypal-checkout/commit/c57d113))
-* Add tests for popout then redirect ([077e4aa](http://github.paypal.com/paypal/paypal-checkout/commit/077e4aa))
-* Add tests for React and Angular driver integrations ([af7d728](http://github.paypal.com/paypal/paypal-checkout/commit/af7d728))
-* Dist ([e37cabe](http://github.paypal.com/paypal/paypal-checkout/commit/e37cabe))
-* Do not destroy postRobot bridges between each test ([072f35c](http://github.paypal.com/paypal/paypal-checkout/commit/072f35c))
-* Ensure errors are passed up as Error objects to onError ([3b45198](http://github.paypal.com/paypal/paypal-checkout/commit/3b45198))
-* Force iframe mode for restart ([1b9b20e](http://github.paypal.com/paypal/paypal-checkout/commit/1b9b20e))
-* Have checkout mock component call onAuth, if passed ([5333339](http://github.paypal.com/paypal/paypal-checkout/commit/5333339))
-* Return bridge promise in legacy setup call ([393bf63](http://github.paypal.com/paypal/paypal-checkout/commit/393bf63))
-* Use config.checkoutUrl rather than CHILD_URI constant ([376e2eb](http://github.paypal.com/paypal/paypal-checkout/commit/376e2eb))
+* 4.0.34 ([22ebce8](https://github.com/paypal/paypal-checkout-components/commit/22ebce8))
+* Add angular demo ([0de2e67](https://github.com/paypal/paypal-checkout-components/commit/0de2e67))
+* Add default xcomponent timeout of 500ms for tests ([034e5c9](https://github.com/paypal/paypal-checkout-components/commit/034e5c9))
+* Add popout redirect tests to button ([9869a49](https://github.com/paypal/paypal-checkout-components/commit/9869a49))
+* Add React demo ([bbb0099](https://github.com/paypal/paypal-checkout-components/commit/bbb0099))
+* Add restart tests ([794d7f6](https://github.com/paypal/paypal-checkout-components/commit/794d7f6))
+* Add test cases for onError ([c57d113](https://github.com/paypal/paypal-checkout-components/commit/c57d113))
+* Add tests for popout then redirect ([077e4aa](https://github.com/paypal/paypal-checkout-components/commit/077e4aa))
+* Add tests for React and Angular driver integrations ([af7d728](https://github.com/paypal/paypal-checkout-components/commit/af7d728))
+* Dist ([e37cabe](https://github.com/paypal/paypal-checkout-components/commit/e37cabe))
+* Do not destroy postRobot bridges between each test ([072f35c](https://github.com/paypal/paypal-checkout-components/commit/072f35c))
+* Ensure errors are passed up as Error objects to onError ([3b45198](https://github.com/paypal/paypal-checkout-components/commit/3b45198))
+* Force iframe mode for restart ([1b9b20e](https://github.com/paypal/paypal-checkout-components/commit/1b9b20e))
+* Have checkout mock component call onAuth, if passed ([5333339](https://github.com/paypal/paypal-checkout-components/commit/5333339))
+* Return bridge promise in legacy setup call ([393bf63](https://github.com/paypal/paypal-checkout-components/commit/393bf63))
+* Use config.checkoutUrl rather than CHILD_URI constant ([376e2eb](https://github.com/paypal/paypal-checkout-components/commit/376e2eb))
 
 
 
 ## <small>4.0.33 (2016-12-06)</small>
 
-* Add debugging docs ([e6404a8](http://github.paypal.com/paypal/paypal-checkout/commit/e6404a8))
-* Add debugging docs ([92e1d74](http://github.paypal.com/paypal/paypal-checkout/commit/92e1d74))
-* Add img directory to docs ([2777172](http://github.paypal.com/paypal/paypal-checkout/commit/2777172))
-* Dist ([f71117b](http://github.paypal.com/paypal/paypal-checkout/commit/f71117b))
+* 4.0.33 ([fc1cf88](https://github.com/paypal/paypal-checkout-components/commit/fc1cf88))
+* Add debugging docs ([e6404a8](https://github.com/paypal/paypal-checkout-components/commit/e6404a8))
+* Add debugging docs ([92e1d74](https://github.com/paypal/paypal-checkout-components/commit/92e1d74))
+* Add img directory to docs ([2777172](https://github.com/paypal/paypal-checkout-components/commit/2777172))
+* Dist ([f71117b](https://github.com/paypal/paypal-checkout-components/commit/f71117b))
 
 
 
 ## <small>4.0.32 (2016-12-05)</small>
 
-* Add tests for popout-from-lightbox case ([56d7b12](http://github.paypal.com/paypal/paypal-checkout/commit/56d7b12))
-* Dist ([ad92288](http://github.paypal.com/paypal/paypal-checkout/commit/ad92288))
-* Re-export config from paypal object ([a6c199c](http://github.paypal.com/paypal/paypal-checkout/commit/a6c199c))
-* Refactor test file structure ([afaf803](http://github.paypal.com/paypal/paypal-checkout/commit/afaf803))
+* 4.0.32 ([01fb6cd](https://github.com/paypal/paypal-checkout-components/commit/01fb6cd))
+* Add tests for popout-from-lightbox case ([56d7b12](https://github.com/paypal/paypal-checkout-components/commit/56d7b12))
+* Dist ([ad92288](https://github.com/paypal/paypal-checkout-components/commit/ad92288))
+* Re-export config from paypal object ([a6c199c](https://github.com/paypal/paypal-checkout-components/commit/a6c199c))
+* Refactor test file structure ([afaf803](https://github.com/paypal/paypal-checkout-components/commit/afaf803))
 
 
 
 ## <small>4.0.31 (2016-12-05)</small>
 
-* Dist ([3a7dc54](http://github.paypal.com/paypal/paypal-checkout/commit/3a7dc54))
-* Remove old code ([9c0ef90](http://github.paypal.com/paypal/paypal-checkout/commit/9c0ef90))
+* 4.0.31 ([ef36945](https://github.com/paypal/paypal-checkout-components/commit/ef36945))
+* Dist ([3a7dc54](https://github.com/paypal/paypal-checkout-components/commit/3a7dc54))
+* Remove old code ([9c0ef90](https://github.com/paypal/paypal-checkout-components/commit/9c0ef90))
 
 
 
 ## <small>4.0.30 (2016-12-05)</small>
 
-* Add beacon file ([4e92497](http://github.paypal.com/paypal/paypal-checkout/commit/4e92497))
-* Add bridge support to tests ([db0d9c5](http://github.paypal.com/paypal/paypal-checkout/commit/db0d9c5))
-* Add mock domains to tests ([5feed67](http://github.paypal.com/paypal/paypal-checkout/commit/5feed67))
-* Add validation tests ([e12f804](http://github.paypal.com/paypal/paypal-checkout/commit/e12f804))
-* Allow xcomponent to do log proxying for tests ([94eb085](http://github.paypal.com/paypal/paypal-checkout/commit/94eb085))
-* Dist ([cde88ef](http://github.paypal.com/paypal/paypal-checkout/commit/cde88ef))
-* Dist ([510150e](http://github.paypal.com/paypal/paypal-checkout/commit/510150e))
-* Do a full-page redirect for legacy integration fallbacks ([e23b165](http://github.paypal.com/paypal/paypal-checkout/commit/e23b165))
-* Do not call proxyRest methods if window closed ([1e5dc98](http://github.paypal.com/paypal/paypal-checkout/commit/1e5dc98))
-* Do not export paypal.config ([4e518fe](http://github.paypal.com/paypal/paypal-checkout/commit/4e518fe))
-* Do not export paypal.xcomponent by default ([4286a31](http://github.paypal.com/paypal/paypal-checkout/commit/4286a31))
-* Fix eslint errors ([f0628f9](http://github.paypal.com/paypal/paypal-checkout/commit/f0628f9))
-* Fix git url ([e8bf3e0](http://github.paypal.com/paypal/paypal-checkout/commit/e8bf3e0))
-* Fix protocol log ([b1ebba8](http://github.paypal.com/paypal/paypal-checkout/commit/b1ebba8))
-* Get tests working in popup-bridge mode ([88f2c6d](http://github.paypal.com/paypal/paypal-checkout/commit/88f2c6d))
-* Go to correct url / url param when BA- token passed ([e317266](http://github.paypal.com/paypal/paypal-checkout/commit/e317266))
-* More test cases ([d5d25a4](http://github.paypal.com/paypal/paypal-checkout/commit/d5d25a4))
-* Only enable lightbox for 5 minutes after auth ([ac890df](http://github.paypal.com/paypal/paypal-checkout/commit/ac890df))
-* Propagate errors up from checkout to button ([d779a9c](http://github.paypal.com/paypal/paypal-checkout/commit/d779a9c))
-* Refactor and test fallback logic ([6974db3](http://github.paypal.com/paypal/paypal-checkout/commit/6974db3))
-* Remove unused code ([cf1380a](http://github.paypal.com/paypal/paypal-checkout/commit/cf1380a))
-* Update button.md (#121) ([6bc07c2](http://github.paypal.com/paypal/paypal-checkout/commit/6bc07c2)), closes [#121](http://github.paypal.com/paypal/paypal-checkout/issues/121)
-* Update LICENSE.txt ([1ef802c](http://github.paypal.com/paypal/paypal-checkout/commit/1ef802c))
-* Update LICENSE.txt ([10fd497](http://github.paypal.com/paypal/paypal-checkout/commit/10fd497))
-* Update package.json name ([552249d](http://github.paypal.com/paypal/paypal-checkout/commit/552249d))
+* 4.0.29 ([e427779](https://github.com/paypal/paypal-checkout-components/commit/e427779))
+* 4.0.30 ([ce0b4d7](https://github.com/paypal/paypal-checkout-components/commit/ce0b4d7))
+* Add beacon file ([4e92497](https://github.com/paypal/paypal-checkout-components/commit/4e92497))
+* Add bridge support to tests ([db0d9c5](https://github.com/paypal/paypal-checkout-components/commit/db0d9c5))
+* Add mock domains to tests ([5feed67](https://github.com/paypal/paypal-checkout-components/commit/5feed67))
+* Add validation tests ([e12f804](https://github.com/paypal/paypal-checkout-components/commit/e12f804))
+* Allow xcomponent to do log proxying for tests ([94eb085](https://github.com/paypal/paypal-checkout-components/commit/94eb085))
+* Dist ([510150e](https://github.com/paypal/paypal-checkout-components/commit/510150e))
+* Dist ([cde88ef](https://github.com/paypal/paypal-checkout-components/commit/cde88ef))
+* Do a full-page redirect for legacy integration fallbacks ([e23b165](https://github.com/paypal/paypal-checkout-components/commit/e23b165))
+* Do not call proxyRest methods if window closed ([1e5dc98](https://github.com/paypal/paypal-checkout-components/commit/1e5dc98))
+* Do not export paypal.config ([4e518fe](https://github.com/paypal/paypal-checkout-components/commit/4e518fe))
+* Do not export paypal.xcomponent by default ([4286a31](https://github.com/paypal/paypal-checkout-components/commit/4286a31))
+* Fix eslint errors ([f0628f9](https://github.com/paypal/paypal-checkout-components/commit/f0628f9))
+* Fix git url ([e8bf3e0](https://github.com/paypal/paypal-checkout-components/commit/e8bf3e0))
+* Fix protocol log ([b1ebba8](https://github.com/paypal/paypal-checkout-components/commit/b1ebba8))
+* Get tests working in popup-bridge mode ([88f2c6d](https://github.com/paypal/paypal-checkout-components/commit/88f2c6d))
+* Go to correct url / url param when BA- token passed ([e317266](https://github.com/paypal/paypal-checkout-components/commit/e317266))
+* More test cases ([d5d25a4](https://github.com/paypal/paypal-checkout-components/commit/d5d25a4))
+* Only enable lightbox for 5 minutes after auth ([ac890df](https://github.com/paypal/paypal-checkout-components/commit/ac890df))
+* Propagate errors up from checkout to button ([d779a9c](https://github.com/paypal/paypal-checkout-components/commit/d779a9c))
+* Refactor and test fallback logic ([6974db3](https://github.com/paypal/paypal-checkout-components/commit/6974db3))
+* Remove unused code ([cf1380a](https://github.com/paypal/paypal-checkout-components/commit/cf1380a))
+* Update button.md (#121) ([6bc07c2](https://github.com/paypal/paypal-checkout-components/commit/6bc07c2)), closes [#121](https://github.com/paypal/paypal-checkout-components/issues/121)
+* Update LICENSE.txt ([1ef802c](https://github.com/paypal/paypal-checkout-components/commit/1ef802c))
+* Update LICENSE.txt ([10fd497](https://github.com/paypal/paypal-checkout-components/commit/10fd497))
+* Update package.json name ([552249d](https://github.com/paypal/paypal-checkout-components/commit/552249d))
 
 
 
 ## <small>4.0.28 (2016-11-18)</small>
 
-* Clean up 3pc disabled code -- handling correctly in button/checkout apps ([8af7055](http://github.paypal.com/paypal/paypal-checkout/commit/8af7055))
-* Dist ([e26ab46](http://github.paypal.com/paypal/paypal-checkout/commit/e26ab46))
-* Move beacon code into repo ([03acebd](http://github.paypal.com/paypal/paypal-checkout/commit/03acebd))
+* 4.0.28 ([b9228f6](https://github.com/paypal/paypal-checkout-components/commit/b9228f6))
+* Clean up 3pc disabled code -- handling correctly in button/checkout apps ([8af7055](https://github.com/paypal/paypal-checkout-components/commit/8af7055))
+* Dist ([e26ab46](https://github.com/paypal/paypal-checkout-components/commit/e26ab46))
+* Move beacon code into repo ([03acebd](https://github.com/paypal/paypal-checkout-components/commit/03acebd))
 
 
 
 ## <small>4.0.27 (2016-11-18)</small>
 
-* Dist ([2d200c6](http://github.paypal.com/paypal/paypal-checkout/commit/2d200c6))
-* Fix button->checkout tests ([ecd9ba0](http://github.paypal.com/paypal/paypal-checkout/commit/ecd9ba0))
-* Fixes for 3rd party cookies disabled mode in button ([a2e2918](http://github.paypal.com/paypal/paypal-checkout/commit/a2e2918))
+* 4.0.27 ([9892145](https://github.com/paypal/paypal-checkout-components/commit/9892145))
+* Dist ([2d200c6](https://github.com/paypal/paypal-checkout-components/commit/2d200c6))
+* Fix button->checkout tests ([ecd9ba0](https://github.com/paypal/paypal-checkout-components/commit/ecd9ba0))
+* Fixes for 3rd party cookies disabled mode in button ([a2e2918](https://github.com/paypal/paypal-checkout-components/commit/a2e2918))
 
 
 
 ## <small>4.0.26 (2016-11-17)</small>
 
-* Add onAuth function ([6a3d14d](http://github.paypal.com/paypal/paypal-checkout/commit/6a3d14d))
-* Dist ([f12c805](http://github.paypal.com/paypal/paypal-checkout/commit/f12c805))
+* 4.0.26 ([394ffc8](https://github.com/paypal/paypal-checkout-components/commit/394ffc8))
+* Add onAuth function ([6a3d14d](https://github.com/paypal/paypal-checkout-components/commit/6a3d14d))
+* Dist ([f12c805](https://github.com/paypal/paypal-checkout-components/commit/f12c805))
 
 
 
 ## <small>4.0.25 (2016-11-16)</small>
 
-* Dist ([1e6cca0](http://github.paypal.com/paypal/paypal-checkout/commit/1e6cca0))
-* Quick fix to enable auth requests from button in cookies disabled mode ([b39e0e1](http://github.paypal.com/paypal/paypal-checkout/commit/b39e0e1))
+* 4.0.25 ([cf91e22](https://github.com/paypal/paypal-checkout-components/commit/cf91e22))
+* Dist ([1e6cca0](https://github.com/paypal/paypal-checkout-components/commit/1e6cca0))
+* Quick fix to enable auth requests from button in cookies disabled mode ([b39e0e1](https://github.com/paypal/paypal-checkout-components/commit/b39e0e1))
 
 
 
 ## <small>4.0.24 (2016-11-16)</small>
 
-* Dist ([9219566](http://github.paypal.com/paypal/paypal-checkout/commit/9219566))
-* Extend existing window.PAYPAL if found ([1b17eec](http://github.paypal.com/paypal/paypal-checkout/commit/1b17eec))
+* 4.0.24 ([765af95](https://github.com/paypal/paypal-checkout-components/commit/765af95))
+* Dist ([9219566](https://github.com/paypal/paypal-checkout-components/commit/9219566))
+* Extend existing window.PAYPAL if found ([1b17eec](https://github.com/paypal/paypal-checkout-components/commit/1b17eec))
 
 
 
 ## <small>4.0.23 (2016-11-16)</small>
 
-* Add tests and account for another corner case for button and container case ([5eadfbe](http://github.paypal.com/paypal/paypal-checkout/commit/5eadfbe))
-* Dist ([a097bda](http://github.paypal.com/paypal/paypal-checkout/commit/a097bda))
+* 4.0.23 ([78a7ee7](https://github.com/paypal/paypal-checkout-components/commit/78a7ee7))
+* Add tests and account for another corner case for button and container case ([5eadfbe](https://github.com/paypal/paypal-checkout-components/commit/5eadfbe))
+* Dist ([a097bda](https://github.com/paypal/paypal-checkout-components/commit/a097bda))
 
 
 
 ## <small>4.0.22 (2016-11-16)</small>
 
-* Dist ([367ddc5](http://github.paypal.com/paypal/paypal-checkout/commit/367ddc5))
-* Emulate strange legacy button logic ([5a78758](http://github.paypal.com/paypal/paypal-checkout/commit/5a78758))
-* Fix to use isArray ([bcac2a1](http://github.paypal.com/paypal/paypal-checkout/commit/bcac2a1))
-* If passed options.button, ignore options.container ([3cda4ba](http://github.paypal.com/paypal/paypal-checkout/commit/3cda4ba))
+* 4.0.22 ([aa87e50](https://github.com/paypal/paypal-checkout-components/commit/aa87e50))
+* Dist ([367ddc5](https://github.com/paypal/paypal-checkout-components/commit/367ddc5))
+* Emulate strange legacy button logic ([5a78758](https://github.com/paypal/paypal-checkout-components/commit/5a78758))
+* Fix to use isArray ([bcac2a1](https://github.com/paypal/paypal-checkout-components/commit/bcac2a1))
+* If passed options.button, ignore options.container ([3cda4ba](https://github.com/paypal/paypal-checkout-components/commit/3cda4ba))
 
 
 
 ## <small>4.0.21 (2016-11-16)</small>
 
-* Add a warning for fallback ([a3ccabd](http://github.paypal.com/paypal/paypal-checkout/commit/a3ccabd))
-* Add test gulp task ([2099833](http://github.paypal.com/paypal/paypal-checkout/commit/2099833))
-* Add test to publish.sh ([9ccb2bb](http://github.paypal.com/paypal/paypal-checkout/commit/9ccb2bb))
-* Add travis.yml ([f53db4d](http://github.paypal.com/paypal/paypal-checkout/commit/f53db4d))
-* Dist ([1ca679b](http://github.paypal.com/paypal/paypal-checkout/commit/1ca679b))
-* Dist ([6fe3fdd](http://github.paypal.com/paypal/paypal-checkout/commit/6fe3fdd))
-* Ensure v4 script gets picked up as current script ([c50e533](http://github.paypal.com/paypal/paypal-checkout/commit/c50e533))
-* Log errors which make it to onError in legacy.js ([78cf375](http://github.paypal.com/paypal/paypal-checkout/commit/78cf375))
+* 4.0.21 ([895411c](https://github.com/paypal/paypal-checkout-components/commit/895411c))
+* Add a warning for fallback ([a3ccabd](https://github.com/paypal/paypal-checkout-components/commit/a3ccabd))
+* Add test gulp task ([2099833](https://github.com/paypal/paypal-checkout-components/commit/2099833))
+* Add test to publish.sh ([9ccb2bb](https://github.com/paypal/paypal-checkout-components/commit/9ccb2bb))
+* Add travis.yml ([f53db4d](https://github.com/paypal/paypal-checkout-components/commit/f53db4d))
+* Dist ([1ca679b](https://github.com/paypal/paypal-checkout-components/commit/1ca679b))
+* Dist ([6fe3fdd](https://github.com/paypal/paypal-checkout-components/commit/6fe3fdd))
+* Ensure v4 script gets picked up as current script ([c50e533](https://github.com/paypal/paypal-checkout-components/commit/c50e533))
+* Log errors which make it to onError in legacy.js ([78cf375](https://github.com/paypal/paypal-checkout-components/commit/78cf375))
 
 
 
 ## <small>4.0.20 (2016-11-15)</small>
 
-* Dist ([9b4f957](http://github.paypal.com/paypal/paypal-checkout/commit/9b4f957))
+* 4.0.20 ([b319976](https://github.com/paypal/paypal-checkout-components/commit/b319976))
+* Dist ([9b4f957](https://github.com/paypal/paypal-checkout-components/commit/9b4f957))
 
 
 
 ## <small>4.0.19 (2016-11-15)</small>
 
-* Dist ([f1ca264](http://github.paypal.com/paypal/paypal-checkout/commit/f1ca264))
-* Make setup callable once only ([9abbb3f](http://github.paypal.com/paypal/paypal-checkout/commit/9abbb3f))
+* 4.0.19 ([19ee4ee](https://github.com/paypal/paypal-checkout-components/commit/19ee4ee))
+* Dist ([f1ca264](https://github.com/paypal/paypal-checkout-components/commit/f1ca264))
+* Make setup callable once only ([9abbb3f](https://github.com/paypal/paypal-checkout-components/commit/9abbb3f))
 
 
 
 ## <small>4.0.18 (2016-11-15)</small>
 
-* Dist ([6c147c8](http://github.paypal.com/paypal/paypal-checkout/commit/6c147c8))
-* Pull in latest files during publish ([e488217](http://github.paypal.com/paypal/paypal-checkout/commit/e488217))
+* 4.0.18 ([95afb1e](https://github.com/paypal/paypal-checkout-components/commit/95afb1e))
+* Dist ([6c147c8](https://github.com/paypal/paypal-checkout-components/commit/6c147c8))
+* Pull in latest files during publish ([e488217](https://github.com/paypal/paypal-checkout-components/commit/e488217))
 
 
 
 ## <small>4.0.17 (2016-11-15)</small>
 
-* Dist ([c562818](http://github.paypal.com/paypal/paypal-checkout/commit/c562818))
-* Fix quick build script ([a05a5a8](http://github.paypal.com/paypal/paypal-checkout/commit/a05a5a8))
-* Work correctly when different url passed than specified env ([450f84d](http://github.paypal.com/paypal/paypal-checkout/commit/450f84d))
+* 4.0.17 ([4e9566e](https://github.com/paypal/paypal-checkout-components/commit/4e9566e))
+* Dist ([c562818](https://github.com/paypal/paypal-checkout-components/commit/c562818))
+* Fix quick build script ([a05a5a8](https://github.com/paypal/paypal-checkout-components/commit/a05a5a8))
+* Work correctly when different url passed than specified env ([450f84d](https://github.com/paypal/paypal-checkout-components/commit/450f84d))
 
 
 
 ## <small>4.0.16 (2016-11-15)</small>
 
-* Dist ([1af219a](http://github.paypal.com/paypal/paypal-checkout/commit/1af219a))
-* Fix gitignore rule ([a77c10a](http://github.paypal.com/paypal/paypal-checkout/commit/a77c10a))
-* Reduce redirect delay for legacy ([abb24c1](http://github.paypal.com/paypal/paypal-checkout/commit/abb24c1))
-* Remove minor versions from dist ([2a5b94f](http://github.paypal.com/paypal/paypal-checkout/commit/2a5b94f))
-* Set publish script to actually publish ([486fbac](http://github.paypal.com/paypal/paypal-checkout/commit/486fbac))
+* 4.0.16 ([cc08c54](https://github.com/paypal/paypal-checkout-components/commit/cc08c54))
+* Dist ([1af219a](https://github.com/paypal/paypal-checkout-components/commit/1af219a))
+* Fix gitignore rule ([a77c10a](https://github.com/paypal/paypal-checkout-components/commit/a77c10a))
+* Reduce redirect delay for legacy ([abb24c1](https://github.com/paypal/paypal-checkout-components/commit/abb24c1))
+* Remove minor versions from dist ([2a5b94f](https://github.com/paypal/paypal-checkout-components/commit/2a5b94f))
+* Set publish script to actually publish ([486fbac](https://github.com/paypal/paypal-checkout-components/commit/486fbac))
 
 
 
 ## <small>4.0.15 (2016-11-15)</small>
 
-* Build checkout.js, etc ([8d9dac1](http://github.paypal.com/paypal/paypal-checkout/commit/8d9dac1))
-* Dist ([2d5a6e7](http://github.paypal.com/paypal/paypal-checkout/commit/2d5a6e7))
-* Remove old dist files ([fb2b0c9](http://github.paypal.com/paypal/paypal-checkout/commit/fb2b0c9))
+* 4.0.15 ([e05c34e](https://github.com/paypal/paypal-checkout-components/commit/e05c34e))
+* Build checkout.js, etc ([8d9dac1](https://github.com/paypal/paypal-checkout-components/commit/8d9dac1))
+* Dist ([2d5a6e7](https://github.com/paypal/paypal-checkout-components/commit/2d5a6e7))
+* Remove old dist files ([fb2b0c9](https://github.com/paypal/paypal-checkout-components/commit/fb2b0c9))
 
 
 
 ## <small>4.0.14 (2016-11-14)</small>
 
-* Add all varieties of hijack test ([895a606](http://github.paypal.com/paypal/paypal-checkout/commit/895a606))
-* Add basic button demo ([69e131a](http://github.paypal.com/paypal/paypal-checkout/commit/69e131a))
-* Add button tests ([b9a586d](http://github.paypal.com/paypal/paypal-checkout/commit/b9a586d))
-* Add closeFlow check to click check ([d66a03c](http://github.paypal.com/paypal/paypal-checkout/commit/d66a03c))
-* Add custom button tests ([0e91c61](http://github.paypal.com/paypal/paypal-checkout/commit/0e91c61))
-* Add custom click tests for merchants listening on click of the button ([d906f4c](http://github.paypal.com/paypal/paypal-checkout/commit/d906f4c))
-* Add first hijack test ([c24c012](http://github.paypal.com/paypal/paypal-checkout/commit/c24c012))
-* Add legacy locale option tests ([9bab273](http://github.paypal.com/paypal/paypal-checkout/commit/9bab273))
-* Added hybrid setup/hijack tests ([b826a13](http://github.paypal.com/paypal/paypal-checkout/commit/b826a13))
-* Break out non legacy-specific code from legacy ([e4c9336](http://github.paypal.com/paypal/paypal-checkout/commit/e4c9336))
-* Bridge failure should only be a hard error for IE ([60bce7b](http://github.paypal.com/paypal/paypal-checkout/commit/60bce7b))
-* Change default prod client id ([f150195](http://github.paypal.com/paypal/paypal-checkout/commit/f150195))
-* Clean up docs ([4c07b39](http://github.paypal.com/paypal/paypal-checkout/commit/4c07b39))
-* Clean up old minor versions from dist/ ([86179d3](http://github.paypal.com/paypal/paypal-checkout/commit/86179d3))
-* Clear up old demo files ([ead9e2f](http://github.paypal.com/paypal/paypal-checkout/commit/ead9e2f))
-* Dist ([b4f554d](http://github.paypal.com/paypal/paypal-checkout/commit/b4f554d))
-* Export http ([7551579](http://github.paypal.com/paypal/paypal-checkout/commit/7551579))
-* Fail hard when env does not match startFlow url ([2a07c91](http://github.paypal.com/paypal/paypal-checkout/commit/2a07c91))
-* Fix build script ([f80f594](http://github.paypal.com/paypal/paypal-checkout/commit/f80f594))
-* Fix button renderer ([2a88125](http://github.paypal.com/paypal/paypal-checkout/commit/2a88125))
-* Fix dynamic bridge urls ([dbbf225](http://github.paypal.com/paypal/paypal-checkout/commit/dbbf225))
-* Fix for hybrid startflow ([0dd5d5f](http://github.paypal.com/paypal/paypal-checkout/commit/0dd5d5f))
-* Ignore minor version files in dist/ ([9eb1f15](http://github.paypal.com/paypal/paypal-checkout/commit/9eb1f15))
-* Locale tests and refactoring ([f38f5cc](http://github.paypal.com/paypal/paypal-checkout/commit/f38f5cc))
-* More button tests ([85b4bb4](http://github.paypal.com/paypal/paypal-checkout/commit/85b4bb4))
-* More button tests ([e0f33f8](http://github.paypal.com/paypal/paypal-checkout/commit/e0f33f8))
-* More test cases and cleanup ([5c7ebe0](http://github.paypal.com/paypal/paypal-checkout/commit/5c7ebe0))
-* Only allow ready method to be called once ([c00f653](http://github.paypal.com/paypal/paypal-checkout/commit/c00f653))
-* Promisify tests ([94b1a62](http://github.paypal.com/paypal/paypal-checkout/commit/94b1a62))
-* Ready tests and improvements ([93ebea8](http://github.paypal.com/paypal/paypal-checkout/commit/93ebea8))
-* Remove additional complexity from ready handler ([610d4d0](http://github.paypal.com/paypal/paypal-checkout/commit/610d4d0))
-* Remove resize delay ([fd5908a](http://github.paypal.com/paypal/paypal-checkout/commit/fd5908a))
-* Run tests for both popup and lightbox ([a4abf85](http://github.paypal.com/paypal/paypal-checkout/commit/a4abf85))
-* Simplify hijack case ([511c54d](http://github.paypal.com/paypal/paypal-checkout/commit/511c54d))
-* Simplify legacy compatibility layer ([a6c0926](http://github.paypal.com/paypal/paypal-checkout/commit/a6c0926))
-* Split legacy tests ([8a5bcb0](http://github.paypal.com/paypal/paypal-checkout/commit/8a5bcb0))
-* Tests refactoring ([319523d](http://github.paypal.com/paypal/paypal-checkout/commit/319523d))
-* Update contrib doc ([a106bcc](http://github.paypal.com/paypal/paypal-checkout/commit/a106bcc))
-* Use payment id by default for client side rest ([fc197f8](http://github.paypal.com/paypal/paypal-checkout/commit/fc197f8))
+* 4.0.14 ([aa1f95e](https://github.com/paypal/paypal-checkout-components/commit/aa1f95e))
+* Add all varieties of hijack test ([895a606](https://github.com/paypal/paypal-checkout-components/commit/895a606))
+* Add basic button demo ([69e131a](https://github.com/paypal/paypal-checkout-components/commit/69e131a))
+* Add button tests ([b9a586d](https://github.com/paypal/paypal-checkout-components/commit/b9a586d))
+* Add closeFlow check to click check ([d66a03c](https://github.com/paypal/paypal-checkout-components/commit/d66a03c))
+* Add custom button tests ([0e91c61](https://github.com/paypal/paypal-checkout-components/commit/0e91c61))
+* Add custom click tests for merchants listening on click of the button ([d906f4c](https://github.com/paypal/paypal-checkout-components/commit/d906f4c))
+* Add first hijack test ([c24c012](https://github.com/paypal/paypal-checkout-components/commit/c24c012))
+* Add legacy locale option tests ([9bab273](https://github.com/paypal/paypal-checkout-components/commit/9bab273))
+* Added hybrid setup/hijack tests ([b826a13](https://github.com/paypal/paypal-checkout-components/commit/b826a13))
+* Break out non legacy-specific code from legacy ([e4c9336](https://github.com/paypal/paypal-checkout-components/commit/e4c9336))
+* Bridge failure should only be a hard error for IE ([60bce7b](https://github.com/paypal/paypal-checkout-components/commit/60bce7b))
+* Change default prod client id ([f150195](https://github.com/paypal/paypal-checkout-components/commit/f150195))
+* Clean up docs ([4c07b39](https://github.com/paypal/paypal-checkout-components/commit/4c07b39))
+* Clean up old minor versions from dist/ ([86179d3](https://github.com/paypal/paypal-checkout-components/commit/86179d3))
+* Clear up old demo files ([ead9e2f](https://github.com/paypal/paypal-checkout-components/commit/ead9e2f))
+* Dist ([b4f554d](https://github.com/paypal/paypal-checkout-components/commit/b4f554d))
+* Export http ([7551579](https://github.com/paypal/paypal-checkout-components/commit/7551579))
+* Fail hard when env does not match startFlow url ([2a07c91](https://github.com/paypal/paypal-checkout-components/commit/2a07c91))
+* Fix build script ([f80f594](https://github.com/paypal/paypal-checkout-components/commit/f80f594))
+* Fix button renderer ([2a88125](https://github.com/paypal/paypal-checkout-components/commit/2a88125))
+* Fix dynamic bridge urls ([dbbf225](https://github.com/paypal/paypal-checkout-components/commit/dbbf225))
+* Fix for hybrid startflow ([0dd5d5f](https://github.com/paypal/paypal-checkout-components/commit/0dd5d5f))
+* Ignore minor version files in dist/ ([9eb1f15](https://github.com/paypal/paypal-checkout-components/commit/9eb1f15))
+* Locale tests and refactoring ([f38f5cc](https://github.com/paypal/paypal-checkout-components/commit/f38f5cc))
+* More button tests ([85b4bb4](https://github.com/paypal/paypal-checkout-components/commit/85b4bb4))
+* More button tests ([e0f33f8](https://github.com/paypal/paypal-checkout-components/commit/e0f33f8))
+* More test cases and cleanup ([5c7ebe0](https://github.com/paypal/paypal-checkout-components/commit/5c7ebe0))
+* Only allow ready method to be called once ([c00f653](https://github.com/paypal/paypal-checkout-components/commit/c00f653))
+* Promisify tests ([94b1a62](https://github.com/paypal/paypal-checkout-components/commit/94b1a62))
+* Ready tests and improvements ([93ebea8](https://github.com/paypal/paypal-checkout-components/commit/93ebea8))
+* Remove additional complexity from ready handler ([610d4d0](https://github.com/paypal/paypal-checkout-components/commit/610d4d0))
+* Remove resize delay ([fd5908a](https://github.com/paypal/paypal-checkout-components/commit/fd5908a))
+* Run tests for both popup and lightbox ([a4abf85](https://github.com/paypal/paypal-checkout-components/commit/a4abf85))
+* Simplify hijack case ([511c54d](https://github.com/paypal/paypal-checkout-components/commit/511c54d))
+* Simplify legacy compatibility layer ([a6c0926](https://github.com/paypal/paypal-checkout-components/commit/a6c0926))
+* Split legacy tests ([8a5bcb0](https://github.com/paypal/paypal-checkout-components/commit/8a5bcb0))
+* Tests refactoring ([319523d](https://github.com/paypal/paypal-checkout-components/commit/319523d))
+* Update contrib doc ([a106bcc](https://github.com/paypal/paypal-checkout-components/commit/a106bcc))
+* Use payment id by default for client side rest ([fc197f8](https://github.com/paypal/paypal-checkout-components/commit/fc197f8))
 
 
 
 ## <small>4.0.13 (2016-11-07)</small>
 
-* Add Braintree support ([92eaad1](http://github.paypal.com/paypal/paypal-checkout/commit/92eaad1))
-* Add click listener to container for legacy integrations, not button ([55e2385](http://github.paypal.com/paypal/paypal-checkout/commit/55e2385))
-* Add function to check for common errors in the page ([e96f38d](http://github.paypal.com/paypal/paypal-checkout/commit/e96f38d))
-* Add iterator shim ([5ad429b](http://github.paypal.com/paypal/paypal-checkout/commit/5ad429b))
-* Add locale prop to checkout component ([3364292](http://github.paypal.com/paypal/paypal-checkout/commit/3364292))
-* Add logger messages for broken json ([3bdd7fd](http://github.paypal.com/paypal/paypal-checkout/commit/3bdd7fd))
-* Add options to enable lightbox and bridge ([397a36d](http://github.paypal.com/paypal/paypal-checkout/commit/397a36d))
-* Add polyfills to compat ([fbc12f0](http://github.paypal.com/paypal/paypal-checkout/commit/fbc12f0))
-* Add support for experience profiles ([c750ca0](http://github.paypal.com/paypal/paypal-checkout/commit/c750ca0))
-* Add support for payments standard button ID ([78ed8b6](http://github.paypal.com/paypal/paypal-checkout/commit/78ed8b6))
-* Add temporary window.Promise shim ([dca5cdb](http://github.paypal.com/paypal/paypal-checkout/commit/dca5cdb))
-* Additional validation ([faeb88d](http://github.paypal.com/paypal/paypal-checkout/commit/faeb88d))
-* Additonal error handling around env/url ([68e4bac](http://github.paypal.com/paypal/paypal-checkout/commit/68e4bac))
-* Allow compatible browsers to message between windows ([1176152](http://github.paypal.com/paypal/paypal-checkout/commit/1176152))
-* Allow messaging into iframe to make rest requests ([4adc441](http://github.paypal.com/paypal/paypal-checkout/commit/4adc441))
-* Better detection for button click with no initxo or startflow ([589f9e6](http://github.paypal.com/paypal/paypal-checkout/commit/589f9e6))
-* Change autoExecute to commit ([6c14d72](http://github.paypal.com/paypal/paypal-checkout/commit/6c14d72))
-* Cleanup ([209ba24](http://github.paypal.com/paypal/paypal-checkout/commit/209ba24))
-* Decode uri on any token we're passed ([2b245ce](http://github.paypal.com/paypal/paypal-checkout/commit/2b245ce))
-* Default redirect to window.top ([db30a7c](http://github.paypal.com/paypal/paypal-checkout/commit/db30a7c))
-* Dist ([86aff2c](http://github.paypal.com/paypal/paypal-checkout/commit/86aff2c))
-* Do close lazily in onCancel to prevent circular unresolved promise loop with close->onClose->onCance ([98bb62f](http://github.paypal.com/paypal/paypal-checkout/commit/98bb62f))
-* Do not autoresize button ([47648c3](http://github.paypal.com/paypal/paypal-checkout/commit/47648c3))
-* Do not autoresize for devices ([960bf89](http://github.paypal.com/paypal/paypal-checkout/commit/960bf89))
-* Do not include head and body tags in parent template ([3f21029](http://github.paypal.com/paypal/paypal-checkout/commit/3f21029))
-* Do not open in click handler if initXO is not called, and log if render is called out of click event ([dfc3772](http://github.paypal.com/paypal/paypal-checkout/commit/dfc3772))
-* Docs ([39c0eb1](http://github.paypal.com/paypal/paypal-checkout/commit/39c0eb1))
-* Docs ([db2b302](http://github.paypal.com/paypal/paypal-checkout/commit/db2b302))
-* Docs ([2ae61bf](http://github.paypal.com/paypal/paypal-checkout/commit/2ae61bf))
-* Docs ([e7a680b](http://github.paypal.com/paypal/paypal-checkout/commit/e7a680b))
-* Docs ([203655d](http://github.paypal.com/paypal/paypal-checkout/commit/203655d))
-* Docs ([79f1705](http://github.paypal.com/paypal/paypal-checkout/commit/79f1705))
-* Enable Checkout in inline iframe when user is authed ([dfb65a5](http://github.paypal.com/paypal/paypal-checkout/commit/dfb65a5))
-* Export enableCheckoutIframe function ([c314b0d](http://github.paypal.com/paypal/paypal-checkout/commit/c314b0d))
-* Export version in config ([cea3e47](http://github.paypal.com/paypal/paypal-checkout/commit/cea3e47))
-* Expose paypal.checkout.win for legacy integrations which rely on it ([db8d125](http://github.paypal.com/paypal/paypal-checkout/commit/db8d125))
-* fix Lightbox scrolling for iOS (#92) ([361ccfb](http://github.paypal.com/paypal/paypal-checkout/commit/361ccfb)), closes [#92](http://github.paypal.com/paypal/paypal-checkout/issues/92)
-* fix linting ([073477e](http://github.paypal.com/paypal/paypal-checkout/commit/073477e))
-* Fix logger prefixes ([a0c3e7d](http://github.paypal.com/paypal/paypal-checkout/commit/a0c3e7d))
-* Fix query params ([026c4f5](http://github.paypal.com/paypal/paypal-checkout/commit/026c4f5))
-* Fix redirects and aliases ([a74adf6](http://github.paypal.com/paypal/paypal-checkout/commit/a74adf6))
-* Fix typo ([6ba6567](http://github.paypal.com/paypal/paypal-checkout/commit/6ba6567))
-* Fix typo ([d922b10](http://github.paypal.com/paypal/paypal-checkout/commit/d922b10))
-* Fix typo ([1b04d6e](http://github.paypal.com/paypal/paypal-checkout/commit/1b04d6e))
-* Fixes for remote rendering and redirecting ([8a96843](http://github.paypal.com/paypal/paypal-checkout/commit/8a96843))
-* Handle array of custom buttons correctly ([2630556](http://github.paypal.com/paypal/paypal-checkout/commit/2630556))
-* Handle multiple loads more gracefully ([2902933](http://github.paypal.com/paypal/paypal-checkout/commit/2902933))
-* Honor hash redirects vs full redirects using promises, rather than autocloseParentTemplate flag ([442f974](http://github.paypal.com/paypal/paypal-checkout/commit/442f974))
-* Log for initxo and startflow not called ([8c95ecf](http://github.paypal.com/paypal/paypal-checkout/commit/8c95ecf))
-* Log if button is clicked in a context which does not allow popups ([941812a](http://github.paypal.com/paypal/paypal-checkout/commit/941812a))
-* Logging and hijack fixes ([a3b8bd8](http://github.paypal.com/paypal/paypal-checkout/commit/a3b8bd8))
-* More robust click handler ([ff1eec6](http://github.paypal.com/paypal/paypal-checkout/commit/ff1eec6))
-* Only listen to click on container when a tag ([2ef7d20](http://github.paypal.com/paypal/paypal-checkout/commit/2ef7d20))
-* Only open bridge on legacy setup ([c4125af](http://github.paypal.com/paypal/paypal-checkout/commit/c4125af))
-* Only send proxyRest message from button or bridge ([0f49d40](http://github.paypal.com/paypal/paypal-checkout/commit/0f49d40))
-* Parent template head and ie9 fixes ([cb7e161](http://github.paypal.com/paypal/paypal-checkout/commit/cb7e161))
-* Prop to disable Lightbox rendering on mobile devices that contain no viewport or screen size less th ([b672453](http://github.paypal.com/paypal/paypal-checkout/commit/b672453)), closes [#91](http://github.paypal.com/paypal/paypal-checkout/issues/91)
-* Remove Braintree client ([61ba70d](http://github.paypal.com/paypal/paypal-checkout/commit/61ba70d))
-* Remove paypal.Checkout docs ([efe08fc](http://github.paypal.com/paypal/paypal-checkout/commit/efe08fc))
-* Remove paypal.Checkout docs ([a7d1aa7](http://github.paypal.com/paypal/paypal-checkout/commit/a7d1aa7))
-* Restructuring ([9ed4ed3](http://github.paypal.com/paypal/paypal-checkout/commit/9ed4ed3))
-* Send commit flag to child ([e716dc6](http://github.paypal.com/paypal/paypal-checkout/commit/e716dc6))
-* Set correct urlPrefix for current environment ([251b623](http://github.paypal.com/paypal/paypal-checkout/commit/251b623))
-* Set size units in px ([f733b13](http://github.paypal.com/paypal/paypal-checkout/commit/f733b13))
-* Support XDomainRequest in request method ([e1e548b](http://github.paypal.com/paypal/paypal-checkout/commit/e1e548b))
-* Update docs to use latest public api ([c4283ae](http://github.paypal.com/paypal/paypal-checkout/commit/c4283ae))
-* upgrading beaver-logger, new settings for button js (#82) ([7dde44e](http://github.paypal.com/paypal/paypal-checkout/commit/7dde44e)), closes [#82](http://github.paypal.com/paypal/paypal-checkout/issues/82)
-* Use 3rd party base64 lib, to support ie9 ([1a6d36f](http://github.paypal.com/paypal/paypal-checkout/commit/1a6d36f))
-* Use button.style prop ([7a799c5](http://github.paypal.com/paypal/paypal-checkout/commit/7a799c5))
-* Use CSS for all lightbox sizing and animations ([1062d9b](http://github.paypal.com/paypal/paypal-checkout/commit/1062d9b))
-* Use file name as module name ([41e8e3b](http://github.paypal.com/paypal/paypal-checkout/commit/41e8e3b))
-* Various compatibility fixes ([df09f54](http://github.paypal.com/paypal/paypal-checkout/commit/df09f54))
-* Wait for document ready to listen on body click ([b6571ad](http://github.paypal.com/paypal/paypal-checkout/commit/b6571ad))
-* Wait for onAuthorize and onCancel to complete before closing Checkout ([2cf4fad](http://github.paypal.com/paypal/paypal-checkout/commit/2cf4fad))
-* Warn for init without setup ([6799ecb](http://github.paypal.com/paypal/paypal-checkout/commit/6799ecb))
+* 4.0.13 ([719fd56](https://github.com/paypal/paypal-checkout-components/commit/719fd56))
+* Add Braintree support ([92eaad1](https://github.com/paypal/paypal-checkout-components/commit/92eaad1))
+* Add click listener to container for legacy integrations, not button ([55e2385](https://github.com/paypal/paypal-checkout-components/commit/55e2385))
+* Add function to check for common errors in the page ([e96f38d](https://github.com/paypal/paypal-checkout-components/commit/e96f38d))
+* Add iterator shim ([5ad429b](https://github.com/paypal/paypal-checkout-components/commit/5ad429b))
+* Add locale prop to checkout component ([3364292](https://github.com/paypal/paypal-checkout-components/commit/3364292))
+* Add logger messages for broken json ([3bdd7fd](https://github.com/paypal/paypal-checkout-components/commit/3bdd7fd))
+* Add options to enable lightbox and bridge ([397a36d](https://github.com/paypal/paypal-checkout-components/commit/397a36d))
+* Add polyfills to compat ([fbc12f0](https://github.com/paypal/paypal-checkout-components/commit/fbc12f0))
+* Add support for experience profiles ([c750ca0](https://github.com/paypal/paypal-checkout-components/commit/c750ca0))
+* Add support for payments standard button ID ([78ed8b6](https://github.com/paypal/paypal-checkout-components/commit/78ed8b6))
+* Add temporary window.Promise shim ([dca5cdb](https://github.com/paypal/paypal-checkout-components/commit/dca5cdb))
+* Additional validation ([faeb88d](https://github.com/paypal/paypal-checkout-components/commit/faeb88d))
+* Additonal error handling around env/url ([68e4bac](https://github.com/paypal/paypal-checkout-components/commit/68e4bac))
+* Allow compatible browsers to message between windows ([1176152](https://github.com/paypal/paypal-checkout-components/commit/1176152))
+* Allow messaging into iframe to make rest requests ([4adc441](https://github.com/paypal/paypal-checkout-components/commit/4adc441))
+* Better detection for button click with no initxo or startflow ([589f9e6](https://github.com/paypal/paypal-checkout-components/commit/589f9e6))
+* Change autoExecute to commit ([6c14d72](https://github.com/paypal/paypal-checkout-components/commit/6c14d72))
+* Cleanup ([209ba24](https://github.com/paypal/paypal-checkout-components/commit/209ba24))
+* Decode uri on any token we're passed ([2b245ce](https://github.com/paypal/paypal-checkout-components/commit/2b245ce))
+* Default redirect to window.top ([db30a7c](https://github.com/paypal/paypal-checkout-components/commit/db30a7c))
+* Dist ([86aff2c](https://github.com/paypal/paypal-checkout-components/commit/86aff2c))
+* Do close lazily in onCancel to prevent circular unresolved promise loop with close->onClose->onCance ([98bb62f](https://github.com/paypal/paypal-checkout-components/commit/98bb62f))
+* Do not autoresize button ([47648c3](https://github.com/paypal/paypal-checkout-components/commit/47648c3))
+* Do not autoresize for devices ([960bf89](https://github.com/paypal/paypal-checkout-components/commit/960bf89))
+* Do not include head and body tags in parent template ([3f21029](https://github.com/paypal/paypal-checkout-components/commit/3f21029))
+* Do not open in click handler if initXO is not called, and log if render is called out of click event ([dfc3772](https://github.com/paypal/paypal-checkout-components/commit/dfc3772))
+* Docs ([e7a680b](https://github.com/paypal/paypal-checkout-components/commit/e7a680b))
+* Docs ([db2b302](https://github.com/paypal/paypal-checkout-components/commit/db2b302))
+* Docs ([39c0eb1](https://github.com/paypal/paypal-checkout-components/commit/39c0eb1))
+* Docs ([79f1705](https://github.com/paypal/paypal-checkout-components/commit/79f1705))
+* Docs ([203655d](https://github.com/paypal/paypal-checkout-components/commit/203655d))
+* Docs ([2ae61bf](https://github.com/paypal/paypal-checkout-components/commit/2ae61bf))
+* Enable Checkout in inline iframe when user is authed ([dfb65a5](https://github.com/paypal/paypal-checkout-components/commit/dfb65a5))
+* Export enableCheckoutIframe function ([c314b0d](https://github.com/paypal/paypal-checkout-components/commit/c314b0d))
+* Export version in config ([cea3e47](https://github.com/paypal/paypal-checkout-components/commit/cea3e47))
+* Expose paypal.checkout.win for legacy integrations which rely on it ([db8d125](https://github.com/paypal/paypal-checkout-components/commit/db8d125))
+* fix Lightbox scrolling for iOS (#92) ([361ccfb](https://github.com/paypal/paypal-checkout-components/commit/361ccfb)), closes [#92](https://github.com/paypal/paypal-checkout-components/issues/92)
+* fix linting ([073477e](https://github.com/paypal/paypal-checkout-components/commit/073477e))
+* Fix logger prefixes ([a0c3e7d](https://github.com/paypal/paypal-checkout-components/commit/a0c3e7d))
+* Fix query params ([026c4f5](https://github.com/paypal/paypal-checkout-components/commit/026c4f5))
+* Fix redirects and aliases ([a74adf6](https://github.com/paypal/paypal-checkout-components/commit/a74adf6))
+* Fix typo ([d922b10](https://github.com/paypal/paypal-checkout-components/commit/d922b10))
+* Fix typo ([6ba6567](https://github.com/paypal/paypal-checkout-components/commit/6ba6567))
+* Fix typo ([1b04d6e](https://github.com/paypal/paypal-checkout-components/commit/1b04d6e))
+* Fixes for remote rendering and redirecting ([8a96843](https://github.com/paypal/paypal-checkout-components/commit/8a96843))
+* Handle array of custom buttons correctly ([2630556](https://github.com/paypal/paypal-checkout-components/commit/2630556))
+* Handle multiple loads more gracefully ([2902933](https://github.com/paypal/paypal-checkout-components/commit/2902933))
+* Honor hash redirects vs full redirects using promises, rather than autocloseParentTemplate flag ([442f974](https://github.com/paypal/paypal-checkout-components/commit/442f974))
+* Log for initxo and startflow not called ([8c95ecf](https://github.com/paypal/paypal-checkout-components/commit/8c95ecf))
+* Log if button is clicked in a context which does not allow popups ([941812a](https://github.com/paypal/paypal-checkout-components/commit/941812a))
+* Logging and hijack fixes ([a3b8bd8](https://github.com/paypal/paypal-checkout-components/commit/a3b8bd8))
+* More robust click handler ([ff1eec6](https://github.com/paypal/paypal-checkout-components/commit/ff1eec6))
+* Only listen to click on container when a tag ([2ef7d20](https://github.com/paypal/paypal-checkout-components/commit/2ef7d20))
+* Only open bridge on legacy setup ([c4125af](https://github.com/paypal/paypal-checkout-components/commit/c4125af))
+* Only send proxyRest message from button or bridge ([0f49d40](https://github.com/paypal/paypal-checkout-components/commit/0f49d40))
+* Parent template head and ie9 fixes ([cb7e161](https://github.com/paypal/paypal-checkout-components/commit/cb7e161))
+* Prop to disable Lightbox rendering on mobile devices that contain no viewport or screen size less th ([b672453](https://github.com/paypal/paypal-checkout-components/commit/b672453)), closes [#91](https://github.com/paypal/paypal-checkout-components/issues/91)
+* Remove Braintree client ([61ba70d](https://github.com/paypal/paypal-checkout-components/commit/61ba70d))
+* Remove paypal.Checkout docs ([a7d1aa7](https://github.com/paypal/paypal-checkout-components/commit/a7d1aa7))
+* Remove paypal.Checkout docs ([efe08fc](https://github.com/paypal/paypal-checkout-components/commit/efe08fc))
+* Restructuring ([9ed4ed3](https://github.com/paypal/paypal-checkout-components/commit/9ed4ed3))
+* Send commit flag to child ([e716dc6](https://github.com/paypal/paypal-checkout-components/commit/e716dc6))
+* Set correct urlPrefix for current environment ([251b623](https://github.com/paypal/paypal-checkout-components/commit/251b623))
+* Set size units in px ([f733b13](https://github.com/paypal/paypal-checkout-components/commit/f733b13))
+* Support XDomainRequest in request method ([e1e548b](https://github.com/paypal/paypal-checkout-components/commit/e1e548b))
+* Update docs to use latest public api ([c4283ae](https://github.com/paypal/paypal-checkout-components/commit/c4283ae))
+* upgrading beaver-logger, new settings for button js (#82) ([7dde44e](https://github.com/paypal/paypal-checkout-components/commit/7dde44e)), closes [#82](https://github.com/paypal/paypal-checkout-components/issues/82)
+* Use 3rd party base64 lib, to support ie9 ([1a6d36f](https://github.com/paypal/paypal-checkout-components/commit/1a6d36f))
+* Use button.style prop ([7a799c5](https://github.com/paypal/paypal-checkout-components/commit/7a799c5))
+* Use CSS for all lightbox sizing and animations ([1062d9b](https://github.com/paypal/paypal-checkout-components/commit/1062d9b))
+* Use file name as module name ([41e8e3b](https://github.com/paypal/paypal-checkout-components/commit/41e8e3b))
+* Various compatibility fixes ([df09f54](https://github.com/paypal/paypal-checkout-components/commit/df09f54))
+* Wait for document ready to listen on body click ([b6571ad](https://github.com/paypal/paypal-checkout-components/commit/b6571ad))
+* Wait for onAuthorize and onCancel to complete before closing Checkout ([2cf4fad](https://github.com/paypal/paypal-checkout-components/commit/2cf4fad))
+* Warn for init without setup ([6799ecb](https://github.com/paypal/paypal-checkout-components/commit/6799ecb))
 
 
 
 ## <small>4.0.12 (2016-10-04)</small>
 
-* Add additional checkpoints ([f687eb7](http://github.paypal.com/paypal/paypal-checkout/commit/f687eb7))
-* Add more logs and checkpoints ([dc774b0](http://github.paypal.com/paypal/paypal-checkout/commit/dc774b0))
-* Add quickbuild script ([40f5929](http://github.paypal.com/paypal/paypal-checkout/commit/40f5929))
-* Add tests for legacy compatibility layer ([7b0709f](http://github.paypal.com/paypal/paypal-checkout/commit/7b0709f))
-* Added support for calling components with env, and loading bridge on render ([505639a](http://github.paypal.com/paypal/paypal-checkout/commit/505639a))
-* adding locale prop (#55) ([6ccecfd](http://github.paypal.com/paypal/paypal-checkout/commit/6ccecfd)), closes [#55](http://github.paypal.com/paypal/paypal-checkout/issues/55)
-* Additional warnings and safeguards ([36e7f31](http://github.paypal.com/paypal/paypal-checkout/commit/36e7f31))
-* Clarify docs ([5b53264](http://github.paypal.com/paypal/paypal-checkout/commit/5b53264))
-* Dist ([3f9fd4c](http://github.paypal.com/paypal/paypal-checkout/commit/3f9fd4c))
-* Enable autoExecute flag ([2726764](http://github.paypal.com/paypal/paypal-checkout/commit/2726764))
-* Export paypal.request for ease of calling server to call paypal rest api ([8b9dfb8](http://github.paypal.com/paypal/paypal-checkout/commit/8b9dfb8))
-* exposing public isEligible()  (#62) ([68644b8](http://github.paypal.com/paypal/paypal-checkout/commit/68644b8)), closes [#62](http://github.paypal.com/paypal/paypal-checkout/issues/62)
-* Fix test for ineligible with only token ([55091cc](http://github.paypal.com/paypal/paypal-checkout/commit/55091cc))
-* Fixes for latest post-robot ([64bd660](http://github.paypal.com/paypal/paypal-checkout/commit/64bd660))
-* Flush logs before redirecting ([b744dca](http://github.paypal.com/paypal/paypal-checkout/commit/b744dca))
-* Make initial height of lightbox 300px ([d2fbfd0](http://github.paypal.com/paypal/paypal-checkout/commit/d2fbfd0))
-* Make legacy integration layer more functional ([5086488](http://github.paypal.com/paypal/paypal-checkout/commit/5086488))
-* Make sure bridge is used in tests ([ef38b7a](http://github.paypal.com/paypal/paypal-checkout/commit/ef38b7a))
-* Miscellaneous (#61) ([e3533f4](http://github.paypal.com/paypal/paypal-checkout/commit/e3533f4)), closes [#61](http://github.paypal.com/paypal/paypal-checkout/issues/61)
-* More logs for domain match ([f314b9b](http://github.paypal.com/paypal/paypal-checkout/commit/f314b9b))
-* More tests and fixes for legacy compatibility layer ([5042504](http://github.paypal.com/paypal/paypal-checkout/commit/5042504))
-* Normalize component names in docs ([d7ba557](http://github.paypal.com/paypal/paypal-checkout/commit/d7ba557))
-* Open bridge after calling paypal.checkout.setup with the correct env ([c64c3ce](http://github.paypal.com/paypal/paypal-checkout/commit/c64c3ce))
-* Refactor legacy interface ([af5adde](http://github.paypal.com/paypal/paypal-checkout/commit/af5adde))
-* Replace ppxo with paypal ([3d6bcc3](http://github.paypal.com/paypal/paypal-checkout/commit/3d6bcc3))
-* return a string instead of an object for locale ([43b813e](http://github.paypal.com/paypal/paypal-checkout/commit/43b813e))
-* Tests for ineligible full page redirect ([2820d03](http://github.paypal.com/paypal/paypal-checkout/commit/2820d03))
-* Update docs ([5655b6e](http://github.paypal.com/paypal/paypal-checkout/commit/5655b6e))
-* Updated docs ([97e19a1](http://github.paypal.com/paypal/paypal-checkout/commit/97e19a1))
-* Updated docs ([d515aff](http://github.paypal.com/paypal/paypal-checkout/commit/d515aff))
-* Updated docs ([68401ec](http://github.paypal.com/paypal/paypal-checkout/commit/68401ec))
-* Updated docs ([fcd6343](http://github.paypal.com/paypal/paypal-checkout/commit/fcd6343))
-* Updated docs ([0ce67a3](http://github.paypal.com/paypal/paypal-checkout/commit/0ce67a3))
-* Updated docs ([68b99e0](http://github.paypal.com/paypal/paypal-checkout/commit/68b99e0))
-* Updated docs ([42472c9](http://github.paypal.com/paypal/paypal-checkout/commit/42472c9))
-* Updated docs ([2c47b75](http://github.paypal.com/paypal/paypal-checkout/commit/2c47b75))
-* Updated docs ([856a6f3](http://github.paypal.com/paypal/paypal-checkout/commit/856a6f3))
-* Upgrade post-robot ([f8f64bb](http://github.paypal.com/paypal/paypal-checkout/commit/f8f64bb))
-* feat(gulp): Task to start web server and run live demo (#48) ([0233d73](http://github.paypal.com/paypal/paypal-checkout/commit/0233d73)), closes [#48](http://github.paypal.com/paypal/paypal-checkout/issues/48)
+* 4.0.12 ([03488e5](https://github.com/paypal/paypal-checkout-components/commit/03488e5))
+* Add additional checkpoints ([f687eb7](https://github.com/paypal/paypal-checkout-components/commit/f687eb7))
+* Add more logs and checkpoints ([dc774b0](https://github.com/paypal/paypal-checkout-components/commit/dc774b0))
+* Add quickbuild script ([40f5929](https://github.com/paypal/paypal-checkout-components/commit/40f5929))
+* Add tests for legacy compatibility layer ([7b0709f](https://github.com/paypal/paypal-checkout-components/commit/7b0709f))
+* Added support for calling components with env, and loading bridge on render ([505639a](https://github.com/paypal/paypal-checkout-components/commit/505639a))
+* adding locale prop (#55) ([6ccecfd](https://github.com/paypal/paypal-checkout-components/commit/6ccecfd)), closes [#55](https://github.com/paypal/paypal-checkout-components/issues/55)
+* Additional warnings and safeguards ([36e7f31](https://github.com/paypal/paypal-checkout-components/commit/36e7f31))
+* Clarify docs ([5b53264](https://github.com/paypal/paypal-checkout-components/commit/5b53264))
+* Dist ([3f9fd4c](https://github.com/paypal/paypal-checkout-components/commit/3f9fd4c))
+* Enable autoExecute flag ([2726764](https://github.com/paypal/paypal-checkout-components/commit/2726764))
+* Export paypal.request for ease of calling server to call paypal rest api ([8b9dfb8](https://github.com/paypal/paypal-checkout-components/commit/8b9dfb8))
+* exposing public isEligible()  (#62) ([68644b8](https://github.com/paypal/paypal-checkout-components/commit/68644b8)), closes [#62](https://github.com/paypal/paypal-checkout-components/issues/62)
+* Fix test for ineligible with only token ([55091cc](https://github.com/paypal/paypal-checkout-components/commit/55091cc))
+* Fixes for latest post-robot ([64bd660](https://github.com/paypal/paypal-checkout-components/commit/64bd660))
+* Flush logs before redirecting ([b744dca](https://github.com/paypal/paypal-checkout-components/commit/b744dca))
+* Make initial height of lightbox 300px ([d2fbfd0](https://github.com/paypal/paypal-checkout-components/commit/d2fbfd0))
+* Make legacy integration layer more functional ([5086488](https://github.com/paypal/paypal-checkout-components/commit/5086488))
+* Make sure bridge is used in tests ([ef38b7a](https://github.com/paypal/paypal-checkout-components/commit/ef38b7a))
+* Miscellaneous (#61) ([e3533f4](https://github.com/paypal/paypal-checkout-components/commit/e3533f4)), closes [#61](https://github.com/paypal/paypal-checkout-components/issues/61)
+* More logs for domain match ([f314b9b](https://github.com/paypal/paypal-checkout-components/commit/f314b9b))
+* More tests and fixes for legacy compatibility layer ([5042504](https://github.com/paypal/paypal-checkout-components/commit/5042504))
+* Normalize component names in docs ([d7ba557](https://github.com/paypal/paypal-checkout-components/commit/d7ba557))
+* Open bridge after calling paypal.checkout.setup with the correct env ([c64c3ce](https://github.com/paypal/paypal-checkout-components/commit/c64c3ce))
+* Refactor legacy interface ([af5adde](https://github.com/paypal/paypal-checkout-components/commit/af5adde))
+* Replace ppxo with paypal ([3d6bcc3](https://github.com/paypal/paypal-checkout-components/commit/3d6bcc3))
+* return a string instead of an object for locale ([43b813e](https://github.com/paypal/paypal-checkout-components/commit/43b813e))
+* Tests for ineligible full page redirect ([2820d03](https://github.com/paypal/paypal-checkout-components/commit/2820d03))
+* Update docs ([5655b6e](https://github.com/paypal/paypal-checkout-components/commit/5655b6e))
+* Updated docs ([0ce67a3](https://github.com/paypal/paypal-checkout-components/commit/0ce67a3))
+* Updated docs ([68401ec](https://github.com/paypal/paypal-checkout-components/commit/68401ec))
+* Updated docs ([68b99e0](https://github.com/paypal/paypal-checkout-components/commit/68b99e0))
+* Updated docs ([d515aff](https://github.com/paypal/paypal-checkout-components/commit/d515aff))
+* Updated docs ([42472c9](https://github.com/paypal/paypal-checkout-components/commit/42472c9))
+* Updated docs ([fcd6343](https://github.com/paypal/paypal-checkout-components/commit/fcd6343))
+* Updated docs ([856a6f3](https://github.com/paypal/paypal-checkout-components/commit/856a6f3))
+* Updated docs ([2c47b75](https://github.com/paypal/paypal-checkout-components/commit/2c47b75))
+* Updated docs ([97e19a1](https://github.com/paypal/paypal-checkout-components/commit/97e19a1))
+* Upgrade post-robot ([f8f64bb](https://github.com/paypal/paypal-checkout-components/commit/f8f64bb))
+* feat(gulp): Task to start web server and run live demo (#48) ([0233d73](https://github.com/paypal/paypal-checkout-components/commit/0233d73)), closes [#48](https://github.com/paypal/paypal-checkout-components/issues/48)
 
 
 
 ## <small>4.0.11 (2016-09-15)</small>
 
-* Add a resize delay to account for transition time ([3f5ca85](http://github.paypal.com/paypal/paypal-checkout/commit/3f5ca85))
-* Add BillingAgreement component, better env-url handling ([092fac2](http://github.paypal.com/paypal/paypal-checkout/commit/092fac2))
-* Add button component ([2d9a7e7](http://github.paypal.com/paypal/paypal-checkout/commit/2d9a7e7))
-* Add button doc ([5ce8507](http://github.paypal.com/paypal/paypal-checkout/commit/5ce8507))
-* Add button doc ([787c4d6](http://github.paypal.com/paypal/paypal-checkout/commit/787c4d6))
-* Add button doc ([18dc3d5](http://github.paypal.com/paypal/paypal-checkout/commit/18dc3d5))
-* Add button doc ([0451b4c](http://github.paypal.com/paypal/paypal-checkout/commit/0451b4c))
-* Add button doc ([327284f](http://github.paypal.com/paypal/paypal-checkout/commit/327284f))
-* Add button doc ([39cd5cd](http://github.paypal.com/paypal/paypal-checkout/commit/39cd5cd))
-* Add button doc ([4f94f9f](http://github.paypal.com/paypal/paypal-checkout/commit/4f94f9f))
-* Add button doc ([53e16a2](http://github.paypal.com/paypal/paypal-checkout/commit/53e16a2))
-* Add button doc ([0ecd9c1](http://github.paypal.com/paypal/paypal-checkout/commit/0ecd9c1))
-* Add button doc ([466b9f8](http://github.paypal.com/paypal/paypal-checkout/commit/466b9f8))
-* Add button doc ([11a9816](http://github.paypal.com/paypal/paypal-checkout/commit/11a9816))
-* Add button doc ([d619486](http://github.paypal.com/paypal/paypal-checkout/commit/d619486))
-* Add button doc ([e1fa83e](http://github.paypal.com/paypal/paypal-checkout/commit/e1fa83e))
-* Add button doc ([8b3989e](http://github.paypal.com/paypal/paypal-checkout/commit/8b3989e))
-* Add button doc ([84f55f2](http://github.paypal.com/paypal/paypal-checkout/commit/84f55f2))
-* Add button doc ([eeeae5b](http://github.paypal.com/paypal/paypal-checkout/commit/eeeae5b))
-* Add button doc ([750f076](http://github.paypal.com/paypal/paypal-checkout/commit/750f076))
-* Add button doc ([f4268f8](http://github.paypal.com/paypal/paypal-checkout/commit/f4268f8))
-* Add button doc ([cfd459d](http://github.paypal.com/paypal/paypal-checkout/commit/cfd459d))
-* Add checkpoints to measure ramp/conversion ([483d4aa](http://github.paypal.com/paypal/paypal-checkout/commit/483d4aa))
-* Add component template spinner for button ([a92689e](http://github.paypal.com/paypal/paypal-checkout/commit/a92689e))
-* Add correct dimensions for different button sizes ([f298025](http://github.paypal.com/paypal/paypal-checkout/commit/f298025))
-* Add instructions for sandbox ([e7129ec](http://github.paypal.com/paypal/paypal-checkout/commit/e7129ec))
-* Add onClick callback to button ([7fdc9ec](http://github.paypal.com/paypal/paypal-checkout/commit/7fdc9ec))
-* Add parent template styles ([0d19c09](http://github.paypal.com/paypal/paypal-checkout/commit/0d19c09))
-* Added locale prop ([11eca19](http://github.paypal.com/paypal/paypal-checkout/commit/11eca19))
-* Added support for client side token creation ([b4546e1](http://github.paypal.com/paypal/paypal-checkout/commit/b4546e1))
-* Additional safeguards and logging ([5bd5ad7](http://github.paypal.com/paypal/paypal-checkout/commit/5bd5ad7))
-* Allow billingToken to be sent to child ([416d2ee](http://github.paypal.com/paypal/paypal-checkout/commit/416d2ee))
-* Allow list of elements to be passed in options.buttons ([60c3e14](http://github.paypal.com/paypal/paypal-checkout/commit/60c3e14))
-* Assume user is logged in after having completed a transaction ([739eb9b](http://github.paypal.com/paypal/paypal-checkout/commit/739eb9b))
-* Break props validation into common lib ([753d104](http://github.paypal.com/paypal/paypal-checkout/commit/753d104))
-* Default options.environment when invalid env passed ([910e76f](http://github.paypal.com/paypal/paypal-checkout/commit/910e76f))
-* Dist ([ccd94ea](http://github.paypal.com/paypal/paypal-checkout/commit/ccd94ea))
-* Do not pass event to click handlers expecting error, and raise a warning ([cdb6fbf](http://github.paypal.com/paypal/paypal-checkout/commit/cdb6fbf))
-* Ensure onClose is promisified ([8f23cbc](http://github.paypal.com/paypal/paypal-checkout/commit/8f23cbc))
-* Exclude mobile devices from v4 ramp for now ([e6097a3](http://github.paypal.com/paypal/paypal-checkout/commit/e6097a3))
-* Extra Docs ([6ecb84c](http://github.paypal.com/paypal/paypal-checkout/commit/6ecb84c))
-* Extra Docs ([9ce92ba](http://github.paypal.com/paypal/paypal-checkout/commit/9ce92ba))
-* Extra Docs ([985e6f8](http://github.paypal.com/paypal/paypal-checkout/commit/985e6f8))
-* Fix button options present check ([f3be051](http://github.paypal.com/paypal/paypal-checkout/commit/f3be051))
-* Fix button rendering code ([6e6033f](http://github.paypal.com/paypal/paypal-checkout/commit/6e6033f))
-* Fix config envs ([70e8d45](http://github.paypal.com/paypal/paypal-checkout/commit/70e8d45))
-* Fix default cancel and return urls ([c0555f5](http://github.paypal.com/paypal/paypal-checkout/commit/c0555f5))
-* Fix demo to prevent default on custom click handlers ([e5542d9](http://github.paypal.com/paypal/paypal-checkout/commit/e5542d9))
-* Fix full page redirects ([bc6f22f](http://github.paypal.com/paypal/paypal-checkout/commit/bc6f22f))
-* Fix heights for button component ([e9296e1](http://github.paypal.com/paypal/paypal-checkout/commit/e9296e1))
-* Fix typo ([d1c5439](http://github.paypal.com/paypal/paypal-checkout/commit/d1c5439))
-* Fix typo ([b7720d8](http://github.paypal.com/paypal/paypal-checkout/commit/b7720d8))
-* Fix url regex ([217e047](http://github.paypal.com/paypal/paypal-checkout/commit/217e047))
-* If container and buttons passed, prioritize buttons and raise a warning ([621f07b](http://github.paypal.com/paypal/paypal-checkout/commit/621f07b))
-* Improve button element code and log warnings ([27550fb](http://github.paypal.com/paypal/paypal-checkout/commit/27550fb))
-* Improve startFlow logic ([9d3de64](http://github.paypal.com/paypal/paypal-checkout/commit/9d3de64))
-* Improve startFlow logic ([080d54b](http://github.paypal.com/paypal/paypal-checkout/commit/080d54b))
-* In case of error from rendering paypal checkout component, redirect to full page ([083b57c](http://github.paypal.com/paypal/paypal-checkout/commit/083b57c))
-* Legacy fallback incontext support ([5a8af21](http://github.paypal.com/paypal/paypal-checkout/commit/5a8af21))
-* Log if url is a match with cancel url ([5c57376](http://github.paypal.com/paypal/paypal-checkout/commit/5c57376))
-* More conversion and error logging ([8808ff2](http://github.paypal.com/paypal/paypal-checkout/commit/8808ff2))
-* More envs and better env decisioning ([6cfe57e](http://github.paypal.com/paypal/paypal-checkout/commit/6cfe57e))
-* Only call onPaymentCancel if we have been given a paymentToken and cancelUrl in init ([8f73a4d](http://github.paypal.com/paypal/paypal-checkout/commit/8f73a4d))
-* Only decorate callbacks if they exist ([e9833f7](http://github.paypal.com/paypal/paypal-checkout/commit/e9833f7))
-* Pass env and stage props to child ([6b67384](http://github.paypal.com/paypal/paypal-checkout/commit/6b67384))
-* Raise a warning when no target element is found for form hijack case ([4c4cdba](http://github.paypal.com/paypal/paypal-checkout/commit/4c4cdba))
-* Remove readme section on legacy to avoid confusion ([f977c5d](http://github.paypal.com/paypal/paypal-checkout/commit/f977c5d))
-* Send billingToken to child for button ([aeefb84](http://github.paypal.com/paypal/paypal-checkout/commit/aeefb84))
-* Simplify button handling logic ([d3b844e](http://github.paypal.com/paypal/paypal-checkout/commit/d3b844e))
-* Support creating billing agreement tokens ([e66f55f](http://github.paypal.com/paypal/paypal-checkout/commit/e66f55f))
-* Support making create token request through bridge ([88bc671](http://github.paypal.com/paypal/paypal-checkout/commit/88bc671))
-* Switch from payNow to autoExecute ([e54bb24](http://github.paypal.com/paypal/paypal-checkout/commit/e54bb24))
-* Update docs ([95d612a](http://github.paypal.com/paypal/paypal-checkout/commit/95d612a))
-* Updated docs with client side EC ([bec76e3](http://github.paypal.com/paypal/paypal-checkout/commit/bec76e3))
-* Use new format for default props ([0590417](http://github.paypal.com/paypal/paypal-checkout/commit/0590417))
-* Use prod hermes for live_demo ([eb60e82](http://github.paypal.com/paypal/paypal-checkout/commit/eb60e82))
+* 4.0.11 ([b1ac505](https://github.com/paypal/paypal-checkout-components/commit/b1ac505))
+* Add a resize delay to account for transition time ([3f5ca85](https://github.com/paypal/paypal-checkout-components/commit/3f5ca85))
+* Add BillingAgreement component, better env-url handling ([092fac2](https://github.com/paypal/paypal-checkout-components/commit/092fac2))
+* Add button component ([2d9a7e7](https://github.com/paypal/paypal-checkout-components/commit/2d9a7e7))
+* Add button doc ([cfd459d](https://github.com/paypal/paypal-checkout-components/commit/cfd459d))
+* Add button doc ([f4268f8](https://github.com/paypal/paypal-checkout-components/commit/f4268f8))
+* Add button doc ([750f076](https://github.com/paypal/paypal-checkout-components/commit/750f076))
+* Add button doc ([eeeae5b](https://github.com/paypal/paypal-checkout-components/commit/eeeae5b))
+* Add button doc ([84f55f2](https://github.com/paypal/paypal-checkout-components/commit/84f55f2))
+* Add button doc ([8b3989e](https://github.com/paypal/paypal-checkout-components/commit/8b3989e))
+* Add button doc ([e1fa83e](https://github.com/paypal/paypal-checkout-components/commit/e1fa83e))
+* Add button doc ([d619486](https://github.com/paypal/paypal-checkout-components/commit/d619486))
+* Add button doc ([11a9816](https://github.com/paypal/paypal-checkout-components/commit/11a9816))
+* Add button doc ([466b9f8](https://github.com/paypal/paypal-checkout-components/commit/466b9f8))
+* Add button doc ([0ecd9c1](https://github.com/paypal/paypal-checkout-components/commit/0ecd9c1))
+* Add button doc ([53e16a2](https://github.com/paypal/paypal-checkout-components/commit/53e16a2))
+* Add button doc ([4f94f9f](https://github.com/paypal/paypal-checkout-components/commit/4f94f9f))
+* Add button doc ([39cd5cd](https://github.com/paypal/paypal-checkout-components/commit/39cd5cd))
+* Add button doc ([327284f](https://github.com/paypal/paypal-checkout-components/commit/327284f))
+* Add button doc ([5ce8507](https://github.com/paypal/paypal-checkout-components/commit/5ce8507))
+* Add button doc ([0451b4c](https://github.com/paypal/paypal-checkout-components/commit/0451b4c))
+* Add button doc ([18dc3d5](https://github.com/paypal/paypal-checkout-components/commit/18dc3d5))
+* Add button doc ([787c4d6](https://github.com/paypal/paypal-checkout-components/commit/787c4d6))
+* Add checkpoints to measure ramp/conversion ([483d4aa](https://github.com/paypal/paypal-checkout-components/commit/483d4aa))
+* Add component template spinner for button ([a92689e](https://github.com/paypal/paypal-checkout-components/commit/a92689e))
+* Add correct dimensions for different button sizes ([f298025](https://github.com/paypal/paypal-checkout-components/commit/f298025))
+* Add instructions for sandbox ([e7129ec](https://github.com/paypal/paypal-checkout-components/commit/e7129ec))
+* Add onClick callback to button ([7fdc9ec](https://github.com/paypal/paypal-checkout-components/commit/7fdc9ec))
+* Add parent template styles ([0d19c09](https://github.com/paypal/paypal-checkout-components/commit/0d19c09))
+* Added locale prop ([11eca19](https://github.com/paypal/paypal-checkout-components/commit/11eca19))
+* Added support for client side token creation ([b4546e1](https://github.com/paypal/paypal-checkout-components/commit/b4546e1))
+* Additional safeguards and logging ([5bd5ad7](https://github.com/paypal/paypal-checkout-components/commit/5bd5ad7))
+* Allow billingToken to be sent to child ([416d2ee](https://github.com/paypal/paypal-checkout-components/commit/416d2ee))
+* Allow list of elements to be passed in options.buttons ([60c3e14](https://github.com/paypal/paypal-checkout-components/commit/60c3e14))
+* Assume user is logged in after having completed a transaction ([739eb9b](https://github.com/paypal/paypal-checkout-components/commit/739eb9b))
+* Break props validation into common lib ([753d104](https://github.com/paypal/paypal-checkout-components/commit/753d104))
+* Default options.environment when invalid env passed ([910e76f](https://github.com/paypal/paypal-checkout-components/commit/910e76f))
+* Dist ([ccd94ea](https://github.com/paypal/paypal-checkout-components/commit/ccd94ea))
+* Do not pass event to click handlers expecting error, and raise a warning ([cdb6fbf](https://github.com/paypal/paypal-checkout-components/commit/cdb6fbf))
+* Ensure onClose is promisified ([8f23cbc](https://github.com/paypal/paypal-checkout-components/commit/8f23cbc))
+* Exclude mobile devices from v4 ramp for now ([e6097a3](https://github.com/paypal/paypal-checkout-components/commit/e6097a3))
+* Extra Docs ([985e6f8](https://github.com/paypal/paypal-checkout-components/commit/985e6f8))
+* Extra Docs ([9ce92ba](https://github.com/paypal/paypal-checkout-components/commit/9ce92ba))
+* Extra Docs ([6ecb84c](https://github.com/paypal/paypal-checkout-components/commit/6ecb84c))
+* Fix button options present check ([f3be051](https://github.com/paypal/paypal-checkout-components/commit/f3be051))
+* Fix button rendering code ([6e6033f](https://github.com/paypal/paypal-checkout-components/commit/6e6033f))
+* Fix config envs ([70e8d45](https://github.com/paypal/paypal-checkout-components/commit/70e8d45))
+* Fix default cancel and return urls ([c0555f5](https://github.com/paypal/paypal-checkout-components/commit/c0555f5))
+* Fix demo to prevent default on custom click handlers ([e5542d9](https://github.com/paypal/paypal-checkout-components/commit/e5542d9))
+* Fix full page redirects ([bc6f22f](https://github.com/paypal/paypal-checkout-components/commit/bc6f22f))
+* Fix heights for button component ([e9296e1](https://github.com/paypal/paypal-checkout-components/commit/e9296e1))
+* Fix typo ([d1c5439](https://github.com/paypal/paypal-checkout-components/commit/d1c5439))
+* Fix typo ([b7720d8](https://github.com/paypal/paypal-checkout-components/commit/b7720d8))
+* Fix url regex ([217e047](https://github.com/paypal/paypal-checkout-components/commit/217e047))
+* If container and buttons passed, prioritize buttons and raise a warning ([621f07b](https://github.com/paypal/paypal-checkout-components/commit/621f07b))
+* Improve button element code and log warnings ([27550fb](https://github.com/paypal/paypal-checkout-components/commit/27550fb))
+* Improve startFlow logic ([9d3de64](https://github.com/paypal/paypal-checkout-components/commit/9d3de64))
+* Improve startFlow logic ([080d54b](https://github.com/paypal/paypal-checkout-components/commit/080d54b))
+* In case of error from rendering paypal checkout component, redirect to full page ([083b57c](https://github.com/paypal/paypal-checkout-components/commit/083b57c))
+* Legacy fallback incontext support ([5a8af21](https://github.com/paypal/paypal-checkout-components/commit/5a8af21))
+* Log if url is a match with cancel url ([5c57376](https://github.com/paypal/paypal-checkout-components/commit/5c57376))
+* More conversion and error logging ([8808ff2](https://github.com/paypal/paypal-checkout-components/commit/8808ff2))
+* More envs and better env decisioning ([6cfe57e](https://github.com/paypal/paypal-checkout-components/commit/6cfe57e))
+* Only call onPaymentCancel if we have been given a paymentToken and cancelUrl in init ([8f73a4d](https://github.com/paypal/paypal-checkout-components/commit/8f73a4d))
+* Only decorate callbacks if they exist ([e9833f7](https://github.com/paypal/paypal-checkout-components/commit/e9833f7))
+* Pass env and stage props to child ([6b67384](https://github.com/paypal/paypal-checkout-components/commit/6b67384))
+* Raise a warning when no target element is found for form hijack case ([4c4cdba](https://github.com/paypal/paypal-checkout-components/commit/4c4cdba))
+* Remove readme section on legacy to avoid confusion ([f977c5d](https://github.com/paypal/paypal-checkout-components/commit/f977c5d))
+* Send billingToken to child for button ([aeefb84](https://github.com/paypal/paypal-checkout-components/commit/aeefb84))
+* Simplify button handling logic ([d3b844e](https://github.com/paypal/paypal-checkout-components/commit/d3b844e))
+* Support creating billing agreement tokens ([e66f55f](https://github.com/paypal/paypal-checkout-components/commit/e66f55f))
+* Support making create token request through bridge ([88bc671](https://github.com/paypal/paypal-checkout-components/commit/88bc671))
+* Switch from payNow to autoExecute ([e54bb24](https://github.com/paypal/paypal-checkout-components/commit/e54bb24))
+* Update docs ([95d612a](https://github.com/paypal/paypal-checkout-components/commit/95d612a))
+* Updated docs with client side EC ([bec76e3](https://github.com/paypal/paypal-checkout-components/commit/bec76e3))
+* Use new format for default props ([0590417](https://github.com/paypal/paypal-checkout-components/commit/0590417))
+* Use prod hermes for live_demo ([eb60e82](https://github.com/paypal/paypal-checkout-components/commit/eb60e82))
 
 
 
 ## <small>4.0.10 (2016-08-26)</small>
 
-* Dist ([567bd72](http://github.paypal.com/paypal/paypal-checkout/commit/567bd72))
+* 4.0.10 ([92cdc3a](https://github.com/paypal/paypal-checkout-components/commit/92cdc3a))
+* Dist ([567bd72](https://github.com/paypal/paypal-checkout-components/commit/567bd72))
 
 
 
 ## <small>4.0.9 (2016-08-26)</small>
 
-* Dist ([4e6f61b](http://github.paypal.com/paypal/paypal-checkout/commit/4e6f61b))
-* Show hidden buttons on document load ([8d3dc20](http://github.paypal.com/paypal/paypal-checkout/commit/8d3dc20))
+* 4.0.9 ([9ca0d1d](https://github.com/paypal/paypal-checkout-components/commit/9ca0d1d))
+* Dist ([4e6f61b](https://github.com/paypal/paypal-checkout-components/commit/4e6f61b))
+* Show hidden buttons on document load ([8d3dc20](https://github.com/paypal/paypal-checkout-components/commit/8d3dc20))
 
 
 
 ## <small>4.0.8 (2016-08-25)</small>
 
-* Add correct z-index for overlay ([afb1f17](http://github.paypal.com/paypal/paypal-checkout/commit/afb1f17))
-* Better onDocumentReady ([7f2d2ac](http://github.paypal.com/paypal/paypal-checkout/commit/7f2d2ac))
-* Check for existence of this.props.onPaymentCancel ([54e9c47](http://github.paypal.com/paypal/paypal-checkout/commit/54e9c47))
-* Dist ([581afe4](http://github.paypal.com/paypal/paypal-checkout/commit/581afe4))
-* Do not clear interval until document is ready ([2a8cc1d](http://github.paypal.com/paypal/paypal-checkout/commit/2a8cc1d))
-* Do not preventDefault on click ([7262318](http://github.paypal.com/paypal/paypal-checkout/commit/7262318))
-* Ensure box-sizing does not affect spinner sie ([5cc18d6](http://github.paypal.com/paypal/paypal-checkout/commit/5cc18d6))
-* Export onPossiblyUnhandledException; ([e3c6823](http://github.paypal.com/paypal/paypal-checkout/commit/e3c6823))
-* Fix for startFlow with custom url ([d8008f9](http://github.paypal.com/paypal/paypal-checkout/commit/d8008f9))
-* Fix paypalCheckoutReady ([13374f6](http://github.paypal.com/paypal/paypal-checkout/commit/13374f6))
-* Limit to global export for now, to avoid issue when loaded into page with global define function ([cb6a9e6](http://github.paypal.com/paypal/paypal-checkout/commit/cb6a9e6))
-* Match legacy logic for determining target element ([efb565a](http://github.paypal.com/paypal/paypal-checkout/commit/efb565a))
-* Rely on xcomponent to provide fixed position for overlay container ([ed9bbe8](http://github.paypal.com/paypal/paypal-checkout/commit/ed9bbe8))
+* 4.0.8 ([f4aa4ee](https://github.com/paypal/paypal-checkout-components/commit/f4aa4ee))
+* Add correct z-index for overlay ([afb1f17](https://github.com/paypal/paypal-checkout-components/commit/afb1f17))
+* Better onDocumentReady ([7f2d2ac](https://github.com/paypal/paypal-checkout-components/commit/7f2d2ac))
+* Check for existence of this.props.onPaymentCancel ([54e9c47](https://github.com/paypal/paypal-checkout-components/commit/54e9c47))
+* Dist ([581afe4](https://github.com/paypal/paypal-checkout-components/commit/581afe4))
+* Do not clear interval until document is ready ([2a8cc1d](https://github.com/paypal/paypal-checkout-components/commit/2a8cc1d))
+* Do not preventDefault on click ([7262318](https://github.com/paypal/paypal-checkout-components/commit/7262318))
+* Ensure box-sizing does not affect spinner sie ([5cc18d6](https://github.com/paypal/paypal-checkout-components/commit/5cc18d6))
+* Export onPossiblyUnhandledException; ([e3c6823](https://github.com/paypal/paypal-checkout-components/commit/e3c6823))
+* Fix for startFlow with custom url ([d8008f9](https://github.com/paypal/paypal-checkout-components/commit/d8008f9))
+* Fix paypalCheckoutReady ([13374f6](https://github.com/paypal/paypal-checkout-components/commit/13374f6))
+* Limit to global export for now, to avoid issue when loaded into page with global define function ([cb6a9e6](https://github.com/paypal/paypal-checkout-components/commit/cb6a9e6))
+* Match legacy logic for determining target element ([efb565a](https://github.com/paypal/paypal-checkout-components/commit/efb565a))
+* Rely on xcomponent to provide fixed position for overlay container ([ed9bbe8](https://github.com/paypal/paypal-checkout-components/commit/ed9bbe8))
 
 
 
 ## <small>4.0.7 (2016-08-19)</small>
 
-* Add extra window.paypal namespaces for backwards compatibility ([3e68c4f](http://github.paypal.com/paypal/paypal-checkout/commit/3e68c4f))
-* Add logging for button render type ([281ffe4](http://github.paypal.com/paypal/paypal-checkout/commit/281ffe4))
-* Allow window.paypalCheckoutReady to be set after the window is loaded ([b01fdda](http://github.paypal.com/paypal/paypal-checkout/commit/b01fdda))
-* Call click function with event ([2fb5785](http://github.paypal.com/paypal/paypal-checkout/commit/2fb5785))
-* Dist ([6addd7b](http://github.paypal.com/paypal/paypal-checkout/commit/6addd7b))
-* Factor out global env state ([a879c35](http://github.paypal.com/paypal/paypal-checkout/commit/a879c35))
-* Fix argument order for handleClick ([fdcec63](http://github.paypal.com/paypal/paypal-checkout/commit/fdcec63))
-* Handle more button options and types ([ac407df](http://github.paypal.com/paypal/paypal-checkout/commit/ac407df))
-* Ignore multiple script loads ([e181225](http://github.paypal.com/paypal/paypal-checkout/commit/e181225))
-* Run window.paypalCheckoutReady after setting up interface entirely ([acc5105](http://github.paypal.com/paypal/paypal-checkout/commit/acc5105))
-* Simplify data-paypal-button compat code ([3fcf941](http://github.paypal.com/paypal/paypal-checkout/commit/3fcf941))
-* Simplify env logic ([e1967f6](http://github.paypal.com/paypal/paypal-checkout/commit/e1967f6))
-* Use paymentToken rather than token ([d83434c](http://github.paypal.com/paypal/paypal-checkout/commit/d83434c))
+* 4.0.7 ([9ea1042](https://github.com/paypal/paypal-checkout-components/commit/9ea1042))
+* Add extra window.paypal namespaces for backwards compatibility ([3e68c4f](https://github.com/paypal/paypal-checkout-components/commit/3e68c4f))
+* Add logging for button render type ([281ffe4](https://github.com/paypal/paypal-checkout-components/commit/281ffe4))
+* Allow window.paypalCheckoutReady to be set after the window is loaded ([b01fdda](https://github.com/paypal/paypal-checkout-components/commit/b01fdda))
+* Call click function with event ([2fb5785](https://github.com/paypal/paypal-checkout-components/commit/2fb5785))
+* Dist ([6addd7b](https://github.com/paypal/paypal-checkout-components/commit/6addd7b))
+* Factor out global env state ([a879c35](https://github.com/paypal/paypal-checkout-components/commit/a879c35))
+* Fix argument order for handleClick ([fdcec63](https://github.com/paypal/paypal-checkout-components/commit/fdcec63))
+* Handle more button options and types ([ac407df](https://github.com/paypal/paypal-checkout-components/commit/ac407df))
+* Ignore multiple script loads ([e181225](https://github.com/paypal/paypal-checkout-components/commit/e181225))
+* Run window.paypalCheckoutReady after setting up interface entirely ([acc5105](https://github.com/paypal/paypal-checkout-components/commit/acc5105))
+* Simplify data-paypal-button compat code ([3fcf941](https://github.com/paypal/paypal-checkout-components/commit/3fcf941))
+* Simplify env logic ([e1967f6](https://github.com/paypal/paypal-checkout-components/commit/e1967f6))
+* Use paymentToken rather than token ([d83434c](https://github.com/paypal/paypal-checkout-components/commit/d83434c))
 
 
 
 ## <small>4.0.6 (2016-08-18)</small>
 
-* Allow button array to use parent click method ([b4dedd8](http://github.paypal.com/paypal/paypal-checkout/commit/b4dedd8))
-* Dist ([ab91381](http://github.paypal.com/paypal/paypal-checkout/commit/ab91381))
-* Keep pp_uid non-sticky for now ([8866210](http://github.paypal.com/paypal/paypal-checkout/commit/8866210))
-* Updated name ([ff9812e](http://github.paypal.com/paypal/paypal-checkout/commit/ff9812e))
-* Updated name ([23f36ce](http://github.paypal.com/paypal/paypal-checkout/commit/23f36ce))
-* Use locale from setup() call for overlay locale ([1b3ca3a](http://github.paypal.com/paypal/paypal-checkout/commit/1b3ca3a))
+* 4.0.6 ([85f55ed](https://github.com/paypal/paypal-checkout-components/commit/85f55ed))
+* Allow button array to use parent click method ([b4dedd8](https://github.com/paypal/paypal-checkout-components/commit/b4dedd8))
+* Dist ([ab91381](https://github.com/paypal/paypal-checkout-components/commit/ab91381))
+* Keep pp_uid non-sticky for now ([8866210](https://github.com/paypal/paypal-checkout-components/commit/8866210))
+* Updated name ([ff9812e](https://github.com/paypal/paypal-checkout-components/commit/ff9812e))
+* Updated name ([23f36ce](https://github.com/paypal/paypal-checkout-components/commit/23f36ce))
+* Use locale from setup() call for overlay locale ([1b3ca3a](https://github.com/paypal/paypal-checkout-components/commit/1b3ca3a))
 
 
 
 ## <small>4.0.5 (2016-08-17)</small>
 
-* Dist ([5baf739](http://github.paypal.com/paypal/paypal-checkout/commit/5baf739))
-* Dist ([9241440](http://github.paypal.com/paypal/paypal-checkout/commit/9241440))
-* Pass down uid to checkout component ([a1e24ee](http://github.paypal.com/paypal/paypal-checkout/commit/a1e24ee))
+* 4.0.5 ([c93af9b](https://github.com/paypal/paypal-checkout-components/commit/c93af9b))
+* Dist ([5baf739](https://github.com/paypal/paypal-checkout-components/commit/5baf739))
+* Dist ([9241440](https://github.com/paypal/paypal-checkout-components/commit/9241440))
+* Pass down uid to checkout component ([a1e24ee](https://github.com/paypal/paypal-checkout-components/commit/a1e24ee))
 
 
 
 ## <small>4.0.4 (2016-08-17)</small>
 
-* Dist ([f4ff71c](http://github.paypal.com/paypal/paypal-checkout/commit/f4ff71c))
-* Make ppobjects configurable in setup call ([2aa8179](http://github.paypal.com/paypal/paypal-checkout/commit/2aa8179))
+* 4.0.4 ([b65d77c](https://github.com/paypal/paypal-checkout-components/commit/b65d77c))
+* Dist ([f4ff71c](https://github.com/paypal/paypal-checkout-components/commit/f4ff71c))
+* Make ppobjects configurable in setup call ([2aa8179](https://github.com/paypal/paypal-checkout-components/commit/2aa8179))
 
 
 
 ## <small>4.0.3 (2016-08-16)</small>
 
-* Dist ([7a5c67d](http://github.paypal.com/paypal/paypal-checkout/commit/7a5c67d))
-* Export ppxo.version ([ddb4331](http://github.paypal.com/paypal/paypal-checkout/commit/ddb4331))
-* Fix current script logic ([a887e7a](http://github.paypal.com/paypal/paypal-checkout/commit/a887e7a))
+* 4.0.3 ([b618ccd](https://github.com/paypal/paypal-checkout-components/commit/b618ccd))
+* Dist ([7a5c67d](https://github.com/paypal/paypal-checkout-components/commit/7a5c67d))
+* Export ppxo.version ([ddb4331](https://github.com/paypal/paypal-checkout-components/commit/ddb4331))
+* Fix current script logic ([a887e7a](https://github.com/paypal/paypal-checkout-components/commit/a887e7a))
 
 
 
 ## <small>4.0.2 (2016-08-16)</small>
 
-* Add some additional legacy safeguards and logs ([ffc9a80](http://github.paypal.com/paypal/paypal-checkout/commit/ffc9a80))
-* Allow overriding paypal url for both bridge and logger ([78b8569](http://github.paypal.com/paypal/paypal-checkout/commit/78b8569))
-* Break up legacy ([96dc914](http://github.paypal.com/paypal/paypal-checkout/commit/96dc914))
-* Cleanup button rendering and add options.condition support ([3a792cf](http://github.paypal.com/paypal/paypal-checkout/commit/3a792cf))
-* Dist ([6a78f65](http://github.paypal.com/paypal/paypal-checkout/commit/6a78f65))
-* Log error messaging when eventing is used. ([8e9937d](http://github.paypal.com/paypal/paypal-checkout/commit/8e9937d))
-* Use renderHijack, not hijackButton ([6c82e04](http://github.paypal.com/paypal/paypal-checkout/commit/6c82e04))
+* 4.0.2 ([1e5d26b](https://github.com/paypal/paypal-checkout-components/commit/1e5d26b))
+* Add some additional legacy safeguards and logs ([ffc9a80](https://github.com/paypal/paypal-checkout-components/commit/ffc9a80))
+* Allow overriding paypal url for both bridge and logger ([78b8569](https://github.com/paypal/paypal-checkout-components/commit/78b8569))
+* Break up legacy ([96dc914](https://github.com/paypal/paypal-checkout-components/commit/96dc914))
+* Cleanup button rendering and add options.condition support ([3a792cf](https://github.com/paypal/paypal-checkout-components/commit/3a792cf))
+* Dist ([6a78f65](https://github.com/paypal/paypal-checkout-components/commit/6a78f65))
+* Log error messaging when eventing is used. ([8e9937d](https://github.com/paypal/paypal-checkout-components/commit/8e9937d))
+* Use renderHijack, not hijackButton ([6c82e04](https://github.com/paypal/paypal-checkout-components/commit/6c82e04))
 
 
 
 ## <small>4.0.1 (2016-08-15)</small>
 
-* Add a demo folder using actual hermes flow ([674de51](http://github.paypal.com/paypal/paypal-checkout/commit/674de51))
-* Add beaver logger support and inject into xcomponent ([84c5997](http://github.paypal.com/paypal/paypal-checkout/commit/84c5997))
-* Add comments and fix close issues ([3396ccd](http://github.paypal.com/paypal/paypal-checkout/commit/3396ccd))
-* Add content for templates, keep overlay open, better overlay functionality ([639be5a](http://github.paypal.com/paypal/paypal-checkout/commit/639be5a))
-* Add eligibility and animations ([b0b6dfc](http://github.paypal.com/paypal/paypal-checkout/commit/b0b6dfc))
-* Add incontext eligibility check, support specifying any url in the legacy api ([2a4ddec](http://github.paypal.com/paypal/paypal-checkout/commit/2a4ddec))
-* Add loading spinner to initial checkout template ([353597d](http://github.paypal.com/paypal/paypal-checkout/commit/353597d))
-* Add mock components for button, checkout ([0ac2982](http://github.paypal.com/paypal/paypal-checkout/commit/0ac2982))
-* Add remove content button to demo ([e7ddade](http://github.paypal.com/paypal/paypal-checkout/commit/e7ddade))
-* Add versioning to build scripts ([be274df](http://github.paypal.com/paypal/paypal-checkout/commit/be274df))
-* Added merchant lightbox demo page, changed name to paypal.checkout.v4 ([8d0e463](http://github.paypal.com/paypal/paypal-checkout/commit/8d0e463))
-* Break redirect to method ([0642dd9](http://github.paypal.com/paypal/paypal-checkout/commit/0642dd9))
-* Build unminified file ([4b68339](http://github.paypal.com/paypal/paypal-checkout/commit/4b68339))
-* Bump version on each publish ([1952198](http://github.paypal.com/paypal/paypal-checkout/commit/1952198))
-* Button Rendering ([17af9b1](http://github.paypal.com/paypal/paypal-checkout/commit/17af9b1))
-* Call onPaymentCancel when window is closed by the user ([dcdd7e8](http://github.paypal.com/paypal/paypal-checkout/commit/dcdd7e8))
-* Convert element list to array ([8051404](http://github.paypal.com/paypal/paypal-checkout/commit/8051404))
-* Default to locale from config ([949ece3](http://github.paypal.com/paypal/paypal-checkout/commit/949ece3))
-* Dist ([b9f243f](http://github.paypal.com/paypal/paypal-checkout/commit/b9f243f))
-* Dist ([9389af9](http://github.paypal.com/paypal/paypal-checkout/commit/9389af9))
-* Dist ([d53534d](http://github.paypal.com/paypal/paypal-checkout/commit/d53534d))
-* Dist ([ac8060a](http://github.paypal.com/paypal/paypal-checkout/commit/ac8060a))
-* Dist ([fc1a4cb](http://github.paypal.com/paypal/paypal-checkout/commit/fc1a4cb))
-* Dist ([bd6568d](http://github.paypal.com/paypal/paypal-checkout/commit/bd6568d))
-* Dist ([cbcb90f](http://github.paypal.com/paypal/paypal-checkout/commit/cbcb90f))
-* Dist ([fd1e734](http://github.paypal.com/paypal/paypal-checkout/commit/fd1e734))
-* Dist ([633f4b7](http://github.paypal.com/paypal/paypal-checkout/commit/633f4b7))
-* Dist ([87d7ff3](http://github.paypal.com/paypal/paypal-checkout/commit/87d7ff3))
-* Dist ([85bc70c](http://github.paypal.com/paypal/paypal-checkout/commit/85bc70c))
-* Dist ([9d28d65](http://github.paypal.com/paypal/paypal-checkout/commit/9d28d65))
-* Dist ([e740670](http://github.paypal.com/paypal/paypal-checkout/commit/e740670))
-* Dist ([2b656d5](http://github.paypal.com/paypal/paypal-checkout/commit/2b656d5))
-* Dist ([39ae494](http://github.paypal.com/paypal/paypal-checkout/commit/39ae494))
-* Dist ([3f7b032](http://github.paypal.com/paypal/paypal-checkout/commit/3f7b032))
-* Dist ([7e0cd94](http://github.paypal.com/paypal/paypal-checkout/commit/7e0cd94))
-* Dist ([85a5436](http://github.paypal.com/paypal/paypal-checkout/commit/85a5436))
-* Dist ([3c0d468](http://github.paypal.com/paypal/paypal-checkout/commit/3c0d468))
-* Dist ([154ccc6](http://github.paypal.com/paypal/paypal-checkout/commit/154ccc6))
-* Dist ([5c55746](http://github.paypal.com/paypal/paypal-checkout/commit/5c55746))
-* Dist ([fa35ee5](http://github.paypal.com/paypal/paypal-checkout/commit/fa35ee5))
-* Dist ([04b7cc3](http://github.paypal.com/paypal/paypal-checkout/commit/04b7cc3))
-* Do not add padding in lightbox container element ([3d9212c](http://github.paypal.com/paypal/paypal-checkout/commit/3d9212c))
-* Do not show content behind iframe ([d1b9036](http://github.paypal.com/paypal/paypal-checkout/commit/d1b9036))
-* Downscale checkout image ([6d892ff](http://github.paypal.com/paypal/paypal-checkout/commit/6d892ff))
-* Encode content as unicode ([007f59f](http://github.paypal.com/paypal/paypal-checkout/commit/007f59f))
-* First commit ([4b672c8](http://github.paypal.com/paypal/paypal-checkout/commit/4b672c8))
-* First pass at docs ([1f4b28c](http://github.paypal.com/paypal/paypal-checkout/commit/1f4b28c))
-* Fix checkout layout for mobile devices ([0a2c182](http://github.paypal.com/paypal/paypal-checkout/commit/0a2c182))
-* Fix components to use latest xcomponent ([7e6f973](http://github.paypal.com/paypal/paypal-checkout/commit/7e6f973))
-* Fix docs ([6b5424b](http://github.paypal.com/paypal/paypal-checkout/commit/6b5424b))
-* Fix lint errors ([da41d7d](http://github.paypal.com/paypal/paypal-checkout/commit/da41d7d))
-* Fixes ([5ee1b6a](http://github.paypal.com/paypal/paypal-checkout/commit/5ee1b6a))
-* Flesh out merchant_legacy demo page ([6f8cb64](http://github.paypal.com/paypal/paypal-checkout/commit/6f8cb64))
-* For legacy compatibility layer, wait for token to be ready before loading url ([83fa37c](http://github.paypal.com/paypal/paypal-checkout/commit/83fa37c))
-* IE11 fixes ([d847ce0](http://github.paypal.com/paypal/paypal-checkout/commit/d847ce0))
-* Improve logo and overlay ([a343aed](http://github.paypal.com/paypal/paypal-checkout/commit/a343aed))
-* Improved docs ([e215036](http://github.paypal.com/paypal/paypal-checkout/commit/e215036))
-* Improved docs ([aff8cba](http://github.paypal.com/paypal/paypal-checkout/commit/aff8cba))
-* Improved docs ([c26f41b](http://github.paypal.com/paypal/paypal-checkout/commit/c26f41b))
-* Improved docs ([ea4097c](http://github.paypal.com/paypal/paypal-checkout/commit/ea4097c))
-* Improved docs ([baaf521](http://github.paypal.com/paypal/paypal-checkout/commit/baaf521))
-* Improved docs ([5d97bc6](http://github.paypal.com/paypal/paypal-checkout/commit/5d97bc6))
-* Improved docs ([f9eada9](http://github.paypal.com/paypal/paypal-checkout/commit/f9eada9))
-* Improved docs ([212f925](http://github.paypal.com/paypal/paypal-checkout/commit/212f925))
-* Improved docs ([cda22a5](http://github.paypal.com/paypal/paypal-checkout/commit/cda22a5))
-* Improved docs ([d03a12b](http://github.paypal.com/paypal/paypal-checkout/commit/d03a12b))
-* Improved docs ([9ed8d70](http://github.paypal.com/paypal/paypal-checkout/commit/9ed8d70))
-* Improved docs ([cf4cfcc](http://github.paypal.com/paypal/paypal-checkout/commit/cf4cfcc))
-* Improved docs ([d9be730](http://github.paypal.com/paypal/paypal-checkout/commit/d9be730))
-* Improved docs ([ca541b3](http://github.paypal.com/paypal/paypal-checkout/commit/ca541b3))
-* Improved docs ([cad45f0](http://github.paypal.com/paypal/paypal-checkout/commit/cad45f0))
-* Improved docs ([c2014ce](http://github.paypal.com/paypal/paypal-checkout/commit/c2014ce))
-* Improved docs ([4b77130](http://github.paypal.com/paypal/paypal-checkout/commit/4b77130))
-* Increase specificity of css class names ([5fa6084](http://github.paypal.com/paypal/paypal-checkout/commit/5fa6084))
-* Lightbox Animation CSS ([aa60794](http://github.paypal.com/paypal/paypal-checkout/commit/aa60794))
-* Lightbox Ease Transition ([7cb4732](http://github.paypal.com/paypal/paypal-checkout/commit/7cb4732))
-* Load button.js on demand ([364592a](http://github.paypal.com/paypal/paypal-checkout/commit/364592a))
-* Make source clearer ([31fc601](http://github.paypal.com/paypal/paypal-checkout/commit/31fc601))
-* merchant.htm: Button added for Lightob alongwith Add Conent ([1aa5fee](http://github.paypal.com/paypal/paypal-checkout/commit/1aa5fee))
-* Minor eligibility and styling fixes ([e824de9](http://github.paypal.com/paypal/paypal-checkout/commit/e824de9))
-* Minor tweaks to checkout component ([d441858](http://github.paypal.com/paypal/paypal-checkout/commit/d441858))
-* overlay.css file added ([a20ae48](http://github.paypal.com/paypal/paypal-checkout/commit/a20ae48))
-* overlay.css: css for logo,msg,continue ([87d166a](http://github.paypal.com/paypal/paypal-checkout/commit/87d166a))
-* overlay.html file added ([2a926e8](http://github.paypal.com/paypal/paypal-checkout/commit/2a926e8))
-* Overlay.html updated for logo message link ([45d4cc5](http://github.paypal.com/paypal/paypal-checkout/commit/45d4cc5))
-* Refactored and split docs ([44bc5c1](http://github.paypal.com/paypal/paypal-checkout/commit/44bc5c1))
-* Remove coverage webpack plugin for now (was generating coverage into dist) ([32d3b4f](http://github.paypal.com/paypal/paypal-checkout/commit/32d3b4f))
-* Remove old dist files ([c63d0a3](http://github.paypal.com/paypal/paypal-checkout/commit/c63d0a3))
-* Remove redundant version param ([c8471d7](http://github.paypal.com/paypal/paypal-checkout/commit/c8471d7))
-* Render bridge automatically ([c231e0c](http://github.paypal.com/paypal/paypal-checkout/commit/c231e0c))
-* Restructuring ([b0c6af6](http://github.paypal.com/paypal/paypal-checkout/commit/b0c6af6))
-* Send onClose to onPaymentCancel for all integrations where onClose is not specified ([02e79e8](http://github.paypal.com/paypal/paypal-checkout/commit/02e79e8))
-* Style iframe wrapper element with border radius and background color to avoid browser issues ([008b458](http://github.paypal.com/paypal/paypal-checkout/commit/008b458))
-* Support environments and load correct bridge urls ([5b35054](http://github.paypal.com/paypal/paypal-checkout/commit/5b35054))
-* Update docs ([59f2f88](http://github.paypal.com/paypal/paypal-checkout/commit/59f2f88))
-* Update docs ([1769412](http://github.paypal.com/paypal/paypal-checkout/commit/1769412))
-* Update docs ([068597e](http://github.paypal.com/paypal/paypal-checkout/commit/068597e))
-* Update docs ([e3bee81](http://github.paypal.com/paypal/paypal-checkout/commit/e3bee81))
-* Update docs ([151b90e](http://github.paypal.com/paypal/paypal-checkout/commit/151b90e))
-* Update docs ([ef5b2c2](http://github.paypal.com/paypal/paypal-checkout/commit/ef5b2c2))
-* Update docs ([6cb9ebc](http://github.paypal.com/paypal/paypal-checkout/commit/6cb9ebc))
-* Update docs ([15e8dc5](http://github.paypal.com/paypal/paypal-checkout/commit/15e8dc5))
-* Update docs ([4047c90](http://github.paypal.com/paypal/paypal-checkout/commit/4047c90))
-* Update docs ([31285fd](http://github.paypal.com/paypal/paypal-checkout/commit/31285fd))
-* Update docs ([511c266](http://github.paypal.com/paypal/paypal-checkout/commit/511c266))
-* Update docs ([b66f2d2](http://github.paypal.com/paypal/paypal-checkout/commit/b66f2d2))
-* Update docs ([3e81be9](http://github.paypal.com/paypal/paypal-checkout/commit/3e81be9))
-* Update docs for clarity ([7631c0e](http://github.paypal.com/paypal/paypal-checkout/commit/7631c0e))
-* Use correct format of mock window urls ([05ae946](http://github.paypal.com/paypal/paypal-checkout/commit/05ae946))
-* Use mock token generator for demo ([01bbf23](http://github.paypal.com/paypal/paypal-checkout/commit/01bbf23))
-* Use the new style spinner ([6b85605](http://github.paypal.com/paypal/paypal-checkout/commit/6b85605))
-* Various IE fixes ([2386665](http://github.paypal.com/paypal/paypal-checkout/commit/2386665))
-* When in lightbox mode, open the iframe 200px high ([997ebb3](http://github.paypal.com/paypal/paypal-checkout/commit/997ebb3))
-* feat(editorconfig): Add editor config ([53700a5](http://github.paypal.com/paypal/paypal-checkout/commit/53700a5))
-* feat(karma): Config file ([f3b55e1](http://github.paypal.com/paypal/paypal-checkout/commit/f3b55e1))
-* feat(test): Unit tests working ([f46679c](http://github.paypal.com/paypal/paypal-checkout/commit/f46679c))
-* feat(webpack):  Move to config file ([15b450c](http://github.paypal.com/paypal/paypal-checkout/commit/15b450c))
-* fix(gulp): Babelified gulp file ([7d38240](http://github.paypal.com/paypal/paypal-checkout/commit/7d38240))
+* 4.0.1 ([a4c13b6](https://github.com/paypal/paypal-checkout-components/commit/a4c13b6))
+* Add a demo folder using actual hermes flow ([674de51](https://github.com/paypal/paypal-checkout-components/commit/674de51))
+* Add beaver logger support and inject into xcomponent ([84c5997](https://github.com/paypal/paypal-checkout-components/commit/84c5997))
+* Add comments and fix close issues ([3396ccd](https://github.com/paypal/paypal-checkout-components/commit/3396ccd))
+* Add content for templates, keep overlay open, better overlay functionality ([639be5a](https://github.com/paypal/paypal-checkout-components/commit/639be5a))
+* Add eligibility and animations ([b0b6dfc](https://github.com/paypal/paypal-checkout-components/commit/b0b6dfc))
+* Add incontext eligibility check, support specifying any url in the legacy api ([2a4ddec](https://github.com/paypal/paypal-checkout-components/commit/2a4ddec))
+* Add loading spinner to initial checkout template ([353597d](https://github.com/paypal/paypal-checkout-components/commit/353597d))
+* Add mock components for button, checkout ([0ac2982](https://github.com/paypal/paypal-checkout-components/commit/0ac2982))
+* Add remove content button to demo ([e7ddade](https://github.com/paypal/paypal-checkout-components/commit/e7ddade))
+* Add versioning to build scripts ([be274df](https://github.com/paypal/paypal-checkout-components/commit/be274df))
+* Added merchant lightbox demo page, changed name to paypal.checkout.v4 ([8d0e463](https://github.com/paypal/paypal-checkout-components/commit/8d0e463))
+* Break redirect to method ([0642dd9](https://github.com/paypal/paypal-checkout-components/commit/0642dd9))
+* Build unminified file ([4b68339](https://github.com/paypal/paypal-checkout-components/commit/4b68339))
+* Bump version on each publish ([1952198](https://github.com/paypal/paypal-checkout-components/commit/1952198))
+* Button Rendering ([17af9b1](https://github.com/paypal/paypal-checkout-components/commit/17af9b1))
+* Call onPaymentCancel when window is closed by the user ([dcdd7e8](https://github.com/paypal/paypal-checkout-components/commit/dcdd7e8))
+* Convert element list to array ([8051404](https://github.com/paypal/paypal-checkout-components/commit/8051404))
+* Default to locale from config ([949ece3](https://github.com/paypal/paypal-checkout-components/commit/949ece3))
+* Dist ([fc1a4cb](https://github.com/paypal/paypal-checkout-components/commit/fc1a4cb))
+* Dist ([bd6568d](https://github.com/paypal/paypal-checkout-components/commit/bd6568d))
+* Dist ([85bc70c](https://github.com/paypal/paypal-checkout-components/commit/85bc70c))
+* Dist ([3f7b032](https://github.com/paypal/paypal-checkout-components/commit/3f7b032))
+* Dist ([85a5436](https://github.com/paypal/paypal-checkout-components/commit/85a5436))
+* Dist ([154ccc6](https://github.com/paypal/paypal-checkout-components/commit/154ccc6))
+* Dist ([fa35ee5](https://github.com/paypal/paypal-checkout-components/commit/fa35ee5))
+* Dist ([04b7cc3](https://github.com/paypal/paypal-checkout-components/commit/04b7cc3))
+* Dist ([39ae494](https://github.com/paypal/paypal-checkout-components/commit/39ae494))
+* Dist ([3c0d468](https://github.com/paypal/paypal-checkout-components/commit/3c0d468))
+* Dist ([e740670](https://github.com/paypal/paypal-checkout-components/commit/e740670))
+* Dist ([9d28d65](https://github.com/paypal/paypal-checkout-components/commit/9d28d65))
+* Dist ([ac8060a](https://github.com/paypal/paypal-checkout-components/commit/ac8060a))
+* Dist ([d53534d](https://github.com/paypal/paypal-checkout-components/commit/d53534d))
+* Dist ([b9f243f](https://github.com/paypal/paypal-checkout-components/commit/b9f243f))
+* Dist ([5c55746](https://github.com/paypal/paypal-checkout-components/commit/5c55746))
+* Dist ([2b656d5](https://github.com/paypal/paypal-checkout-components/commit/2b656d5))
+* Dist ([87d7ff3](https://github.com/paypal/paypal-checkout-components/commit/87d7ff3))
+* Dist ([fd1e734](https://github.com/paypal/paypal-checkout-components/commit/fd1e734))
+* Dist ([cbcb90f](https://github.com/paypal/paypal-checkout-components/commit/cbcb90f))
+* Dist ([9389af9](https://github.com/paypal/paypal-checkout-components/commit/9389af9))
+* Dist ([7e0cd94](https://github.com/paypal/paypal-checkout-components/commit/7e0cd94))
+* Dist ([633f4b7](https://github.com/paypal/paypal-checkout-components/commit/633f4b7))
+* Do not add padding in lightbox container element ([3d9212c](https://github.com/paypal/paypal-checkout-components/commit/3d9212c))
+* Do not show content behind iframe ([d1b9036](https://github.com/paypal/paypal-checkout-components/commit/d1b9036))
+* Downscale checkout image ([6d892ff](https://github.com/paypal/paypal-checkout-components/commit/6d892ff))
+* Encode content as unicode ([007f59f](https://github.com/paypal/paypal-checkout-components/commit/007f59f))
+* First commit ([4b672c8](https://github.com/paypal/paypal-checkout-components/commit/4b672c8))
+* First pass at docs ([1f4b28c](https://github.com/paypal/paypal-checkout-components/commit/1f4b28c))
+* Fix checkout layout for mobile devices ([0a2c182](https://github.com/paypal/paypal-checkout-components/commit/0a2c182))
+* Fix components to use latest xcomponent ([7e6f973](https://github.com/paypal/paypal-checkout-components/commit/7e6f973))
+* Fix docs ([6b5424b](https://github.com/paypal/paypal-checkout-components/commit/6b5424b))
+* Fix lint errors ([da41d7d](https://github.com/paypal/paypal-checkout-components/commit/da41d7d))
+* Fixes ([5ee1b6a](https://github.com/paypal/paypal-checkout-components/commit/5ee1b6a))
+* Flesh out merchant_legacy demo page ([6f8cb64](https://github.com/paypal/paypal-checkout-components/commit/6f8cb64))
+* For legacy compatibility layer, wait for token to be ready before loading url ([83fa37c](https://github.com/paypal/paypal-checkout-components/commit/83fa37c))
+* IE11 fixes ([d847ce0](https://github.com/paypal/paypal-checkout-components/commit/d847ce0))
+* Improve logo and overlay ([a343aed](https://github.com/paypal/paypal-checkout-components/commit/a343aed))
+* Improved docs ([c2014ce](https://github.com/paypal/paypal-checkout-components/commit/c2014ce))
+* Improved docs ([4b77130](https://github.com/paypal/paypal-checkout-components/commit/4b77130))
+* Improved docs ([cad45f0](https://github.com/paypal/paypal-checkout-components/commit/cad45f0))
+* Improved docs ([ca541b3](https://github.com/paypal/paypal-checkout-components/commit/ca541b3))
+* Improved docs ([d9be730](https://github.com/paypal/paypal-checkout-components/commit/d9be730))
+* Improved docs ([9ed8d70](https://github.com/paypal/paypal-checkout-components/commit/9ed8d70))
+* Improved docs ([d03a12b](https://github.com/paypal/paypal-checkout-components/commit/d03a12b))
+* Improved docs ([c26f41b](https://github.com/paypal/paypal-checkout-components/commit/c26f41b))
+* Improved docs ([212f925](https://github.com/paypal/paypal-checkout-components/commit/212f925))
+* Improved docs ([f9eada9](https://github.com/paypal/paypal-checkout-components/commit/f9eada9))
+* Improved docs ([5d97bc6](https://github.com/paypal/paypal-checkout-components/commit/5d97bc6))
+* Improved docs ([baaf521](https://github.com/paypal/paypal-checkout-components/commit/baaf521))
+* Improved docs ([ea4097c](https://github.com/paypal/paypal-checkout-components/commit/ea4097c))
+* Improved docs ([aff8cba](https://github.com/paypal/paypal-checkout-components/commit/aff8cba))
+* Improved docs ([e215036](https://github.com/paypal/paypal-checkout-components/commit/e215036))
+* Improved docs ([cf4cfcc](https://github.com/paypal/paypal-checkout-components/commit/cf4cfcc))
+* Improved docs ([cda22a5](https://github.com/paypal/paypal-checkout-components/commit/cda22a5))
+* Increase specificity of css class names ([5fa6084](https://github.com/paypal/paypal-checkout-components/commit/5fa6084))
+* Lightbox Animation CSS ([aa60794](https://github.com/paypal/paypal-checkout-components/commit/aa60794))
+* Lightbox Ease Transition ([7cb4732](https://github.com/paypal/paypal-checkout-components/commit/7cb4732))
+* Load button.js on demand ([364592a](https://github.com/paypal/paypal-checkout-components/commit/364592a))
+* Make source clearer ([31fc601](https://github.com/paypal/paypal-checkout-components/commit/31fc601))
+* merchant.htm: Button added for Lightob alongwith Add Conent ([1aa5fee](https://github.com/paypal/paypal-checkout-components/commit/1aa5fee))
+* Minor eligibility and styling fixes ([e824de9](https://github.com/paypal/paypal-checkout-components/commit/e824de9))
+* Minor tweaks to checkout component ([d441858](https://github.com/paypal/paypal-checkout-components/commit/d441858))
+* overlay.css file added ([a20ae48](https://github.com/paypal/paypal-checkout-components/commit/a20ae48))
+* overlay.css: css for logo,msg,continue ([87d166a](https://github.com/paypal/paypal-checkout-components/commit/87d166a))
+* overlay.html file added ([2a926e8](https://github.com/paypal/paypal-checkout-components/commit/2a926e8))
+* Overlay.html updated for logo message link ([45d4cc5](https://github.com/paypal/paypal-checkout-components/commit/45d4cc5))
+* Refactored and split docs ([44bc5c1](https://github.com/paypal/paypal-checkout-components/commit/44bc5c1))
+* Remove coverage webpack plugin for now (was generating coverage into dist) ([32d3b4f](https://github.com/paypal/paypal-checkout-components/commit/32d3b4f))
+* Remove old dist files ([c63d0a3](https://github.com/paypal/paypal-checkout-components/commit/c63d0a3))
+* Remove redundant version param ([c8471d7](https://github.com/paypal/paypal-checkout-components/commit/c8471d7))
+* Render bridge automatically ([c231e0c](https://github.com/paypal/paypal-checkout-components/commit/c231e0c))
+* Restructuring ([b0c6af6](https://github.com/paypal/paypal-checkout-components/commit/b0c6af6))
+* Send onClose to onPaymentCancel for all integrations where onClose is not specified ([02e79e8](https://github.com/paypal/paypal-checkout-components/commit/02e79e8))
+* Style iframe wrapper element with border radius and background color to avoid browser issues ([008b458](https://github.com/paypal/paypal-checkout-components/commit/008b458))
+* Support environments and load correct bridge urls ([5b35054](https://github.com/paypal/paypal-checkout-components/commit/5b35054))
+* Update docs ([6cb9ebc](https://github.com/paypal/paypal-checkout-components/commit/6cb9ebc))
+* Update docs ([068597e](https://github.com/paypal/paypal-checkout-components/commit/068597e))
+* Update docs ([1769412](https://github.com/paypal/paypal-checkout-components/commit/1769412))
+* Update docs ([3e81be9](https://github.com/paypal/paypal-checkout-components/commit/3e81be9))
+* Update docs ([31285fd](https://github.com/paypal/paypal-checkout-components/commit/31285fd))
+* Update docs ([15e8dc5](https://github.com/paypal/paypal-checkout-components/commit/15e8dc5))
+* Update docs ([e3bee81](https://github.com/paypal/paypal-checkout-components/commit/e3bee81))
+* Update docs ([b66f2d2](https://github.com/paypal/paypal-checkout-components/commit/b66f2d2))
+* Update docs ([59f2f88](https://github.com/paypal/paypal-checkout-components/commit/59f2f88))
+* Update docs ([151b90e](https://github.com/paypal/paypal-checkout-components/commit/151b90e))
+* Update docs ([4047c90](https://github.com/paypal/paypal-checkout-components/commit/4047c90))
+* Update docs ([511c266](https://github.com/paypal/paypal-checkout-components/commit/511c266))
+* Update docs ([ef5b2c2](https://github.com/paypal/paypal-checkout-components/commit/ef5b2c2))
+* Update docs for clarity ([7631c0e](https://github.com/paypal/paypal-checkout-components/commit/7631c0e))
+* Use correct format of mock window urls ([05ae946](https://github.com/paypal/paypal-checkout-components/commit/05ae946))
+* Use mock token generator for demo ([01bbf23](https://github.com/paypal/paypal-checkout-components/commit/01bbf23))
+* Use the new style spinner ([6b85605](https://github.com/paypal/paypal-checkout-components/commit/6b85605))
+* Various IE fixes ([2386665](https://github.com/paypal/paypal-checkout-components/commit/2386665))
+* When in lightbox mode, open the iframe 200px high ([997ebb3](https://github.com/paypal/paypal-checkout-components/commit/997ebb3))
+* feat(editorconfig): Add editor config ([53700a5](https://github.com/paypal/paypal-checkout-components/commit/53700a5))
+* feat(karma): Config file ([f3b55e1](https://github.com/paypal/paypal-checkout-components/commit/f3b55e1))
+* feat(test): Unit tests working ([f46679c](https://github.com/paypal/paypal-checkout-components/commit/f46679c))
+* feat(webpack):  Move to config file ([15b450c](https://github.com/paypal/paypal-checkout-components/commit/15b450c))
+* fix(gulp): Babelified gulp file ([7d38240](https://github.com/paypal/paypal-checkout-components/commit/7d38240))
 
 
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.paypal.com/paypal/paypal-checkout.git"
+    "url": "git://github.com/paypal/paypal-checkout-components.git"
   },
   "homepage": "https://developer.paypal.com/",
   "keywords": [


### PR DESCRIPTION
I noticed the links in the changelog point to the old private repository. This PR fixes the issue with two changes:
1. Updates package.json to use the public repository link. 
1. Uses the [conventional-changelog-cli](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli) tool to regenerate the changelog. This awesome tool uses the repository link defined in package.json for creating the commit hyperlinks in the changelog.