### PR TITLE
added support for zh Hant

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "scripts": {
         "dev": "babel-node $(npm bin)/webpack-dev-server --config webpack.config.dev.js --port 9001 --host localhost.paypal.com --open-page demo/dev/index.htm --https --hot=false --inline=false",
-        "lint": "eslint --ext .js --ext .jsx src/ test/ *.js --fix",
+        "lint": "eslint --ext .js --ext .jsx src/ test/ *.js",
         "flow-typed": "rm -rf flow-typed && flow-typed install && rm flow-typed/npm/puppeteer_*",
         "flow": "flow",
         "karma": "cross-env NODE_ENV=test babel-node $(npm bin)/karma start",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "scripts": {
         "dev": "babel-node $(npm bin)/webpack-dev-server --config webpack.config.dev.js --port 9001 --host localhost.paypal.com --open-page demo/dev/index.htm --https --hot=false --inline=false",
-        "lint": "eslint --ext .js --ext .jsx src/ test/ *.js",
+        "lint": "eslint --ext .js --ext .jsx src/ test/ *.js --fix",
         "flow-typed": "rm -rf flow-typed && flow-typed install && rm flow-typed/npm/puppeteer_*",
         "flow": "flow",
         "karma": "cross-env NODE_ENV=test babel-node $(npm bin)/karma start",

--- a/src/funding/content.jsx
+++ b/src/funding/content.jsx
@@ -337,7 +337,7 @@ export const componentContent : ContentMap = {
         Subscribe: ({ logo }) => <Fragment>{ logo }<Text animate optional> 订购</Text></Fragment>,
         SaferTag:  () => <Text animate optional>更安全、更便捷的付款方式</Text>,
         Pay:       ({ logo }) => <Fragment><Text animate optional>用</Text>{ logo }<Text animate optional>付款</Text></Fragment>,
-        Donate:    ({ logo }) => <Fragment>{ logo }<Text animate optional> 捐赠</Text></Fragment>
+        Donate:    ({ logo }) => <Fragment>{ logo }<Text animate optional> 捐赠</Text></Fragment>,
         BuyNow:    ({ logo }) => <Fragment>{ logo }<Text animate optional> 立即购买</Text></Fragment>
     },
     zh_Hant: {
@@ -345,6 +345,8 @@ export const componentContent : ContentMap = {
         Subscribe: ({ logo }) => <Fragment>{ logo }<Text animate optional> 訂閱</Text></Fragment>,
         SaferTag:  () => <Text animate optional>更安全方便的付款方式</Text>,
         Pay:       ({ logo }) => <Fragment><Text animate optional>使用</Text>{ logo }<Text animate optional>付款</Text></Fragment>,
+        // MISSING VALUE FOR DONATE !!!!
+        Donate:    ({ logo }) => <Fragment>{ logo }<Text animate optional> 捐赠</Text></Fragment>,
         BuyNow:    ({ logo }) => <Fragment>{ logo }<Text animate optional> 立即購</Text></Fragment>
     }
 };

--- a/src/funding/content.jsx
+++ b/src/funding/content.jsx
@@ -337,7 +337,14 @@ export const componentContent : ContentMap = {
         Subscribe: ({ logo }) => <Fragment>{ logo }<Text animate optional> 订购</Text></Fragment>,
         SaferTag:  () => <Text animate optional>更安全、更便捷的付款方式</Text>,
         Pay:       ({ logo }) => <Fragment><Text animate optional>用</Text>{ logo }<Text animate optional>付款</Text></Fragment>,
-        BuyNow:    ({ logo }) => <Fragment>{ logo }<Text animate optional> 立即购买</Text></Fragment>,
         Donate:    ({ logo }) => <Fragment>{ logo }<Text animate optional> 捐赠</Text></Fragment>
+        BuyNow:    ({ logo }) => <Fragment>{ logo }<Text animate optional> 立即购买</Text></Fragment>
+    },
+    zh_Hant: {
+        Checkout:  ({ logo }) => <Fragment>{ logo }<Text animate optional> 結帳</Text></Fragment>,
+        Subscribe: ({ logo }) => <Fragment>{ logo }<Text animate optional> 訂閱</Text></Fragment>,
+        SaferTag:  () => <Text animate optional>更安全方便的付款方式</Text>,
+        Pay:       ({ logo }) => <Fragment><Text animate optional>使用</Text>{ logo }<Text animate optional>付款</Text></Fragment>,
+        BuyNow:    ({ logo }) => <Fragment>{ logo }<Text animate optional> 立即購</Text></Fragment>
     }
 };

--- a/src/funding/content.jsx
+++ b/src/funding/content.jsx
@@ -345,8 +345,7 @@ export const componentContent : ContentMap = {
         Subscribe: ({ logo }) => <Fragment>{ logo }<Text animate optional> 訂閱</Text></Fragment>,
         SaferTag:  () => <Text animate optional>更安全方便的付款方式</Text>,
         Pay:       ({ logo }) => <Fragment><Text animate optional>使用</Text>{ logo }<Text animate optional>付款</Text></Fragment>,
-        // MISSING VALUE FOR DONATE !!!!
-        Donate:    ({ logo }) => <Fragment>{ logo }<Text animate optional> 捐赠</Text></Fragment>,
+        Donate:    ({ logo }) => <Fragment>{ logo }<Text animate optional> 捐款</Text></Fragment>,
         BuyNow:    ({ logo }) => <Fragment>{ logo }<Text animate optional> 立即購</Text></Fragment>
     }
 };

--- a/src/ui/buttons/content.jsx
+++ b/src/ui/buttons/content.jsx
@@ -122,5 +122,8 @@ export const buttonContent : ButtonContentMap = {
     },
     zh: {
         PoweredBy: ({ logoColor }) => <Fragment><Text>技术支持提供方： </Text><PayPalLogo logoColor={ logoColor } /></Fragment>
+    },
+    zh_Hant: {
+        PoweredBy: ({ logoColor }) => <Fragment><Text>技術支持： </Text><PayPalLogo logoColor={ logoColor } /></Fragment>
     }
 };

--- a/src/zoid/checkout/content.js
+++ b/src/zoid/checkout/content.js
@@ -154,5 +154,9 @@ export const containerContent : ContentMap = {
     zh: {
         windowMessage:   '没有找到安全的PayPal浏览器？我们将帮助您重启窗口以完成付款',
         continueMessage: '继续'
+    },
+    zh_Hant: {
+        windowMessage:   '看不到安全 PayPal 瀏覽器？我們會協助你重新啟動視窗，以完成購物程序',
+        continueMessage: '按一下並繼續'
     }
 };

--- a/test/ssr/ssr.test.js
+++ b/test/ssr/ssr.test.js
@@ -58,6 +58,23 @@ test(`Button should render with ssr, with minimal options`, async () => {
     }
 });
 
+test(`Button should render with ssr, with zh_Hant locale option`, async () => {
+
+    const { Buttons } = await getButtonScript();
+
+    const buttonHTML = Buttons({
+        locale:          { country: 'HK', lang: 'zh_Hant' },
+        platform:        'desktop',
+        sessionID:       'xyz',
+        buttonSessionID: 'abc',
+        fundingEligibility
+    }).render(html());
+
+    if (!buttonHTML || typeof buttonHTML !== 'string') {
+        throw new Error(`Expected html to be a non-empty string`);
+    }
+});
+
 test(`Button should fail to render with ssr, with invalid style option`, async () => {
 
     const { Buttons } = await getButtonScript();
@@ -130,6 +147,7 @@ test(`Button should fail to render with ssr, with invalid locale`, async () => {
         throw new Error(`Expected button render to error out`);
     }
 });
+
 
 test(`Button renderer should export DEFAULT_PROPS`, async () => {
 


### PR DESCRIPTION
# Description

- When users set locale=zh_HK in SPB, they expect all languages showed as Chinese(traditional), but the text on the overlay is showing as Chinese(simplified)
- it is needed to  merge [this](https://github.com/paypal/paypal-sdk-constants/pull/55) in order to make CI pass


![image](https://user-images.githubusercontent.com/17114924/118312364-d6756f00-b4b6-11eb-88c4-8a819d70309e.png)

## Following steps mentioned below:

- https://github.paypal.com/Globalization-R/G11nMetadata/blob/develop/AddLangsToCheckout.md

## Related PR's

- https://github.com/paypal/paypal-identity-components/pull/14
- https://github.com/paypal/paypal-sdk-constants/pull/55