### PR TITLE
Remove correlationID from buttons

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -284,12 +284,6 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 value: getEnableThreeDomainSecure
             },
 
-            correlationID: {
-                type:       'string',
-                required:   false,
-                value:      getCorrelationID
-            },
-
             sdkCorrelationID: {
                 type:       'string',
                 required:   false,


### PR DESCRIPTION
### Purpose

This PR is step 3, "Remove the correlationID prop from checkout-components," of [this PR](https://github.com/paypal/paypal-checkout-components/pull/1585). It removes `correlationID` from buttons.