### PR TITLE
Update venmo eligibility

### DIFF
--- a/src/funding/common.jsx
+++ b/src/funding/common.jsx
@@ -72,7 +72,7 @@ export type FundingSourceConfig = {|
     automatic : boolean,
     shippingChange? : boolean,
     requiresPopupSupport? : boolean,
-    supports3rdPartyMobileBrowsers? : boolean,
+    supportsThirdPartyMobileBrowsers? : boolean,
     platforms : $ReadOnlyArray<$Values<typeof PLATFORM>>,
     layouts : $ReadOnlyArray<$Values<typeof BUTTON_LAYOUT>>,
     flows : $ReadOnlyArray<$Values<typeof BUTTON_FLOW>>,

--- a/src/funding/common.jsx
+++ b/src/funding/common.jsx
@@ -72,6 +72,7 @@ export type FundingSourceConfig = {|
     automatic : boolean,
     shippingChange? : boolean,
     requiresPopupSupport? : boolean,
+    supports3rdPartyMobileBrowsers? : boolean,
     platforms : $ReadOnlyArray<$Values<typeof PLATFORM>>,
     layouts : $ReadOnlyArray<$Values<typeof BUTTON_LAYOUT>>,
     flows : $ReadOnlyArray<$Values<typeof BUTTON_FLOW>>,

--- a/src/funding/common.jsx
+++ b/src/funding/common.jsx
@@ -71,6 +71,7 @@ export type FundingSourceConfig = {|
     enabled : boolean,
     automatic : boolean,
     shippingChange? : boolean,
+    requiresPopupSupport? : boolean,
     platforms : $ReadOnlyArray<$Values<typeof PLATFORM>>,
     layouts : $ReadOnlyArray<$Values<typeof BUTTON_LAYOUT>>,
     flows : $ReadOnlyArray<$Values<typeof BUTTON_FLOW>>,

--- a/src/funding/common.jsx
+++ b/src/funding/common.jsx
@@ -72,7 +72,7 @@ export type FundingSourceConfig = {|
     automatic : boolean,
     shippingChange? : boolean,
     requiresPopupSupport? : boolean,
-    supportsThirdPartyMobileBrowsers? : boolean,
+    requiresSupportedNativeBrowser? : boolean,
     platforms : $ReadOnlyArray<$Values<typeof PLATFORM>>,
     layouts : $ReadOnlyArray<$Values<typeof BUTTON_LAYOUT>>,
     flows : $ReadOnlyArray<$Values<typeof BUTTON_FLOW>>,

--- a/src/funding/funding.js
+++ b/src/funding/funding.js
@@ -2,7 +2,7 @@
 
 import type { FundingEligibilityType } from '@paypal/sdk-client/src';
 import { PLATFORM, FUNDING, COMPONENTS } from '@paypal/sdk-constants/src';
-import { values } from 'belter/src';
+import { values, supportsPopups } from 'belter/src';
 
 import type { Wallet } from '../types';
 import { BUTTON_LAYOUT, BUTTON_FLOW } from '../constants';
@@ -59,6 +59,10 @@ export function isFundingEligible(source : $Values<typeof FUNDING>,
     }
 
     if (fundingConfig.shippingChange === false && onShippingChange) {
+        return false;
+    }
+
+    if (fundingConfig.requiresPopupSupport === true && supportsPopups() === false) {
         return false;
     }
 

--- a/src/funding/funding.js
+++ b/src/funding/funding.js
@@ -19,12 +19,12 @@ type IsFundingEligibleOptions = {|
     components : $ReadOnlyArray<$Values<typeof COMPONENTS>>,
     onShippingChange : ?Function,
     wallet? : ?Wallet,
-    supportsPopups? : ?boolean,
-    thirdPartyMobileBrowser? : ?boolean
+    supportsPopups? : boolean,
+    supportedNativeBrowser? : boolean
 |};
 
 export function isFundingEligible(source : $Values<typeof FUNDING>,
-    { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, wallet, supportsPopups, thirdPartyMobileBrowser } : IsFundingEligibleOptions) : boolean {
+    { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, wallet, supportsPopups, supportedNativeBrowser } : IsFundingEligibleOptions) : boolean {
 
     if (!fundingEligibility[source] || !fundingEligibility[source].eligible) {
         return false;
@@ -68,7 +68,7 @@ export function isFundingEligible(source : $Values<typeof FUNDING>,
         return false;
     }
 
-    if (fundingConfig.supportsThirdPartyMobileBrowsers === false && thirdPartyMobileBrowser === true) {
+    if (fundingConfig.requiresSupportedNativeBrowser === true && supportedNativeBrowser === false) {
         return false;
     }
 
@@ -79,17 +79,17 @@ export function isFundingEligible(source : $Values<typeof FUNDING>,
     return true;
 }
 
-export function determineEligibleFunding({ fundingSource, layout, platform, fundingEligibility, components, onShippingChange, flow, wallet, supportsPopups, thirdPartyMobileBrowser } :
+export function determineEligibleFunding({ fundingSource, layout, platform, fundingEligibility, components, onShippingChange, flow, wallet, supportsPopups, supportedNativeBrowser } :
     {| fundingSource : ?$Values<typeof FUNDING>, remembered : $ReadOnlyArray<$Values<typeof FUNDING>>, layout : $Values<typeof BUTTON_LAYOUT>,
     platform : $Values<typeof PLATFORM>, fundingEligibility : FundingEligibilityType, components : $ReadOnlyArray<$Values<typeof COMPONENTS>>,
-    onShippingChange? : ?Function, flow : $Values<typeof BUTTON_FLOW>, wallet? : ?Wallet, supportsPopups? : ?boolean, thirdPartyMobileBrowser? : ?boolean |}) : $ReadOnlyArray<$Values<typeof FUNDING>> {
+    onShippingChange? : ?Function, flow : $Values<typeof BUTTON_FLOW>, wallet? : ?Wallet, supportsPopups? : boolean, supportedNativeBrowser? : boolean |}) : $ReadOnlyArray<$Values<typeof FUNDING>> {
 
     if (fundingSource) {
         return [ fundingSource ];
     }
 
     let eligibleFunding = values(FUNDING).filter(source =>
-        isFundingEligible(source, { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, wallet, supportsPopups, thirdPartyMobileBrowser }));
+        isFundingEligible(source, { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, wallet, supportsPopups, supportedNativeBrowser }));
 
     if (layout === BUTTON_LAYOUT.HORIZONTAL) {
         eligibleFunding = eligibleFunding.slice(0, 2);

--- a/src/funding/funding.js
+++ b/src/funding/funding.js
@@ -2,7 +2,7 @@
 
 import type { FundingEligibilityType } from '@paypal/sdk-client/src';
 import { PLATFORM, FUNDING, COMPONENTS } from '@paypal/sdk-constants/src';
-import { values, supportsPopups } from 'belter/src';
+import { values } from 'belter/src';
 
 import type { Wallet } from '../types';
 import { BUTTON_LAYOUT, BUTTON_FLOW } from '../constants';
@@ -18,11 +18,12 @@ type IsFundingEligibleOptions = {|
     fundingEligibility : FundingEligibilityType,
     components : $ReadOnlyArray<$Values<typeof COMPONENTS>>,
     onShippingChange : ?Function,
-    wallet? : ?Wallet
+    wallet? : ?Wallet,
+    supportsPopups? : boolean
 |};
 
 export function isFundingEligible(source : $Values<typeof FUNDING>,
-    { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, wallet } : IsFundingEligibleOptions) : boolean {
+    { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, wallet, supportsPopups } : IsFundingEligibleOptions) : boolean {
 
     if (!fundingEligibility[source] || !fundingEligibility[source].eligible) {
         return false;
@@ -62,7 +63,7 @@ export function isFundingEligible(source : $Values<typeof FUNDING>,
         return false;
     }
 
-    if (fundingConfig.requiresPopupSupport === true && supportsPopups() === false) {
+    if (fundingConfig.requiresPopupSupport === true && supportsPopups === false) {
         return false;
     }
 

--- a/src/funding/venmo/config.jsx
+++ b/src/funding/venmo/config.jsx
@@ -11,6 +11,7 @@ export function getVenmoConfig() : FundingSourceConfig {
     return {
         ...DEFAULT_FUNDING_CONFIG,
 
+        shippingChange:       false,
         requiresPopupSupport: true,
 
         platforms: [
@@ -44,22 +45,6 @@ export function getVenmoConfig() : FundingSourceConfig {
             [ BUTTON_COLOR.GOLD ]:   BUTTON_COLOR.BLUE,
             [ BUTTON_COLOR.BLUE ]:   BUTTON_COLOR.SILVER,
             [ BUTTON_COLOR.SILVER ]: BUTTON_COLOR.BLUE
-        },
-
-        eligible: ({ fundingEligibility, layout }) => {
-            if (layout === BUTTON_LAYOUT.VERTICAL) {
-                return true;
-            }
-
-            if (fundingEligibility.venmo && fundingEligibility.venmo.recommended) {
-                return true;
-            }
-
-            if (fundingEligibility.credit && fundingEligibility.credit.eligible) {
-                return false;
-            }
-
-            return true;
         }
     };
 }

--- a/src/funding/venmo/config.jsx
+++ b/src/funding/venmo/config.jsx
@@ -11,8 +11,9 @@ export function getVenmoConfig() : FundingSourceConfig {
     return {
         ...DEFAULT_FUNDING_CONFIG,
 
-        shippingChange:       false,
-        requiresPopupSupport: true,
+        requiresPopupSupport:           true,
+        shippingChange:                 false,
+        supports3rdPartyMobileBrowsers: false,
 
         platforms: [
             PLATFORM.MOBILE

--- a/src/funding/venmo/config.jsx
+++ b/src/funding/venmo/config.jsx
@@ -12,8 +12,8 @@ export function getVenmoConfig() : FundingSourceConfig {
         ...DEFAULT_FUNDING_CONFIG,
 
         requiresPopupSupport:             true,
+        requiresSupportedNativeBrowser:   true,
         shippingChange:                   false,
-        requiresSupportedNativeBrowser: false,
 
         platforms: [
             PLATFORM.MOBILE

--- a/src/funding/venmo/config.jsx
+++ b/src/funding/venmo/config.jsx
@@ -11,9 +11,9 @@ export function getVenmoConfig() : FundingSourceConfig {
     return {
         ...DEFAULT_FUNDING_CONFIG,
 
-        requiresPopupSupport:           true,
-        shippingChange:                 false,
-        supports3rdPartyMobileBrowsers: false,
+        requiresPopupSupport:             true,
+        shippingChange:                   false,
+        supportsThirdPartyMobileBrowsers: false,
 
         platforms: [
             PLATFORM.MOBILE

--- a/src/funding/venmo/config.jsx
+++ b/src/funding/venmo/config.jsx
@@ -10,7 +10,9 @@ import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
 export function getVenmoConfig() : FundingSourceConfig {
     return {
         ...DEFAULT_FUNDING_CONFIG,
-    
+
+        requiresPopupSupport: true,
+
         platforms: [
             PLATFORM.MOBILE
         ],
@@ -21,21 +23,21 @@ export function getVenmoConfig() : FundingSourceConfig {
         ],
 
         Logo: ({ logoColor, optional }) => VenmoLogo({ logoColor, optional }),
-    
+
         colors: [
             BUTTON_COLOR.BLUE,
             BUTTON_COLOR.SILVER,
             BUTTON_COLOR.BLACK,
             BUTTON_COLOR.WHITE
         ],
-    
+
         logoColors:  {
             [ BUTTON_COLOR.BLUE ]:   LOGO_COLOR.WHITE,
             [ BUTTON_COLOR.SILVER ]: LOGO_COLOR.BLUE,
             [ BUTTON_COLOR.BLACK ]:  LOGO_COLOR.WHITE,
             [ BUTTON_COLOR.WHITE ]:  LOGO_COLOR.BLUE
         },
-    
+
         secondaryColors: {
             ...DEFAULT_FUNDING_CONFIG.secondaryColors,
 

--- a/src/funding/venmo/config.jsx
+++ b/src/funding/venmo/config.jsx
@@ -13,7 +13,7 @@ export function getVenmoConfig() : FundingSourceConfig {
 
         requiresPopupSupport:             true,
         shippingChange:                   false,
-        supportsThirdPartyMobileBrowsers: false,
+        requiresSupportedNativeBrowser: false,
 
         platforms: [
             PLATFORM.MOBILE

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -95,10 +95,10 @@ export function validateButtonProps(props : ButtonPropsInputs) {
 export function Buttons(props : ButtonsProps) : ElementNode {
     const { onClick = noop } = props;
     const { wallet, fundingSource, style, locale, remembered, env, fundingEligibility, platform, commit, vault,
-        nonce, components, onShippingChange, personalization, userIDToken, content, flow, experiment } = normalizeButtonProps(props);
+        nonce, components, onShippingChange, personalization, userIDToken, content, flow, experiment, supportsPopups, thirdPartyMobileBrowser } = normalizeButtonProps(props);
     const { layout, shape, tagline } = style;
 
-    let fundingSources = determineEligibleFunding({ fundingSource, layout, remembered, platform, fundingEligibility, components, onShippingChange, flow, wallet });
+    let fundingSources = determineEligibleFunding({ fundingSource, layout, remembered, platform, fundingEligibility, components, onShippingChange, flow, wallet, supportsPopups, thirdPartyMobileBrowser });
     const multiple = fundingSources.length > 1;
 
     if (!fundingSources.length) {

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -95,10 +95,10 @@ export function validateButtonProps(props : ButtonPropsInputs) {
 export function Buttons(props : ButtonsProps) : ElementNode {
     const { onClick = noop } = props;
     const { wallet, fundingSource, style, locale, remembered, env, fundingEligibility, platform, commit, vault,
-        nonce, components, onShippingChange, personalization, userIDToken, content, flow, experiment, supportsPopups, thirdPartyMobileBrowser } = normalizeButtonProps(props);
+        nonce, components, onShippingChange, personalization, userIDToken, content, flow, experiment, supportsPopups, supportedNativeBrowser } = normalizeButtonProps(props);
     const { layout, shape, tagline } = style;
 
-    let fundingSources = determineEligibleFunding({ fundingSource, layout, remembered, platform, fundingEligibility, components, onShippingChange, flow, wallet, supportsPopups, thirdPartyMobileBrowser });
+    let fundingSources = determineEligibleFunding({ fundingSource, layout, remembered, platform, fundingEligibility, components, onShippingChange, flow, wallet, supportsPopups, supportedNativeBrowser });
     const multiple = fundingSources.length > 1;
 
     if (!fundingSources.length) {

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -230,7 +230,8 @@ export type ButtonProps = {|
     flow : $Values<typeof BUTTON_FLOW>,
     experiment : Experiment,
     vault : boolean,
-    components : $ReadOnlyArray<$Values<typeof COMPONENTS>>
+    components : $ReadOnlyArray<$Values<typeof COMPONENTS>>,
+    supportsPopups : boolean
 |};
 
 // eslint-disable-next-line flowtype/require-exact-type
@@ -335,7 +336,7 @@ export function normalizeButtonStyle(props : ?ButtonPropsInputs, style : ButtonS
         if (typeof height !== 'number') {
             throw new TypeError(`Expected style.height to be a number, got: ${ height }`);
         }
-        
+
         const [ minHeight, maxHeight ] = [ BUTTON_SIZE_STYLE[BUTTON_SIZE.SMALL].minHeight, BUTTON_SIZE_STYLE[BUTTON_SIZE.HUGE].maxHeight ];
 
         if (height < minHeight || height > maxHeight) {

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -231,7 +231,7 @@ export type ButtonProps = {|
     experiment : Experiment,
     vault : boolean,
     components : $ReadOnlyArray<$Values<typeof COMPONENTS>>,
-    supportsPopups : boolean
+    userAgent : string
 |};
 
 // eslint-disable-next-line flowtype/require-exact-type

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -189,7 +189,9 @@ export type RenderButtonProps = {|
     flow : $Values<typeof BUTTON_FLOW>,
     experiment : Experiment,
     vault : boolean,
-    userIDToken : ?string
+    userIDToken : ?string,
+    supportsPopups : ?boolean,
+    thirdPartyMobileBrowser : ?boolean
 |};
 
 export type PrerenderDetails = {|
@@ -231,7 +233,8 @@ export type ButtonProps = {|
     experiment : Experiment,
     vault : boolean,
     components : $ReadOnlyArray<$Values<typeof COMPONENTS>>,
-    userAgent : string
+    supportsPopups : boolean,
+    thirdPartyMobileBrowser : boolean
 |};
 
 // eslint-disable-next-line flowtype/require-exact-type
@@ -264,7 +267,9 @@ export type ButtonPropsInputs = {
     flow? : $Values<typeof BUTTON_FLOW>,
     experiment : Experiment,
     vault : boolean,
-    userIDToken : ?string
+    userIDToken : ?string,
+    supportsPopups? : boolean,
+    thirdPartyMobileBrowser? : boolean
 };
 
 export const DEFAULT_STYLE = {
@@ -397,7 +402,9 @@ export function normalizeButtonProps(props : ?ButtonPropsInputs) : RenderButtonP
         flow = BUTTON_FLOW.PURCHASE,
         experiment = getDefaultExperiment(),
         vault,
-        userIDToken
+        userIDToken,
+        supportsPopups,
+        thirdPartyMobileBrowser
     } = props;
 
     const { country, lang } = locale;
@@ -444,5 +451,5 @@ export function normalizeButtonProps(props : ?ButtonPropsInputs) : RenderButtonP
 
     return { clientID, fundingSource, style, locale, remembered, env, fundingEligibility, platform, clientAccessToken,
         buttonSessionID, commit, sessionID, nonce, components, onShippingChange, personalization, content, wallet, flow,
-        experiment, vault, userIDToken };
+        experiment, vault, userIDToken, supportsPopups, thirdPartyMobileBrowser };
 }

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -190,8 +190,8 @@ export type RenderButtonProps = {|
     experiment : Experiment,
     vault : boolean,
     userIDToken : ?string,
-    supportsPopups : ?boolean,
-    thirdPartyMobileBrowser : ?boolean
+    supportsPopups : boolean,
+    supportedNativeBrowser : boolean
 |};
 
 export type PrerenderDetails = {|
@@ -234,7 +234,7 @@ export type ButtonProps = {|
     vault : boolean,
     components : $ReadOnlyArray<$Values<typeof COMPONENTS>>,
     supportsPopups : boolean,
-    thirdPartyMobileBrowser : boolean
+    supportedNativeBrowser : boolean
 |};
 
 // eslint-disable-next-line flowtype/require-exact-type
@@ -268,8 +268,8 @@ export type ButtonPropsInputs = {
     experiment : Experiment,
     vault : boolean,
     userIDToken : ?string,
-    supportsPopups? : boolean,
-    thirdPartyMobileBrowser? : boolean
+    supportsPopups : boolean,
+    supportedNativeBrowser : boolean
 };
 
 export const DEFAULT_STYLE = {
@@ -403,8 +403,8 @@ export function normalizeButtonProps(props : ?ButtonPropsInputs) : RenderButtonP
         experiment = getDefaultExperiment(),
         vault,
         userIDToken,
-        supportsPopups,
-        thirdPartyMobileBrowser
+        supportsPopups = false,
+        supportedNativeBrowser = false
     } = props;
 
     const { country, lang } = locale;
@@ -442,7 +442,7 @@ export function normalizeButtonProps(props : ?ButtonPropsInputs) : RenderButtonP
             throw new Error(`Invalid funding source: ${ fundingSource }`);
         }
 
-        if (!isFundingEligible(fundingSource, { platform, fundingSource, fundingEligibility, components, onShippingChange, flow, wallet })) {
+        if (!isFundingEligible(fundingSource, { platform, fundingSource, fundingEligibility, components, onShippingChange, flow, wallet, supportsPopups, supportedNativeBrowser })) {
             throw new Error(`Funding Source not eligible: ${ fundingSource }`);
         }
     }
@@ -451,5 +451,5 @@ export function normalizeButtonProps(props : ?ButtonPropsInputs) : RenderButtonP
 
     return { clientID, fundingSource, style, locale, remembered, env, fundingEligibility, platform, clientAccessToken,
         buttonSessionID, commit, sessionID, nonce, components, onShippingChange, personalization, content, wallet, flow,
-        experiment, vault, userIDToken, supportsPopups, thirdPartyMobileBrowser };
+        experiment, vault, userIDToken, supportsPopups, supportedNativeBrowser };
 }

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -9,7 +9,7 @@ import { getLogger, getLocale, getClientID, getEnv, getIntent, getCommit, getVau
 import { rememberFunding, getRememberedFunding, getRefinedFundingEligibility } from '@paypal/funding-components/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { create, type ZoidComponent } from 'zoid/src';
-import { uniqueID, memoize } from 'belter/src';
+import { uniqueID, memoize, supportsPopups as userAgentSupportsPopups } from 'belter/src';
 import { FUNDING, FUNDING_BRAND_LABEL, QUERY_BOOL, ENV } from '@paypal/sdk-constants/src';
 import { node, dom } from 'jsx-pragmatic/src';
 
@@ -31,7 +31,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
         url: () => `${ getPayPalDomain() }${ window.__CHECKOUT_URI__ || __PAYPAL_CHECKOUT__.__URI__.__BUTTONS__ }`,
 
         domain: getPayPalDomainRegex(),
-        
+
         autoResize: {
             width:  false,
             height: true
@@ -62,7 +62,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
         },
 
         eligible: ({ props }) => {
-            const { fundingSource, onShippingChange, style = {}, fundingEligibility = getRefinedFundingEligibility() } = props;
+            const { fundingSource, onShippingChange, style = {}, fundingEligibility = getRefinedFundingEligibility(), supportsPopups } = props;
             const flow = determineFlow(props);
 
             if (!fundingSource) {
@@ -80,7 +80,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
             const platform           = getPlatform();
             const components         = getComponents();
 
-            if (isFundingEligible(fundingSource, { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow })) {
+            if (isFundingEligible(fundingSource, { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, supportsPopups })) {
                 return {
                     eligible: true
                 };
@@ -102,7 +102,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                     const { fundingSource, onShippingChange, style = {}, fundingEligibility = getRefinedFundingEligibility() } = props;
                     const flow = determineFlow(props);
                     const { layout } = style;
-        
+
                     const platform           = getPlatform();
                     const components         = getComponents();
 
@@ -286,7 +286,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 required:   false,
                 queryParam: true
             },
-            
+
             env: {
                 type:       'string',
                 queryParam: true,
@@ -390,19 +390,19 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 queryParam: true,
                 value:      getEnableFunding
             },
-            
+
             disableFunding: {
                 type:       'array',
                 queryParam: true,
                 value:      getDisableFunding
             },
-            
+
             disableCard: {
                 type:       'array',
                 queryParam: true,
                 value:      getDisableCard
             },
-            
+
             merchantID: {
                 type:       'array',
                 queryParam: true,
@@ -418,7 +418,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                     };
                 }
             },
-            
+
             getPageUrl: {
                 type:  'function',
                 value: () => {
@@ -471,6 +471,12 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 type:       'boolean',
                 queryParam: true,
                 required:   false
+            },
+
+            supportsPopups: {
+                type:       'boolean',
+                value:      () => userAgentSupportsPopups(),
+                queryParam: true
             }
         }
     });

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -483,6 +483,10 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
             supportedNativeBrowser: {
                 type:       'boolean',
                 value:      () => {
+                    if (!userAgentSupportsPopups()) {
+                        return false;
+                    }
+
                     if (isIos() && isSafari()) {
                         return true;
                     }

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -9,7 +9,7 @@ import { getLogger, getLocale, getClientID, getEnv, getIntent, getCommit, getVau
 import { rememberFunding, getRememberedFunding, getRefinedFundingEligibility } from '@paypal/funding-components/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { create, type ZoidComponent } from 'zoid/src';
-import { uniqueID, memoize, supportsPopups as userAgentSupportsPopups } from 'belter/src';
+import { uniqueID, memoize, getUserAgent } from 'belter/src';
 import { FUNDING, FUNDING_BRAND_LABEL, QUERY_BOOL, ENV } from '@paypal/sdk-constants/src';
 import { node, dom } from 'jsx-pragmatic/src';
 
@@ -62,7 +62,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
         },
 
         eligible: ({ props }) => {
-            const { fundingSource, onShippingChange, style = {}, fundingEligibility = getRefinedFundingEligibility(), supportsPopups } = props;
+            const { fundingSource, onShippingChange, style = {}, fundingEligibility = getRefinedFundingEligibility(), userAgent } = props;
             const flow = determineFlow(props);
 
             if (!fundingSource) {
@@ -80,7 +80,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
             const platform           = getPlatform();
             const components         = getComponents();
 
-            if (isFundingEligible(fundingSource, { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, supportsPopups })) {
+            if (isFundingEligible(fundingSource, { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, userAgent })) {
                 return {
                     eligible: true
                 };
@@ -473,9 +473,9 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 required:   false
             },
 
-            supportsPopups: {
-                type:       'boolean',
-                value:      () => userAgentSupportsPopups(),
+            userAgent: {
+                type:       'string',
+                value:      getUserAgent,
                 queryParam: true
             }
         }

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -62,7 +62,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
         },
 
         eligible: ({ props }) => {
-            const { fundingSource, onShippingChange, style = {}, fundingEligibility = getRefinedFundingEligibility(), supportsPopups, thirdPartyMobileBrowser } = props;
+            const { fundingSource, onShippingChange, style = {}, fundingEligibility = getRefinedFundingEligibility(), supportsPopups, supportedNativeBrowser } = props;
             const flow = determineFlow(props);
 
             if (!fundingSource) {
@@ -80,7 +80,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
             const platform           = getPlatform();
             const components         = getComponents();
 
-            if (isFundingEligible(fundingSource, { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, supportsPopups, thirdPartyMobileBrowser })) {
+            if (isFundingEligible(fundingSource, { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, supportsPopups, supportedNativeBrowser })) {
                 return {
                     eligible: true
                 };
@@ -480,14 +480,14 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 queryParam: true
             },
 
-            thirdPartyMobileBrowser: {
+            supportedNativeBrowser: {
                 type:       'boolean',
                 value:      () => {
-                    if (isIos() && !isSafari()) {
+                    if (isIos() && isSafari()) {
                         return true;
                     }
 
-                    if (isAndroid() && !isChrome()) {
+                    if (isAndroid() && isChrome()) {
                         return true;
                     }
 


### PR DESCRIPTION
This PR updates the client-side eligibility logic for venmo related to the user agent string. 

The venmo button should only display on mobile when using a valid native browser (we do not support 3rd party browsers like Chrome on iOS). It will make the venmo ineligible for the following use cases:
- WebViews (handled by `supportsPopups`)
- 3rd party mobile browsers (handled by `supportedNativeBrowser`)
- when `onShippingChange` is used

This new `requiresPopupSupport` eligibility setting is tied to this function in belter: https://github.com/krakenjs/belter/blob/821f3e135a055c1607313f8b604eda0cbc685ad3/src/device.js#L136. 


### Test Cases

I've been running the apps locally and testing with different user agent strings. Here are some screenshots:


Smart buttons - valid Android UA
<img width="427" alt="pixel-2-valid-user-agent-string" src="https://user-images.githubusercontent.com/534034/106664030-26fd3800-656a-11eb-8dd2-5f9ade16ecb1.png">

Smart buttons  - invalid WebView UA
<img width="415" alt="facebook-webview-invalid-user-agent-string" src="https://user-images.githubusercontent.com/534034/106664168-4eec9b80-656a-11eb-87cc-526cfde07b1b.png">

- Standalone button - valid iPhone UA
<img width="413" alt="standalone-valid-user-agent-string" src="https://user-images.githubusercontent.com/534034/106663720-b9e9a280-6569-11eb-9e4e-f84eac1d6674.png">



