### PR TITLE
Add white background to paypal logo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ flow-typed
 
 .DS_Store
 package-lock.json
+
+# Vscode
+.vscode

--- a/src/constants/class.js
+++ b/src/constants/class.js
@@ -37,5 +37,8 @@ export const CLASS = {
 
     HIDDEN:  ('hidden' : 'hidden'),
 
-    IMMEDIATE: ('immediate' : 'immediate')
+    IMMEDIATE: ('immediate' : 'immediate'),
+
+    CARD_FIELDS_CONTAINER: ('card-fields-container' : 'card-fields-container'),
+    CARD_FIELDS_WITH_LOGO: ('card-fields-with-logo' : 'card-fields-with-logo')
 };

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -172,8 +172,8 @@ export function Buttons(props : ButtonsProps) : ElementNode {
             }
             
             {fundingSources.indexOf(FUNDING.CARD) !== -1 ? (
-                <div class="card-fields-with-logo">
-                    <div id="card-fields-container" class="card-fields-container" />
+                <div class={ CLASS.CARD_FIELDS_WITH_LOGO }>
+                    <div id="card-fields-container" class={ CLASS.CARD_FIELDS_CONTAINER } />
                     {layout === BUTTON_LAYOUT.VERTICAL ? (
                         <PoweredByPayPal locale={ locale } />
                     ) : null}

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -170,19 +170,15 @@ export function Buttons(props : ButtonsProps) : ElementNode {
                         personalization={ personalization }
                     /> : null
             }
-
-            {
-                (fundingSources.indexOf(FUNDING.CARD) !== -1)
-                    ? <div id="card-fields-container" class="card-fields-container" />
-                    : null
-            }
-
-            {
-                (layout === BUTTON_LAYOUT.VERTICAL && fundingSources.indexOf(FUNDING.CARD) !== -1)
-                    ? <PoweredByPayPal
-                        locale={ locale }
-                    /> : null
-            }
+            
+            {fundingSources.indexOf(FUNDING.CARD) !== -1 ? (
+                <div class="card-fields-with-logo">
+                    <div id="card-fields-container" class="card-fields-container" />
+                    {layout === BUTTON_LAYOUT.VERTICAL ? (
+                        <PoweredByPayPal locale={ locale } />
+                    ) : null}
+                </div>
+            ) : null}
 
             <Script
                 nonce={ nonce }

--- a/src/ui/buttons/styles/button.js
+++ b/src/ui/buttons/styles/button.js
@@ -123,4 +123,9 @@ export const buttonStyle = `
     .${ CLASS.CONTAINER } .${ CLASS.VAULT_HEADER } {
         margin-top: 10px;
     }
+    
+    .card-fields-with-logo {
+        background-color: white;
+        padding: 1px 0;
+    }
 `;

--- a/src/ui/buttons/styles/button.js
+++ b/src/ui/buttons/styles/button.js
@@ -124,7 +124,7 @@ export const buttonStyle = `
         margin-top: 10px;
     }
     
-    .card-fields-with-logo {
+    .${ CLASS.CARD_FIELDS_WITH_LOGO } {
         background-color: white;
         padding: 1px 0;
     }


### PR DESCRIPTION
Add white background to the "Powered by PayPal" logo to resolve logo visibility issues.

## Before
<img width="652" alt="Screen Shot 2021-01-25 at 10 33 47 AM" src="https://user-images.githubusercontent.com/6020627/105774294-f68a1e00-5f19-11eb-8ed2-bb05a0a1ac6c.png">

![before 2](https://user-images.githubusercontent.com/6020627/105762956-f8e47c00-5f09-11eb-8032-13b1e1dc210b.png)



## After
<img width="844" alt="Screen Shot 2021-01-25 at 12 30 04 PM" src="https://user-images.githubusercontent.com/6020627/105762658-84a9d880-5f09-11eb-9ea2-3643ca1745ec.png">
<img width="845" alt="Screen Shot 2021-01-25 at 12 30 14 PM" src="https://user-images.githubusercontent.com/6020627/105762665-870c3280-5f09-11eb-92f9-fd421a3256d2.png">
