### PR TITLE
Use basic eligibility for venmo experiment

### DIFF
--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -1,8 +1,7 @@
 /* @flow */
 import { supportsPopups, isAndroid, isChrome, isIos, isSafari, isSFVC, type Experiment } from 'belter/src';
 import { FUNDING } from '@paypal/sdk-constants/src';
-import { getEnableFunding, createExperiment } from '@paypal/sdk-client/src';
-import { getRefinedFundingEligibility } from '@paypal/funding-components/src';
+import { getEnableFunding, createExperiment, getFundingEligibility } from '@paypal/sdk-client/src';
 
 import type { Experiment as VenmoExperiment } from '../../types';
 import { BUTTON_FLOW } from '../../constants';
@@ -47,7 +46,7 @@ export function createVenmoExperiment() : Experiment | void {
     const enableFunding = getEnableFunding();
     const isEnableFundingVenmo = enableFunding && enableFunding.indexOf(FUNDING.VENMO) !== -1;
 
-    const fundingEligibility = getRefinedFundingEligibility();
+    const fundingEligibility = getFundingEligibility();
     const isEligibleForVenmo = fundingEligibility && fundingEligibility[FUNDING.VENMO] && fundingEligibility[FUNDING.VENMO].eligible;
 
     // exclude buyers who are not eligible


### PR DESCRIPTION
This PR updates the new venmo experiment to use `getFundingEligibilty` instead of `getRefinedFundingEligibility`.

The `getRefinedFundingEligibility` function includes more logic related to remembering eligibility that we do not need to for this venmo experiment: https://github.com/paypal/paypal-funding-components/blob/master/src/eligibility.js#L107. For this experiment we are only concerned with the basic eligibility that's embedded into the sdk script. 