### PR TITLE
a11y: change iframe title, button labels

### DIFF
--- a/src/button/config.js
+++ b/src/button/config.js
@@ -1,12 +1,13 @@
 /* @flow */
 /* eslint no-template-curly-in-string: off, max-lines: off */
 
-import { FUNDING, DEFAULT, COUNTRY, BUTTON_LABEL, BUTTON_COLOR, BUTTON_LOGO_COLOR, BUTTON_SIZE,
+import { FUNDING, FUNDING_BRAND_LABEL, DEFAULT, COUNTRY, BUTTON_LABEL, BUTTON_COLOR, BUTTON_LOGO_COLOR, BUTTON_SIZE,
     BUTTON_TAGLINE_COLOR, BUTTON_SHAPE, BUTTON_LAYOUT, BUTTON_LOGO } from '../constants';
 
 type ButtonConfig = {
     [ string ] : {
-        colors? : $ReadOnlyArray<$Values<typeof BUTTON_COLOR>>
+        colors? : $ReadOnlyArray<$Values<typeof BUTTON_COLOR>>,
+        title? : string
     }
 };
 
@@ -111,7 +112,9 @@ export const BUTTON_CONFIG : ButtonConfig = {
         allowPrimary: true,
 
         allowPrimaryVertical:   true,
-        allowPrimaryHorizontal: true
+        allowPrimaryHorizontal: true,
+        
+        title: `${ FUNDING_BRAND_LABEL.PAYPAL }`
     },
 
     [ BUTTON_LABEL.CHECKOUT ]: {
@@ -204,7 +207,9 @@ export const BUTTON_CONFIG : ButtonConfig = {
         allowPrimaryVertical:   false,
         allowPrimaryHorizontal: false,
 
-        allowFundingIcons: false
+        allowFundingIcons: false,
+    
+        title: `${ FUNDING_BRAND_LABEL.CREDIT }`
     },
 
     [ BUTTON_LABEL.VENMO ]: {

--- a/src/constants/funding.js
+++ b/src/constants/funding.js
@@ -24,6 +24,11 @@ export const FUNDING = {
     OXXO:         'oxxo'
 };
 
+export const FUNDING_BRAND_LABEL = {
+    PAYPAL:         'PayPal',
+    CREDIT:         'PayPal Credit'
+};
+
 export const CARD = {
     VISA:        'visa',
     MASTERCARD:  'mastercard',


### PR DESCRIPTION
- removed alt attribute for <img> for button logo
- adds aria-label for div for buttons
      They are translated per their label if necessary
      Replaces the logo placeholder with PayPal in the content
- adds iframe title