### PR TITLE
Only show venmo on supported mobile browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@paypal/sdk-constants": "^1.0.64",
     "Base64": "^1.0.0",
     "beaver-logger": "^3.0.6",
-    "belter": "^1.0.96",
+    "belter": "^1.0.164",
     "bowser": "^1.7.1",
     "cross-domain-utils": "^2.0.1",
     "form-serialize": "^0.7.2",

--- a/src/billing/template/containerTemplate.jsx
+++ b/src/billing/template/containerTemplate.jsx
@@ -2,11 +2,10 @@
 /** @jsx jsxDom */
 /* eslint max-lines: 0 */
 
-import { base64encode, supportsPopups } from 'belter/src';
+import { base64encode, supportsPopups, isIos } from 'belter/src';
 
 import { fundingLogos } from '../../resources';
 import { BUTTON_LOGO_COLOR, CHECKOUT_OVERLAY_COLOR } from '../../constants';
-import { isIos } from '../../lib';
 import { containerContent } from '../../checkout/template/containerContent';
 import { getSandboxStyle, getContainerStyle } from '../../checkout/template';
 
@@ -163,4 +162,3 @@ export function containerTemplate({ id, props, CLASS, ANIMATION, CONTEXT, EVENT,
         </div>
     );
 }
-

--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -1028,13 +1028,6 @@ export const Button : Component<ButtonOptions> = create({
             def() : Object {
                 return { action: 'checkout' };
             }
-        },
-
-        // its unclear if this prop is actually needed for second render
-        supportedNativeBrowser: {
-            type:       'boolean',
-            value:      isSupportedNativeBrowser,
-            queryParam: true
         }
     }
 });

--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -7,7 +7,7 @@ import { create } from 'zoid/src';
 import { type Component } from 'zoid/src/component/component';
 import { info, warn, track, error, flush as flushLogs, immediateFlush } from 'beaver-logger/client';
 import { getDomain } from 'cross-domain-utils/src';
-import { base64encode, identity, noop } from 'belter/src';
+import { base64encode, identity, noop, isDevice, isIEIntranet } from 'belter/src';
 import { debounce, once } from 'zoid/src/lib';
 
 import { pptm } from '../external';
@@ -16,9 +16,9 @@ import { SOURCE, ENV, FPTI, FUNDING, BUTTON_LABEL, BUTTON_COLOR,
     BUTTON_SIZE, BUTTON_SHAPE, BUTTON_LAYOUT, COUNTRY, FUNDING_BRAND_LABEL } from '../constants';
 import { redirect as redir, checkRecognizedBrowser,
     getBrowserLocale, getSessionID, getStorageID, request, getScriptVersion,
-    isIEIntranet, isEligible, getCurrentScriptUrl,
-    getDomainSetting, extendUrl, isDevice, rememberFunding,
-    getRememberedFunding, memoize, uniqueID, getThrottle, getBrowser } from '../lib';
+    isEligible, getCurrentScriptUrl,
+    getDomainSetting, extendUrl, rememberFunding,
+    getRememberedFunding, memoize, uniqueID, getThrottle, getBrowser, isSupportedNativeBrowser } from '../lib';
 import { rest } from '../api';
 import { onAuthorizeListener } from '../experiments';
 import { getPaymentType, awaitBraintreeClient,
@@ -494,7 +494,7 @@ export const Button : Component<ButtonOptions> = create({
 
                 allowed = Array.isArray(allowed) ? allowed : [];
                 disallowed = Array.isArray(disallowed) ? disallowed : [];
-                
+
                 if (allowed && allowed.indexOf(FUNDING.ITAU) !== -1) {
                     allowed = allowed.filter(source => (source !== FUNDING.ITAU));
                 }
@@ -513,7 +513,7 @@ export const Button : Component<ButtonOptions> = create({
                     remembered = remembered.filter(source => (source !== FUNDING.VENMO));
                 }
 
-                if (!isDevice() || getDomainSetting('disable_venmo')) {
+                if (!isSupportedNativeBrowser() || getDomainSetting('disable_venmo')) {
                     if (disallowed && disallowed.indexOf(FUNDING.VENMO) === -1) {
                         disallowed = [ ...disallowed, FUNDING.VENMO ];
                     }
@@ -955,7 +955,7 @@ export const Button : Component<ButtonOptions> = create({
                     layout:       BUTTON_LAYOUT.HORIZONTAL
                 };
             },
-            
+
             decorate(style : Object) : Object {
                 const { label, layout = BUTTON_LAYOUT.HORIZONTAL } = style;
                 if (!label && layout === BUTTON_LAYOUT.HORIZONTAL) {
@@ -1028,6 +1028,13 @@ export const Button : Component<ButtonOptions> = create({
             def() : Object {
                 return { action: 'checkout' };
             }
+        },
+
+        // its unclear if this prop is actually needed for second render
+        supportedNativeBrowser: {
+            type:       'boolean',
+            value:      isSupportedNativeBrowser,
+            queryParam: true
         }
     }
 });

--- a/src/checkout/component.js
+++ b/src/checkout/component.js
@@ -6,10 +6,10 @@ import { info, track, warn, flush as flushLogs, immediateFlush } from 'beaver-lo
 import { create, CONSTANTS, PopupOpenError } from 'zoid/src';
 import { type Component } from 'zoid/src/component/component';
 import type { CrossDomainWindowType } from 'cross-domain-utils/src';
-import { base64encode } from 'belter/src';
+import { base64encode, isDevice, supportsPopups } from 'belter/src';
 
-import { isDevice, request, getQueryParam, redirect as redir, patchMethod,
-    setLogLevel, getSessionID, getBrowserLocale, supportsPopups, memoize,
+import { request, getQueryParam, redirect as redir, patchMethod,
+    setLogLevel, getSessionID, getBrowserLocale, memoize,
     getDomainSetting, getScriptVersion, getButtonSessionID, isPayPalDomain,
     isEligible, getCurrentScriptUrl } from '../lib';
 import { config } from '../config';
@@ -329,7 +329,7 @@ export const Checkout : Component<CheckoutPropsType> = create({
             type:     'function',
             required: true,
             once:     true,
-            
+
             decorate(original) : Function | void {
                 if (original) {
                     return function decorateOnAuthorize(data, actions = {}) : ZalgoPromise<void> {
@@ -546,7 +546,7 @@ export const Checkout : Component<CheckoutPropsType> = create({
                 return config.logLevel;
             }
         },
-        
+
         test: {
             type:     'object',
             required: false,
@@ -629,4 +629,3 @@ patchMethod(Checkout, 'renderTo', ({ args: [ win, props ], original, context }) 
         throw err;
     });
 });
-

--- a/src/checkout/template/containerTemplate.jsx
+++ b/src/checkout/template/containerTemplate.jsx
@@ -2,12 +2,11 @@
 /** @jsx jsxDom */
 /* eslint max-lines: 0 */
 
-import { base64encode, supportsPopups } from 'belter/src';
+import { base64encode, supportsPopups, isIos, noop } from 'belter/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
 
 import { fundingLogos } from '../../resources';
 import { BUTTON_LOGO_COLOR, CHECKOUT_OVERLAY_COLOR } from '../../constants';
-import { isIos, noop } from '../../lib';
 
 import { containerContent } from './containerContent';
 import { getContainerStyle } from './containerStyle';

--- a/src/hacks.js
+++ b/src/hacks.js
@@ -4,9 +4,10 @@ import { info, warn, flush as flushLogs } from 'beaver-logger/client';
 import { CONSTANTS } from 'zoid/src';
 import { getParent, getTop } from 'cross-domain-utils/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
+import { isIE, noop } from 'belter/src';
 
 import { config } from './config';
-import { noop, isIE, getDomainSetting, extendUrl, patchMethod, once, extend } from './lib';
+import { getDomainSetting, extendUrl, patchMethod, once, extend } from './lib';
 import { Button } from './button';
 import { Checkout } from './checkout';
 import { BUTTON_LABEL, BUTTON_SIZE, BUTTON_COLOR } from './constants';

--- a/src/legacy/eligibility.js
+++ b/src/legacy/eligibility.js
@@ -1,6 +1,8 @@
 /* @flow */
 
-import { isDevice, isEligible, supportsPopups } from '../lib';
+import { isDevice, supportsPopups } from 'belter/src';
+
+import { isEligible } from '../lib';
 
 export function isLegacyEligible() : boolean {
 

--- a/src/legacy/interface.js
+++ b/src/legacy/interface.js
@@ -4,11 +4,12 @@
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { prefix, flush as flushLogs } from 'beaver-logger/client';
 import formSerialize from 'form-serialize';
+import { supportsPopups } from 'belter/src';
 
 import { Checkout } from '../checkout';
 import { config } from '../config';
 import { ENV, FPTI } from '../constants';
-import { supportsPopups, once, safeJSON, extendUrl, stringifyError, request } from '../lib';
+import { once, safeJSON, extendUrl, stringifyError, request } from '../lib';
 
 import { setupPostBridge } from './postBridge';
 import { isLegacyEligible } from './eligibility';
@@ -138,7 +139,7 @@ function awaitPaymentTokenAndUrl(event? : ?Event, targetElement? : ?HTMLElement)
 
             info('gettoken_targetelement_start');
             flushLogs();
-    
+
             if (targetElement.tagName.toLowerCase() === 'a') {
                 method = 'get';
                 url = targetElement.getAttribute('href');
@@ -148,7 +149,7 @@ function awaitPaymentTokenAndUrl(event? : ?Event, targetElement? : ?HTMLElement)
                 body = formSerialize(targetElement);
                 contentType = targetElement.getAttribute('enctype') || 'application/x-www-form-urlencoded';
             }
-    
+
             if (method && url) {
                 event.preventDefault();
 
@@ -173,7 +174,7 @@ function awaitPaymentTokenAndUrl(event? : ?Event, targetElement? : ?HTMLElement)
                     });
                     flushLogs();
                 });
-                
+
             } else {
                 warn('gettoken_targetelement_no_method_or_url');
                 flushLogs();
@@ -361,7 +362,7 @@ function handleClickHijack(event, element) : void {
     const { url, paymentToken } = awaitPaymentTokenAndUrl(event, targetElement);
 
     let token;
-    
+
     paymentToken.then(result => {
         token = result;
     });

--- a/src/lib/device.js
+++ b/src/lib/device.js
@@ -4,20 +4,16 @@ import {
     getOpener,
     getTop
 } from 'cross-domain-utils/src';
-
-export function getUserAgent() : string {
-    // eslint-disable-next-line compat/compat
-    return window.navigator.mockUserAgent || window.navigator.userAgent;
-}
-
-export function isDevice() : boolean {
-    const userAgent = getUserAgent();
-    if (userAgent.match(/Android|webOS|iPhone|iPad|iPod|bada|Symbian|Palm|CriOS|BlackBerry|IEMobile|WindowsMobile|Opera Mini/i)) {
-        return true;
-    }
-
-    return false;
-}
+import {
+    getUserAgent,
+    supportsPopups,
+    isAndroid,
+    isChrome,
+    isIos,
+    isSafari,
+    isSFVC,
+    isIE
+} from 'belter/src';
 
 export function isInsidePopup() : boolean {
     // Checks to see if the top-most window is a pop-up
@@ -29,77 +25,6 @@ export function isStandAlone() : boolean {
     // eslint-disable-next-line compat/compat
     return !isInsidePopup() && (window.navigator.standalone === true || window.matchMedia('(display-mode: standalone)').matches);
 }
-
-export function isFacebookWebView(ua? : string = getUserAgent()) : boolean {
-    return (ua.indexOf('FBAN') !== -1) || (ua.indexOf('FBAV') !== -1);
-}
-
-export function isFirefoxIOS(ua? : string = getUserAgent()) : boolean {
-    return (/FxiOS/i).test(ua);
-}
-
-export function isEdgeIOS(ua? : string = getUserAgent()) : boolean {
-    return (/EdgiOS/i).test(ua);
-}
-
-export function isOperaMini(ua? : string = getUserAgent()) : boolean {
-    return ua.indexOf('Opera Mini') > -1;
-}
-
-export function isAndroid(ua? : string = getUserAgent()) : boolean {
-    return (/Android/).test(ua);
-}
-
-export function isIos(ua? : string = getUserAgent()) : boolean {
-    return (/iPhone|iPod|iPad/).test(ua);
-}
-
-export function isGoogleSearchApp(ua? : string = getUserAgent()) : boolean {
-    return (/\bGSA\b/).test(ua);
-}
-
-export function isQQBrowser(ua? : string = getUserAgent()) : boolean {
-    return (/QQBrowser/).test(ua);
-}
-
-export function isIosWebview(ua? : string = getUserAgent()) : boolean {
-    if (isIos(ua)) {
-        if (isGoogleSearchApp(ua)) {
-            return true;
-        }
-        return (/.+AppleWebKit(?!.*Safari)/).test(ua);
-    }
-    return false;
-}
-
-export function isAndroidWebview(ua? : string = getUserAgent()) : boolean {
-    if (isAndroid(ua)) {
-        return (/Version\/[\d.]+/).test(ua) && !isOperaMini(ua);
-    }
-    return false;
-}
-
-export function isWebView() : boolean {
-    return isFacebookWebView() ||
-        isIosWebview() ||
-        isAndroidWebview();
-}
-
-export function isIE() : boolean {
-
-    if (window.document.documentMode) {
-        return true;
-    }
-
-    if (window.navigator && typeof window.navigator.userAgent === 'string') {
-        if ((/Edge|MSIE/i).test(window.navigator.userAgent)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 
 export function isIE11() : boolean {
     if (!isIE()) {
@@ -119,57 +44,24 @@ export function isIE11() : boolean {
     return false;
 }
 
-export function isIECompHeader() : boolean {
-    const mHttp = window.document.querySelector('meta[http-equiv="X-UA-Compatible"]');
-    const mContent = window.document.querySelector('meta[content="IE=edge"]');
-    if (mHttp && mContent) {
-        return true;
-    }
-    return false;
-}
-
-export function isElectron() : boolean {
+export function isSupportedNativeBrowser() : boolean {
     const userAgent = getUserAgent();
-    // here we want a case-insensitive full word boundary
-    return (/\belectron\b/i).test(userAgent);
-}
 
-export function isIEIntranet() : boolean {
-    if (!isIE11()) {
+    if (!supportsPopups(userAgent)) {
         return false;
     }
 
-    // This status check only works for older versions of IE with document.documentMode set
+    if (isSFVC()) {
+        return false;
+    }
 
-    if (window.document.documentMode) {
-        try {
-            const status = window.status;
+    if (isIos() && isSafari()) {
+        return true;
+    }
 
-            window.status = 'testIntranetMode';
-
-            if (window.status === 'testIntranetMode') {
-                window.status = status;
-
-                return true;
-            }
-
-            return false;
-
-        } catch (err) {
-
-            return false;
-        }
+    if (isAndroid() && isChrome()) {
+        return true;
     }
 
     return false;
-}
-
-export function isMacOsCna() : boolean {
-    const userAgent = getUserAgent();
-    return (/Macintosh.*AppleWebKit(?!.*Safari)/i).test(userAgent);
-}
-
-export function supportsPopups(ua? : string = getUserAgent()) : boolean {
-    return !(isIosWebview(ua) || isAndroidWebview(ua) || isOperaMini(ua) ||
-        isFirefoxIOS(ua) || isEdgeIOS(ua) || isFacebookWebView(ua) || isQQBrowser(ua) || isElectron() || isMacOsCna() || isStandAlone());
 }

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -3,13 +3,13 @@
 import { info } from 'beaver-logger/client';
 import { ZalgoPromise } from 'zalgo-promise/src';
 import type { CrossDomainWindowType } from 'cross-domain-utils/src';
+import { isDevice } from 'belter/src';
 
 import { LANG_TO_DEFAULT_COUNTRY, LOCALE } from '../constants';
 import type { LocaleType } from '../types';
 import { config } from '../config';
 
 import { memoize } from './util';
-import { isDevice } from './device';
 
 function isDocumentReady() : boolean {
     return Boolean(document.body) && document.readyState === 'complete';

--- a/src/lib/eligibility.js
+++ b/src/lib/eligibility.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 import { info, flush as flushLogs } from 'beaver-logger/client';
+import { isIEIntranet, getUserAgent } from 'belter/src';
 
 import { config } from '../config';
 
-import { isIEIntranet, getUserAgent } from './device';
 import { once } from './util';
 
 const bowserCache = {};

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -1,8 +1,7 @@
 /* @flow */
 
 import { warn } from 'beaver-logger/client';
-
-import { isIE, isIEIntranet, isIECompHeader } from './device';
+import { isIE, isIEIntranet, isIECompHeader } from 'belter/src';
 
 function logWarn(err) : void {
     if (window.console) {

--- a/src/lib/meta.js
+++ b/src/lib/meta.js
@@ -2,10 +2,10 @@
 
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { once, bridge } from 'post-robot/src';
+import { isIEIntranet } from 'belter/src';
 
 import { config } from '../config';
 
-import { isIEIntranet  } from './device';
 import { memoize } from './util';
 import { getScriptVersion } from './script';
 import { extendUrl } from './dom';

--- a/src/lib/security.js
+++ b/src/lib/security.js
@@ -1,10 +1,9 @@
 /* @flow */
 
 import { getParent, isSameDomain } from 'cross-domain-utils/src';
+import { supportsPopups } from 'belter/src';
 
 import { config } from '../config';
-
-import { supportsPopups } from './device';
 
 export function allowIframe() : boolean {
 


### PR DESCRIPTION
This PR adds additional user agent string checks for Venmo. The venmo button should only show on Safari on iOS and Chrome on Android.

This PR also refactors device.js to take advantage of belter and also to support the new `isSupportedNativeBrowser` function which is the same approach v5 takes with determining to show venmo.

### Screenshots

#### Safari on iOS

<img width="1140" alt="safari-ios-venmo-screenshot" src="https://user-images.githubusercontent.com/534034/115088421-bb263c80-9ed5-11eb-8573-3fedd5aa2f64.png">

#### Chrome on iOS

Chrome on iOS is not supported. Note how the code sets funding.disallowed to prevent venmo from rendering in the second render.
<img width="1384" alt="chrome-ios-no-venmo-screenshot" src="https://user-images.githubusercontent.com/534034/115088463-d2652a00-9ed5-11eb-8afd-2976b9759409.png">
