### PR TITLE
Update GitHub actions coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    # Disable patch since it is noisy and incorrect
+    patch:
+      default:
+        enabled: no
+        if_not_found: success

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10.13, 12, 14]
+        node: [12, 14]
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
The codecov patch feature seems to be really noisy and useless in this project. This PR removes that check. 

Related threads:
- https://github.com/aws/amazon-vpc-cni-k8s/pull/1226/files
- https://community.codecov.io/t/cannot-disable-codecov-patch-check/682