### PR TITLE
Add 'supportedNativeBrowser' as a valid query param

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -490,7 +490,8 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
 
             supportedNativeBrowser: {
                 type:       'boolean',
-                value:      isSupportedNativeBrowser
+                value:      isSupportedNativeBrowser,
+                queryParam: true
             }
         }
     });


### PR DESCRIPTION
This fixes a bug with the new venmo eligibility logic. Previously `supportedNativeBrowser` wasn't being passed to the server as a query param so it broke eligibility on the server render.

Here's a screenshot of the fix showing these parameters being passed to the server locally:
<img width="1306" alt="venmo-eligibility-query-params" src="https://user-images.githubusercontent.com/534034/107278253-1d1c7e80-6a1b-11eb-9ad8-2ae1e4579d4d.png">
