### PR TITLE
adds useNewVenmoPath query param

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -497,7 +497,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
             useNewVenmoPath: {
                 type:       'boolean',
                 required:   false,
-                value:      ({ props }) => props && props.fundingSource && props.fundingSource === FUNDING.VENMO,
+                // value:      ({ props }) => props && props.fundingSource && props.fundingSource === FUNDING.VENMO,
                 queryParam: true
             }
         }

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -492,6 +492,13 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 type:       'boolean',
                 value:      isSupportedNativeBrowser,
                 queryParam: true
+            },
+
+            useNewVenmoPath: {
+                type:       'boolean',
+                required:   false,
+                value:      ({ props }) => props && props.fundingSource && props.fundingSource === FUNDING.VENMO,
+                queryParam: true
             }
         }
     });


### PR DESCRIPTION
Adds the query param `useNewVenmoPath` for use when venmo is used as the funding source.

**Testing locally:**  
- clone & run this repo this repo locally: `npm install && npm run dev`  
- clone a local version of [clientsdknodeweb](https://github.paypal.com/Checkout-R/clientsdknodeweb) and [alias](https://github.paypal.com/Checkout-R/clientsdknodeweb#mounting-local-client-modules) it to your local version of `paypal-checkout-components` before [running it locally ](https://github.paypal.com/Checkout-R/clientsdknodeweb#quick-start)
- stick the 2 test files found [here](https://git.io/Jt5ZM) in a directory and `npm install && node app.js`. It's set up to run a test page at `http://localhost:3000/` which loads a Venmo button using the version of `clientsdknodeweb` that you have running locally, which is pulling from the local copy of `paypal-checkout-components`
- if you run into an SSL/HSTS issue when trying to load the test page do the `thisisunsafe` [thing](https://dev.to/brettimus/this-is-unsafe-and-a-bad-idea-5ej4)


![Screen Shot 2021-02-24 at 1 21 01 PM](https://user-images.githubusercontent.com/3858622/109054335-5d2e6300-76a3-11eb-8814-a38eb56ac18a.png)

<!-- 
To test:  
Run [clientsdknodeweb](https://github.paypal.com/Checkout-R/clientsdknodeweb/tree/release)
-->