### PR TITLE
Remove usage of Array.prototype.includes to fix IE11

### DIFF
--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -105,7 +105,7 @@ export function Buttons(props : ButtonsProps) : ElementNode {
         throw new Error(`No eligible funding fundingSources found to render buttons:\n\n${ JSON.stringify(fundingEligibility, null, 4) }`);
     }
 
-    if (fundingSources.includes(FUNDING.CARD)) {
+    if (fundingSources.indexOf(FUNDING.CARD) !== -1) {
         fundingSources = fundingSources.filter(src => src !== FUNDING.CARD).concat([ FUNDING.CARD ]);
     }
 


### PR DESCRIPTION
I tested the JS SDK in IE11 over the weekend and noticed that it's breaking due to this usage of `includes()`. [Array.prototype.includes](https://caniuse.com/array-includes) is not available in older browsers so it requires a polyfill if we are going to use it. 

To resolve the issue, I replaced `includes` with the old school ES3 `indexOf('card') !== -1` check. This way we don't have to worry about bringing in a polyfill.

cc: @allen-tong