### PR TITLE
Add missing alt and aria-label attributes to img elements in checkout.js PayPal button for screen readers

### DIFF
--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -255,7 +255,7 @@ function renderContent(text : string, { label, locale, color, branding, logoColo
             return (
                 <img
                     class={ `${ CLASS.LOGO } ${ CLASS.LOGO }-${ name } ${ CLASS.LOGO }-${ color }` }
-                    src={ `data:image/svg+xml;base64,${ base64encode(logo.toString()) }` } />
+                    src={ `data:image/svg+xml;base64,${ base64encode(logo.toString()) }` } alt ="" aria-label={name} />
             );
         },
 

--- a/src/button/template/componentTemplate.jsx
+++ b/src/button/template/componentTemplate.jsx
@@ -255,7 +255,7 @@ function renderContent(text : string, { label, locale, color, branding, logoColo
             return (
                 <img
                     class={ `${ CLASS.LOGO } ${ CLASS.LOGO }-${ name } ${ CLASS.LOGO }-${ color }` }
-                    src={ `data:image/svg+xml;base64,${ base64encode(logo.toString()) }` } alt ="" aria-label={name} />
+                    src={ `data:image/svg+xml;base64,${ base64encode(logo.toString()) }` } alt="" aria-label={ name } />
             );
         },
 


### PR DESCRIPTION
The checkout.js PayPal button is a responsive div element with role='button' and an aria-label applied. The img elements within do not have alt or aria-label attributes, so screen readers read out the entire src base-64 encoding string, which is a terrible user experience and has been documented in JIRA ticket [DTCHKINT-388](https://engineering.paypalcorp.com/jira/browse/DTCHKINT-388).

This PR fixes the above issue by adding alt and aria-label attributes to the img elements within the checkout.js PayPal button.