### PR TITLE
Ignore errors when refocusing popup window

### DIFF
--- a/src/checkout/template/containerTemplate.jsx
+++ b/src/checkout/template/containerTemplate.jsx
@@ -7,7 +7,7 @@ import { ZalgoPromise } from 'zalgo-promise/src';
 
 import { fundingLogos } from '../../resources';
 import { BUTTON_LOGO_COLOR, CHECKOUT_OVERLAY_COLOR } from '../../constants';
-import { isIos } from '../../lib';
+import { isIos, noop } from '../../lib';
 
 import { containerContent } from './containerContent';
 import { getContainerStyle } from './containerStyle';
@@ -62,7 +62,7 @@ export function containerTemplate({ id, props, CLASS, ANIMATION, CONTEXT, EVENT,
             // eslint-disable-next-line no-alert
             window.alert('Please switch tabs to reactivate the PayPal window');
         } else {
-            ZalgoPromise.try(actions.focus).catch(actions.close);
+            ZalgoPromise.try(actions.focus).catch(noop);
         }
     }
 


### PR DESCRIPTION
### Purpose

This PR fixes the PayPal popup window crash when clicking 'Click to Continue' after minimizing it in Internet Explorer 11. This bug only applies to v4, and doesn't apply to v5.

JIRA ticket: https://engineering.paypalcorp.com/jira/browse/DTCHKINT-492