### PR TITLE
Correct aria-labels on buttons when style.label is used 

### DIFF
--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -3,12 +3,12 @@
 
 import type { FundingEligibilityType } from '@paypal/sdk-client/src';
 import { FUNDING, ENV, type LocaleType } from '@paypal/sdk-constants/src';
-import { node, type ElementNode } from 'jsx-pragmatic/src';
+import { node, html, type ElementNode } from 'jsx-pragmatic/src';
 import { LOGO_COLOR, LOGO_CLASS } from '@paypal/sdk-logos/src';
 import { noop, preventClickFocus, isBrowser, isElement } from 'belter/src';
 
 import type { ContentType, Wallet, Experiment, WalletInstrument } from '../../types';
-import { ATTRIBUTE, CLASS, BUTTON_COLOR, BUTTON_NUMBER, TEXT_COLOR, BUTTON_FLOW } from '../../constants';
+import { ATTRIBUTE, CLASS, BUTTON_COLOR, BUTTON_LABEL, BUTTON_NUMBER, TEXT_COLOR, BUTTON_FLOW } from '../../constants';
 import { getFundingConfig } from '../../funding';
 
 import type { ButtonStyle, Personalization, OnShippingChange } from './props';
@@ -93,8 +93,6 @@ export function Button({ fundingSource, style, multiple, locale, env, fundingEli
     };
 
     const { layout, shape } = style;
-    
-    const labelText =  typeof fundingConfig.labelText === 'function' ?  fundingConfig.labelText({ content }) : (fundingConfig.labelText || fundingSource);
 
     const logoNode = (
         <Logo
@@ -156,7 +154,23 @@ export function Button({ fundingSource, style, multiple, locale, env, fundingEli
     }
 
     const shouldShowWalletMenu = isWallet && instrument && showWalletMenu({ instrument });
+    
+    const getLabelText = () => {
+        if (typeof fundingConfig.labelText === 'function') {
+            return fundingConfig.labelText({ content });
+        }
 
+        if (label !== BUTTON_LABEL.PAYPAL) {
+            const str = labelNode.render(html());
+            if (str.replace(/<img.*<\/img>/, '').length > 0) {
+                return str.replace(/<span.*?>/, '')
+                    .replace(/<\/span>/, '')
+                    .replace(/<img.*<\/img>/, fundingSource);
+            }
+        }
+        return (fundingConfig.labelText || fundingSource);
+    };
+        
     return (
         <div
             class={ [
@@ -198,7 +212,7 @@ export function Button({ fundingSource, style, multiple, locale, env, fundingEli
                 onRender={ onButtonRender }
                 onKeyPress={ keypressHandler }
                 tabindex='0'
-                aria-label={ labelText }>
+                aria-label={ getLabelText() }>
 
                 <div class={ CLASS.BUTTON_LABEL }>
                     { labelNode }


### PR DESCRIPTION
When a [label style](https://developer.paypal.com/docs/checkout/integration-features/customize-button/#label) other than `paypal` is used, the [aria-label](https://www.w3.org/TR/wai-aria/#aria-label) of the buttons doesn't accurately reflect the legible contents of the button. This PR resolves [that issue](
https://engineering.paypalcorp.com/jira/browse/DTCHKINT-300). 



It's worth mentioning that this is most likely not the most ideal solution, as it is doing something that is expressly warned against in one of the [greatest stackoverflow answers of all time](https://stackoverflow.com/questions/1732348/regex-match-open-tags-except-xhtml-self-contained-tags/1732454#1732454). That being said, an alternative solution would involve reworking [src/funding/content.jsx](https://github.com/paypal/paypal-checkout-components/blob/master/src/funding/content.jsx) into a two separate pieces of functionality, one that provides that actual textual content & one that uses that function to construct a component to be consumed in a manner replacing the current implementation. 

.....this seems waaaaay easier though. ¯\\\_(ツ)\_/¯