### PR TITLE
GitHub Actions - Only lock threads for old issues

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -18,10 +18,4 @@ jobs:
             This issue has been automatically locked since there
             has not been any recent activity after it was closed.
             Please open a new issue for related bugs.
-          pr-lock-inactive-days: '365'
-          pr-exclude-labels: 'work-in-progress'
-          pr-lock-labels: 'outdated'
-          pr-lock-comment: >
-            This pull request has been automatically locked since there
-            has not been any recent activity after it was closed.
-            Please open a new issue for related bugs.
+          process-only: 'issues'


### PR DESCRIPTION
I think I made a mistake with configuring this Lock Threads action to lock PRs. This PR updates it to only lock old Issues.