### PR TITLE
Persist correlationID prop in the query string

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -286,7 +286,8 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
             correlationID: {
                 type:       'string',
                 required:   false,
-                value:      getCorrelationID
+                value:      getCorrelationID,
+                queryParam: true
             },
 
             storageID: {
@@ -508,7 +509,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 value:      isSupportedNativeBrowser,
                 queryParam: true
             },
-            
+
             userExperienceFlow: {
                 type:       'string',
                 required:   false,


### PR DESCRIPTION
This PR updates the existing correlationID prop to persist in the query string to make it easier to debug.

This is the correlationID that gets embedded into the JS SDK script (as the `getCorrelationID()` function). It can be used to look up the logs and see the initial funding eligibility request details.

When running this PR branch locally you will see the correlationID get passed in the query string of the smart buttons call:
<img width="1541" alt="local-buttons-query-string-screenshot" src="https://user-images.githubusercontent.com/534034/112162172-d2655900-8bb9-11eb-8792-45998bd11be5.png">
