### PR TITLE
Avoid multiple popups on Prerender state

### DIFF
--- a/src/zoid/buttons/prerender.jsx
+++ b/src/zoid/buttons/prerender.jsx
@@ -23,7 +23,7 @@ type PrerenderedButtonsProps = {|
 |};
 
 export function PrerenderedButtons({ nonce, onRenderCheckout, props } : PrerenderedButtonsProps) : ChildType {
-
+    let win;
     const handleClick = (event, { fundingSource, card } : {| fundingSource : $Values<typeof FUNDING>, card : ?$Values<typeof CARD> |}) => {
         getLogger().info('button_prerender_click').track({
             [ FPTI_KEY.BUTTON_SESSION_UID ]: props.buttonSessionID,
@@ -33,10 +33,12 @@ export function PrerenderedButtons({ nonce, onRenderCheckout, props } : Prerende
         }).flush();
         
         if (supportsPopups()) {
-            const win = assertSameDomain(popup('', {
-                width:  DEFAULT_POPUP_SIZE.WIDTH,
-                height: DEFAULT_POPUP_SIZE.HEIGHT
-            }));
+            if (!win || win.closed) {
+                win = assertSameDomain(popup('', {
+                    width:  DEFAULT_POPUP_SIZE.WIDTH,
+                    height: DEFAULT_POPUP_SIZE.HEIGHT
+                }));
+            }
 
             const doc = window.document;
 

--- a/src/zoid/buttons/prerender.jsx
+++ b/src/zoid/buttons/prerender.jsx
@@ -33,6 +33,7 @@ export function PrerenderedButtons({ nonce, onRenderCheckout, props } : Prerende
         }).flush();
         
         if (supportsPopups()) {
+            // remember the popup window to prevent showing a new popup window on every click in the prerender state
             if (!win || win.closed) {
                 win = assertSameDomain(popup('', {
                     width:  DEFAULT_POPUP_SIZE.WIDTH,


### PR DESCRIPTION
- Added logic to check if a popup window was previously opened before opening a new one on `PrerenderedButtons`. This will avoid multiple popups windows when spamming the buttons on the Prerender state.