### PR TITLE
Fix passed style object being mutated.

### DIFF
--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -310,11 +310,10 @@ export function normalizeButtonStyle(props : ?ButtonPropsInputs, style : ButtonS
         throw new Error(`Expected ${ fundingSource || FUNDING.PAYPAL } to be eligible`);
     }
 
-    style.color = style.color ? style.color : fundingConfig.colors[0];
     const {
         label,
         layout = fundingSource ? BUTTON_LAYOUT.HORIZONTAL : fundingConfig.layouts[0],
-        color = fundingConfig.colors[0],
+        color = style.color || fundingConfig.colors[0],
         shape = fundingConfig.shapes[0],
         tagline = (layout === BUTTON_LAYOUT.HORIZONTAL && !fundingSource),
         height,


### PR DESCRIPTION
Currently the style object passed to the SDK get mutated to add `gold` when no color is passed. This can cause some issues when the same object is passed to different buttons. See line 15 here:
https://codesandbox.io/s/fancy-snowflake-qbds5?file=/src/index.js

This PR fixes this by setting the value in the deconstructed constant instead.