### PR TITLE
Rename prop to sdkCorrelationID

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -286,6 +286,12 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
             correlationID: {
                 type:       'string',
                 required:   false,
+                value:      getCorrelationID
+            },
+
+            sdkCorrelationID: {
+                type:       'string',
+                required:   false,
                 value:      getCorrelationID,
                 queryParam: true
             },


### PR DESCRIPTION
This PR renames the `correlationID` prop to `sdkCorrelationID` to better define what type of correlationID it is. 

We need to do this rename in a few steps:
1. Add the new `sdkCorrelationID` prop with `querystring: true` and keep the existing prop `correlationID` prop (this PR).
2. Update SPB to use the new `sdkCorrelationID` prop instead of `correlationID`
3. Remove the `correlationID` prop from checkout-components