### PR TITLE
Fix eligibility call for standalone venmo button

### DIFF
--- a/src/funding/funding.js
+++ b/src/funding/funding.js
@@ -19,8 +19,8 @@ type IsFundingEligibleOptions = {|
     components : $ReadOnlyArray<$Values<typeof COMPONENTS>>,
     onShippingChange : ?Function,
     wallet? : ?Wallet,
-    supportsPopups? : boolean,
-    supportedNativeBrowser? : boolean
+    supportsPopups : boolean,
+    supportedNativeBrowser : boolean
 |};
 
 export function isFundingEligible(source : $Values<typeof FUNDING>,
@@ -82,7 +82,7 @@ export function isFundingEligible(source : $Values<typeof FUNDING>,
 export function determineEligibleFunding({ fundingSource, layout, platform, fundingEligibility, components, onShippingChange, flow, wallet, supportsPopups, supportedNativeBrowser } :
     {| fundingSource : ?$Values<typeof FUNDING>, remembered : $ReadOnlyArray<$Values<typeof FUNDING>>, layout : $Values<typeof BUTTON_LAYOUT>,
     platform : $Values<typeof PLATFORM>, fundingEligibility : FundingEligibilityType, components : $ReadOnlyArray<$Values<typeof COMPONENTS>>,
-    onShippingChange? : ?Function, flow : $Values<typeof BUTTON_FLOW>, wallet? : ?Wallet, supportsPopups? : boolean, supportedNativeBrowser? : boolean |}) : $ReadOnlyArray<$Values<typeof FUNDING>> {
+    onShippingChange? : ?Function, flow : $Values<typeof BUTTON_FLOW>, wallet? : ?Wallet, supportsPopups : boolean, supportedNativeBrowser : boolean |}) : $ReadOnlyArray<$Values<typeof FUNDING>> {
 
     if (fundingSource) {
         return [ fundingSource ];

--- a/src/marks/component.jsx
+++ b/src/marks/component.jsx
@@ -3,7 +3,7 @@
 
 import { node, dom } from 'jsx-pragmatic/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
-import { getElement, isDevice, memoize } from 'belter/src';
+import { getElement, isDevice, memoize, supportsPopups as userAgentSupportsPopups } from 'belter/src';
 import { PLATFORM, FUNDING } from '@paypal/sdk-constants/src';
 import { getRememberedFunding } from '@paypal/funding-components/src';
 import { getComponents, getFundingEligibility, getEnv } from '@paypal/sdk-client/src';
@@ -11,6 +11,7 @@ import { getComponents, getFundingEligibility, getEnv } from '@paypal/sdk-client
 import type { OnShippingChange } from '../ui/buttons/props';
 import { BUTTON_LAYOUT, BUTTON_FLOW } from '../constants';
 import { determineEligibleFunding, isFundingEligible } from '../funding';
+import { isSupportedNativeBrowser } from '../zoid/buttons/util';
 
 import { MarksElement } from './template';
 
@@ -38,7 +39,9 @@ export const getMarksComponent : () => MarksComponent = memoize(() => {
         const layout = BUTTON_LAYOUT.VERTICAL;
         const components = getComponents();
         const flow = BUTTON_FLOW.PURCHASE;
-        const fundingSources = determineEligibleFunding({ fundingSource, fundingEligibility, components, platform, remembered, layout, flow });
+        const supportsPopups = userAgentSupportsPopups();
+        const supportedNativeBrowser = isSupportedNativeBrowser();
+        const fundingSources = determineEligibleFunding({ fundingSource, fundingEligibility, components, platform, remembered, layout, flow, supportsPopups, supportedNativeBrowser });
         const experiment = {};
         const env = getEnv();
 
@@ -47,7 +50,7 @@ export const getMarksComponent : () => MarksComponent = memoize(() => {
                 return true;
             }
 
-            return isFundingEligible(fundingSource, { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow });
+            return isFundingEligible(fundingSource, { layout, platform, fundingSource, fundingEligibility, components, onShippingChange, flow, supportsPopups, supportedNativeBrowser });
         };
 
         const render = (container) => {

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -1,4 +1,5 @@
 /* @flow */
+import { supportsPopups, isAndroid, isChrome, isIos, isSafari } from 'belter/src';
 
 import { BUTTON_FLOW } from '../../constants';
 import type { ButtonProps } from '../../ui/buttons/props';
@@ -12,4 +13,24 @@ export function determineFlow(props : ButtonProps) : $Values<typeof BUTTON_FLOW>
     } else {
         return BUTTON_FLOW.PURCHASE;
     }
+}
+
+export function isSupportedNativeBrowser() : boolean {
+    if (typeof window === 'undefined') {
+        return false;
+    }
+
+    if (!supportsPopups()) {
+        return false;
+    }
+
+    if (isIos() && isSafari()) {
+        return true;
+    }
+
+    if (isAndroid() && isChrome()) {
+        return true;
+    }
+
+    return false;
 }

--- a/test/integration/tests/button/standalone.js
+++ b/test/integration/tests/button/standalone.js
@@ -48,11 +48,11 @@ describe(`paypal standalone buttons`, () => {
                     fundingSource
 
                 });
-                
+
                 if (!button.isEligible()) {
                     throw new Error(`Expected button to be eligible`);
                 }
-                
+
                 return button.render('#testContainer');
             });
         });
@@ -73,7 +73,7 @@ describe(`paypal standalone buttons`, () => {
                 if (button.isEligible()) {
                     throw new Error(`Expected button to not be eligible`);
                 }
-                
+
                 return button.render('#testContainer').catch(expect('buttonRenderCatch')).then(() => {
                     mockEligibility.cancel();
                 });
@@ -100,6 +100,29 @@ describe(`paypal standalone buttons`, () => {
             });
         });
     });
+
+    it(`should render a standalone venmo button and error out when using an unsupported native browser`, () => {
+        return wrapPromise(({ expect }) => {
+            const fundingSource = FUNDING.VENMO;
+
+            // ineligible user agent - chrome on ios
+            window.navigator.mockUserAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/78.0.3904.84 Mobile/15E148 Safari/604.1';
+
+            const button = window.paypal.Buttons({
+                test: {},
+                fundingSource
+            });
+
+            if (button.isEligible()) {
+                throw new Error(`Expected button to not be eligible`);
+            }
+
+            return button.render('#testContainer').catch(expect('buttonRenderCatch')).then(() => {
+                window.navigator.mockUserAgent = '';
+            });
+        });
+    });
+
 
     it(`should render a standalone ideal button and error out when onShippingChange is passed, even when ideal is eligible`, () => {
         return wrapPromise(({ expect }) => {

--- a/test/integration/tests/button/standalone.js
+++ b/test/integration/tests/button/standalone.js
@@ -5,7 +5,7 @@ import { FUNDING } from '@paypal/sdk-constants/src';
 import { wrapPromise } from 'belter/src';
 import { SUPPORTED_FUNDING_SOURCES } from '@paypal/funding-components/src';
 
-import { createTestContainer, destroyTestContainer, IPHONE6_USER_AGENT, mockProp } from '../common';
+import { createTestContainer, destroyTestContainer, IPHONE6_USER_AGENT, WEBVIEW_USER_AGENT, mockProp } from '../common';
 
 describe(`paypal standalone buttons`, () => {
 
@@ -101,12 +101,10 @@ describe(`paypal standalone buttons`, () => {
         });
     });
 
-    it(`should render a standalone venmo button and error out when using an unsupported native browser`, () => {
+    it(`should render a standalone venmo button and error out for webviews`, () => {
         return wrapPromise(({ expect }) => {
             const fundingSource = FUNDING.VENMO;
-
-            // ineligible user agent - chrome on ios
-            window.navigator.mockUserAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/78.0.3904.84 Mobile/15E148 Safari/604.1';
+            window.navigator.mockUserAgent = WEBVIEW_USER_AGENT;
 
             const button = window.paypal.Buttons({
                 test: {},

--- a/test/integration/tests/button/standalone.js
+++ b/test/integration/tests/button/standalone.js
@@ -123,7 +123,6 @@ describe(`paypal standalone buttons`, () => {
         });
     });
 
-
     it(`should render a standalone ideal button and error out when onShippingChange is passed, even when ideal is eligible`, () => {
         return wrapPromise(({ expect }) => {
             const fundingSource = FUNDING.IDEAL;

--- a/test/integration/tests/marks/standalone.js
+++ b/test/integration/tests/marks/standalone.js
@@ -5,7 +5,7 @@ import { FUNDING } from '@paypal/sdk-constants/src';
 import { wrapPromise } from 'belter/src';
 import { SUPPORTED_FUNDING_SOURCES } from '@paypal/funding-components/src';
 
-import { createTestContainer, destroyTestContainer, IPHONE6_USER_AGENT, mockProp } from '../common';
+import { createTestContainer, destroyTestContainer, IPHONE6_USER_AGENT, WEBVIEW_USER_AGENT, mockProp } from '../common';
 
 describe(`paypal standalone marks`, () => {
 
@@ -90,12 +90,10 @@ describe(`paypal standalone marks`, () => {
         });
     });
 
-    it(`should render a standalone venmo mark and error out when using an unsupported native browser`, () => {
+    it(`should render a standalone venmo mark and error out for webviews`, () => {
         return wrapPromise(({ expect }) => {
             const fundingSource = FUNDING.VENMO;
-
-            // ineligible user agent - chrome on ios
-            window.navigator.mockUserAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/78.0.3904.84 Mobile/15E148 Safari/604.1';
+            window.navigator.mockUserAgent = WEBVIEW_USER_AGENT;
 
             const mark = window.paypal.Marks({
                 test: {},

--- a/test/integration/tests/marks/standalone.js
+++ b/test/integration/tests/marks/standalone.js
@@ -21,7 +21,7 @@ describe(`paypal standalone marks`, () => {
         if (!window.__TEST_FUNDING_ELIGIBILITY__[fundingSource]) {
             continue;
         }
-        
+
         it(`should render a standalone ${ fundingSource } mark and succeed when eligible`, () => {
             return wrapPromise(() => {
                 if (fundingSource === FUNDING.VENMO) {
@@ -35,11 +35,11 @@ describe(`paypal standalone marks`, () => {
                     fundingSource
 
                 });
-                
+
                 if (!mark.isEligible()) {
                     throw new Error(`Expected mark to be eligible`);
                 }
-                
+
                 return mark.render('#testContainer').then(() => {
                     mockEligibility.cancel();
                 });
@@ -62,7 +62,7 @@ describe(`paypal standalone marks`, () => {
                 if (mark.isEligible()) {
                     throw new Error(`Expected mark to not be eligible`);
                 }
-                
+
                 return mark.render('#testContainer').catch(expect('markRenderCatch')).then(() => {
                     mockEligibility.cancel();
                 });
@@ -86,6 +86,28 @@ describe(`paypal standalone marks`, () => {
 
             return mark.render('#testContainer').catch(expect('markRenderCatch')).then(() => {
                 mockEligibility.cancel();
+            });
+        });
+    });
+
+    it(`should render a standalone venmo mark and error out when using an unsupported native browser`, () => {
+        return wrapPromise(({ expect }) => {
+            const fundingSource = FUNDING.VENMO;
+
+            // ineligible user agent - chrome on ios
+            window.navigator.mockUserAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/78.0.3904.84 Mobile/15E148 Safari/604.1';
+
+            const mark = window.paypal.Marks({
+                test: {},
+                fundingSource
+            });
+
+            if (mark.isEligible()) {
+                throw new Error(`Expected mark to not be eligible`);
+            }
+
+            return mark.render('#testContainer').catch(expect('markRenderCatch')).then(() => {
+                window.navigator.mockUserAgent = '';
             });
         });
     });


### PR DESCRIPTION
This PR fixes the `isEligible()` call for the Venmo standalone button. It also updates the Marks component to pass in `supportsPopups` and `supportedNativeBrowser`.

The `isEligible()` call doesn't know about derived props so it was unable to use them. Ex:
<img width="1340" alt="eligible-screenshot" src="https://user-images.githubusercontent.com/534034/106980440-cb77a980-6725-11eb-8572-87ed409f2535.png">

This PR fixes the issue by calculating these values when no prop is passed in. It assumes that isEligible() will only be called on the client.


Screenshot of venmo button and venmo mark rendering on an Android Pixel 2 user agent string:
<img width="322" alt="venmo-button-and-mark-screenshot" src="https://user-images.githubusercontent.com/534034/106980617-201b2480-6726-11eb-851d-70f5cf1a434d.png">