### PR TITLE
Update badges and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -175,24 +175,13 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
    Copyright 2016 PayPal
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 PayPal Checkout
 ---------------
 
-[![npm version](https://img.shields.io/npm/v/@paypal/checkout-components.svg?style=flat-square)](https://www.npmjs.com/package/@paypal/checkout-components)
-[![build status](https://img.shields.io/github/workflow/status/paypal/paypal-checkout-components/build?logo=github&style=flat-square)](https://github.com/paypal/paypal-checkout-components/actions?query=workflow%3Abuild)
-[![code coverage](https://img.shields.io/codecov/c/github/paypal/paypal-checkout-components.svg?style=flat-square)](https://codecov.io/github/paypal/paypal-checkout-components)
+[![build status][build-badge]][build]
+[![code coverage][coverage-badge]][coverage]
+[![npm version][version-badge]][package]
+[![apache license][license-badge]][license]
 
-[![dependencies Status](https://david-dm.org/paypal/paypal-checkout-components/status.svg)](https://david-dm.org/paypal/paypal-checkout-components) [![devDependencies Status](https://david-dm.org/paypal/paypal-checkout-components/dev-status.svg)](https://david-dm.org/paypal/paypal-checkout-components?type=dev)
-
+[build-badge]: https://img.shields.io/github/workflow/status/paypal/paypal-checkout-components/build?logo=github&style=flat-square
+[build]: https://github.com/paypal/paypal-checkout-components/actions?query=workflow%3Abuild
+[coverage-badge]: https://img.shields.io/codecov/c/github/paypal/paypal-checkout-components.svg?style=flat-square
+[coverage]: https://codecov.io/github/paypal/paypal-checkout-components/
+[version-badge]: https://img.shields.io/npm/v/@paypal/checkout-components.svg?style=flat-square
+[package]: https://www.npmjs.com/package/@paypal/checkout-components
+[license-badge]: https://img.shields.io/npm/l/@paypal/checkout-components.svg?style=flat-square
+[license]: https://github.com/paypal/paypal-checkout-components/blob/master/LICENSE
 
 A set of components allowing easy integration of PayPal Buttons and PayPal Checkout into your site, powered by
 [zoid](https://github.com/krakenjs/zoid).


### PR DESCRIPTION
This PR updates the README badges with the goal of standardizing them across projects. Ex:

<img width="877" alt="Screen Shot 2020-12-10 at 11 11 23 AM" src="https://user-images.githubusercontent.com/534034/101805507-7712cd80-3ad8-11eb-8859-03d6c1b32ab6.png">

So far the same badges have been set up for [paypal-sdk-client](https://github.com/paypal/paypal-sdk-client/blob/master/README.md).

This PR also makes some minor edits to the license to update https for the links and remove the appendix that's not needed.