### PR TITLE
Pin exact version of grumbler-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "flow-bin": "0.70.0",
     "fs-extra": "^4.0.2",
     "grabthar-release": "^1.0.39",
-    "grumbler-scripts": "^3",
+    "grumbler-scripts": "3.0.89",
     "imagemagick": "^0.1.3",
     "imgur": "^0.2.1",
     "memory-fs": "^0.4.1",


### PR DESCRIPTION
### Purpose

This PR fixes [these existing CI Jest errors](https://github.com/paypal/paypal-checkout-components/pull/1603/checks?check_run_id=2324615204) by pinning an exact version of grumbler-scripts.