### PR TITLE
Reorder SPB and move PayPal branding below SCF

### DIFF
--- a/src/funding/funding.js
+++ b/src/funding/funding.js
@@ -1,8 +1,8 @@
 /* @flow */
 
+import { SUPPORTED_FUNDING_SOURCES } from '@paypal/funding-components/src';
 import type { FundingEligibilityType } from '@paypal/sdk-client/src';
 import { PLATFORM, FUNDING, COMPONENTS } from '@paypal/sdk-constants/src';
-import { values } from 'belter/src';
 
 import type { Wallet } from '../types';
 import { BUTTON_LAYOUT, BUTTON_FLOW } from '../constants';
@@ -78,7 +78,7 @@ export function determineEligibleFunding({ fundingSource, layout, platform, fund
         return [ fundingSource ];
     }
 
-    let eligibleFunding = values(FUNDING).filter(source =>
+    let eligibleFunding = SUPPORTED_FUNDING_SOURCES.filter(source =>
         isFundingEligible(source, { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, wallet }));
 
     if (layout === BUTTON_LAYOUT.HORIZONTAL) {

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -168,6 +168,12 @@ export function Buttons(props : ButtonsProps) : ElementNode {
             }
 
             {
+                (fundingSources.indexOf(FUNDING.CARD) !== -1)
+                    ? <div id="card-fields-container" class="card-fields-container" />
+                    : null
+            }
+
+            {
                 (layout === BUTTON_LAYOUT.VERTICAL && fundingSources.indexOf(FUNDING.CARD) !== -1)
                     ? <PoweredByPayPal
                         locale={ locale }


### PR DESCRIPTION
Changes:
* Move "Debit or Credit Card" button to the bottom of the SPB stack
* Move "Powered by PayPal" branding below inline guest card fields

Before:
<img width="767" alt="Screen Shot 2020-11-11 at 1 35 52 PM" src="https://user-images.githubusercontent.com/25190326/98867327-3d8c6b00-2423-11eb-9837-2d82beff3d5e.png">

After:
<img width="767" alt="Screen Shot 2020-11-11 at 1 36 36 PM" src="https://user-images.githubusercontent.com/25190326/98867339-42e9b580-2423-11eb-82d7-3b8e4f76848d.png">
