### PR TITLE
Remove Node 10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10.13, 12, 14]
+        node: [12, 14]
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
### Purpose

This PR removes Node 10 from v4, since Node 10 is no longer supported.