### PR TITLE
Update style tests

### DIFF
--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -319,7 +319,7 @@ export function normalizeButtonStyle(props : ?ButtonPropsInputs, style : ButtonS
         period
     } = style;
 
-    // if color is a empty or whitespace, reset it to undefined
+    // if color is a falsy value, set it to the default color from the funding config
     const color = style.color ? style.color : fundingConfig.colors[0];
 
     if (values(BUTTON_LAYOUT).indexOf(layout) === -1) {

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -310,16 +310,17 @@ export function normalizeButtonStyle(props : ?ButtonPropsInputs, style : ButtonS
         throw new Error(`Expected ${ fundingSource || FUNDING.PAYPAL } to be eligible`);
     }
 
-    style.color = style.color ? style.color : fundingConfig.colors[0];
     const {
         label,
         layout = fundingSource ? BUTTON_LAYOUT.HORIZONTAL : fundingConfig.layouts[0],
-        color = fundingConfig.colors[0],
         shape = fundingConfig.shapes[0],
         tagline = (layout === BUTTON_LAYOUT.HORIZONTAL && !fundingSource),
         height,
         period
     } = style;
+
+    // if color is a empty or whitespace, reset it to undefined
+    const color = style.color ? style.color : fundingConfig.colors[0];
 
     if (values(BUTTON_LAYOUT).indexOf(layout) === -1) {
         throw new Error(`Invalid layout: ${ layout }`);

--- a/test/integration/tests/button/style.js
+++ b/test/integration/tests/button/style.js
@@ -86,16 +86,43 @@ describe('paypal button color', () => {
         }).render('#testContainer');
     });
 
-    it('should render a button with gold background when passed empty string', (done) => {
+    it('should set style.color to undefined when given an empty string', (done) => {
+        const style = {
+            color: ' '
+        };
+        const expected = JSON.stringify({
+            color: undefined
+        });
         done = once(done);
         window.paypal.Buttons({
-
+            style,
             test: {
-                style: {
-                    color: ''
-                },
                 onRender() {
-                    assert.ok(getElementRecursive('.paypal-button-color-gold'));
+                    if (JSON.stringify(style) !== expected) {
+                        done(new Error(`Expected style object ${ JSON.stringify(style) } to be ${ expected }`));
+                    }
+                    done();
+                }
+            },
+
+            onError: done
+
+        }).render('#testContainer');
+    });
+
+    it('should not mutate the style object', (done) => {
+        const style = {
+            shape: 'pill'
+        };
+        const expected = JSON.stringify(style);
+        done = once(done);
+        window.paypal.Buttons({
+            style,
+            test: {
+                onRender() {
+                    if (JSON.stringify(style) !== expected) {
+                        done(new Error(`Expected style object ${ JSON.stringify(style) } to remain unmodified as ${ expected }`));
+                    }
                     done();
                 }
             },

--- a/test/integration/tests/button/style.js
+++ b/test/integration/tests/button/style.js
@@ -88,7 +88,7 @@ describe('paypal button color', () => {
 
     it('should set style.color to undefined when given an empty string', (done) => {
         const style = {
-            color: ' '
+            color: ''
         };
         const expected = JSON.stringify({
             color: undefined

--- a/test/integration/tests/button/style.js
+++ b/test/integration/tests/button/style.js
@@ -61,53 +61,33 @@ describe('paypal button color', () => {
     });
 
     it('should render a button with gold background when no color is specified', () => {
-        window.paypal.Buttons({
-
-            test: {
-                onRender() {
-                    assert.ok(getElementRecursive('.paypal-button-color-gold'));
-                }
+        return window.paypal.Buttons({
+            style: {
+                color: ''
             }
-
-        }).render('#testContainer');
+        }).render('#testContainer').then(() => {
+            assert.ok(getElementRecursive('.paypal-button-color-gold'));
+        });
     });
 
     it('should render a button with black background when passed "black"', () => {
-        window.paypal.Buttons({
-
-            test: {
-                style: {
-                    color: 'black'
-                },
-                onRender() {
-                    assert.ok(getElementRecursive('.paypal-button-color-black'));
-                }
+        return window.paypal.Buttons({
+            style: {
+                color: 'black'
             }
-        }).render('#testContainer');
+        }).render('#testContainer').then(() => {
+            assert.ok(getElementRecursive('.paypal-button-color-black'));
+        });
     });
 
-    it('should set style.color to undefined when given an empty string', (done) => {
-        const style = {
-            color: ''
-        };
-        const expected = JSON.stringify({
-            color: undefined
+    it('should render a button with gold background when passed ""', () => {
+        return window.paypal.Buttons({
+            style: {
+                color: ''
+            }
+        }).render('#testContainer').then(() => {
+            assert.ok(getElementRecursive('.paypal-button-color-gold'));
         });
-        done = once(done);
-        window.paypal.Buttons({
-            style,
-            test: {
-                onRender() {
-                    if (JSON.stringify(style) !== expected) {
-                        done(new Error(`Expected style object ${ JSON.stringify(style) } to be ${ expected }`));
-                    }
-                    done();
-                }
-            },
-
-            onError: done
-
-        }).render('#testContainer');
     });
 
     it('should not mutate the style object', (done) => {


### PR DESCRIPTION
A recent pull request from the community revealed flaws in the style tests. This change modifies the test for empty string based on the issue brought up in that PR and adds a new test to check for style mutation

Related PR - #1568  

Update: This includes changes to all `style.color` tests and removes any mutation of the `style` object while still handling the empty string case for `style.color`