### PR TITLE
Update Travis CI config for Karma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: node_js
 node_js:
   - "lts/*"
-before_install:
-  - sudo apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+dist: xenial
+services:
+  - xvfb
 before_script:
   - npm run flow-typed
 script:
   - npm run build
 cache:
   npm: false
-sudo: required
 dist: xenial
 addons:
   chrome: stable


### PR DESCRIPTION
The [Karma Travis CI Docs](https://karma-runner.github.io/5.2/plus/travis.html) recommend using the xvfb service with the xenial distro. This PR updates the config to use that approach. 

With this change sudo is no longer needed. I don't think sudo was supported anymore with Travis CI. I remember seeing warnings about that. Perhaps this change will speed up the travis queuing slowness we've seen 🤞 