### PR TITLE
v4 - Fix aria label for Debit or Credit Card button

### DIFF
--- a/demo/dev/card.htm
+++ b/demo/dev/card.htm
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="/checkout.js" data-paypal-checkout></script>
+</head>
+
+<body>
+    <div id="paypal-button"></div>
+
+    <script>
+        // paypal.config.buttonUris.sandbox = '/smart/button';
+        // paypal.config.buttonUris.production = '/smart/button';
+
+        paypal.Button.render({
+
+            env: 'demo', // Optional: specify 'sandbox' environment
+
+        style: {
+            branding: true, // optional
+            layout: 'vertical',
+            size:  'large', // small | medium | large | responsive
+            shape: 'rect',   // pill | rect
+            color: 'gold'   // gold | blue | silve | black
+        },
+
+            client: {
+                demo: 'abc123'
+            },
+
+            payment: function () {
+
+                var env = this.props.env;
+                var client = this.props.client;
+
+                return paypal.rest.payment.create(env, client, {
+                    transactions: [
+                        {
+                            amount: { total: '1.00', currency: 'USD' }
+                        }
+                    ]
+                });
+            },
+
+            commit: true, // Optional: show a 'Pay Now' button in the checkout flow
+
+            onAuthorize: function (data, actions) {
+
+                // Optional: display a confirmation page here
+
+                return actions.payment.execute().then(function () {
+                    // Show a success page to the buyer
+                });
+            }
+
+        }, '#paypal-button');
+    </script>
+</body>

--- a/src/button/config.js
+++ b/src/button/config.js
@@ -816,7 +816,9 @@ export const BUTTON_CONFIG : ButtonConfig = {
         allowPrimary: false,
 
         allowPrimaryVertical:   false,
-        allowPrimaryHorizontal: false
+        allowPrimaryHorizontal: false,
+
+        title: `${ FUNDING_BRAND_LABEL.CARD }`
     }
 };
 

--- a/src/constants/funding.js
+++ b/src/constants/funding.js
@@ -26,7 +26,8 @@ export const FUNDING = {
 
 export const FUNDING_BRAND_LABEL = {
     PAYPAL:         'PayPal',
-    CREDIT:         'PayPal Credit'
+    CREDIT:         'PayPal Credit',
+    CARD:           'Debit or Credit Card'
 };
 
 export const CARD = {


### PR DESCRIPTION
This PR updates the aria-label for the Debit or Credit Card button.

### Steps to verify the fix

1. Clone this branch
2. `npm install`
3. Change the port number from 9000 to 9001 here: https://github.com/paypal/paypal-checkout-components/blob/v4/package.json#L32
4. `npm run dev`
5. Go to https://localhost.paypal.com:9001/webpack-dev-server/demo/dev/card.htm and verify the aria-label of the Card Section:

<img width="1278" alt="Screen Shot 2020-12-15 at 4 45 46 PM" src="https://user-images.githubusercontent.com/534034/102282030-97d28d00-3ef5-11eb-9a53-9974326b8c51.png">
 