### PR TITLE
Use GitHub Actions to manage old Issues and PRs

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,27 @@
+name: "Lock outdated threads"
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: '365'
+          issue-exclude-labels: 'work-in-progress'
+          issue-lock-labels: 'outdated'
+          issue-lock-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+          pr-lock-inactive-days: '365'
+          pr-exclude-labels: 'work-in-progress'
+          pr-lock-labels: 'outdated'
+          pr-lock-comment: >
+            This pull request has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: "Close stale Issues and PRs"
+on:
+  schedule:
+    - cron: "30 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 90
+          days-before-close: 7
+          exempt-issue-labels: "awaiting-approval,work-in-progress"
+          stale-issue-message: >
+            This issue has been automatically marked as stale.
+            **If this issue is still affecting you, please leave any comment** (for example, "bump"), and we'll keep it open.
+            We are sorry that we haven't been able to prioritize it yet. If you have any new additional information, please include it with your comment!
+          stale-pr-message: >
+            This pull request has been automatically marked as stale.
+            **If this pull request is still relevant, please leave any comment** (for example, "bump"), and we'll keep it open.
+            We are sorry that we haven't been able to prioritize reviewing it yet. Your contribution is very much appreciated.
+          close-issue-message: >
+            Closing this issue after a prolonged period of inactivity. If this issue is still present in the latest release, please create a new issue with up-to-date information.
+          close-pr-message: >
+            Closing this pull request after a prolonged period of inactivity. If this issue is still present in the latest release, please ask for this pull request to be reopened.


### PR DESCRIPTION
This PR adds two new GitHub Action workflows to help get our issues under control:
1. [lock threads](https://github.com/dessant/lock-threads) - configured to lock Issues and PRs older than 1 year. This will prevent folks from commenting on really old issues that are closed.
2. [stale action](https://github.com/actions/stale) - configured to auto-close issues and PRs with no activity after 90 days.