### PR TITLE
Vaulted button for returning Venmo Pay users

### DIFF
--- a/src/funding/paypal/template.jsx
+++ b/src/funding/paypal/template.jsx
@@ -2,7 +2,7 @@
 /** @jsx node */
 
 import { node, Fragment, Style, type ChildType } from 'jsx-pragmatic/src';
-import { PPLogo, PayPalLogo, CreditLogo, CreditMark, PayPalMark, GlyphCard, GlyphBank, LOGO_CLASS } from '@paypal/sdk-logos/src';
+import { PPLogo, PayPalLogo, CreditLogo, CreditMark, PayPalMark, GlyphCard, GlyphBank, LOGO_CLASS, VenmoLogo, LOGO_COLOR } from '@paypal/sdk-logos/src';
 import { FUNDING, WALLET_INSTRUMENT } from '@paypal/sdk-constants/src';
 
 import { type LogoOptions, type LabelOptions, type WalletLabelOptions, type TagOptions, BasicLabel } from '../common';
@@ -148,6 +148,7 @@ function ButtonPersonalization(opts : LabelOptions) : ?ChildType {
 
 
 export function Label(opts : LabelOptions) : ChildType {
+
     return (
         <Fragment>
             <BasicLabel { ...opts } />
@@ -217,7 +218,7 @@ export function WalletLabelOld(opts : WalletLabelOptions) : ?ChildType {
 export function WalletLabel(opts : WalletLabelOptions) : ?ChildType {
     const { logoColor, instrument, content, commit, vault, textColor, fundingSource } = opts;
 
-    if (instrument && !instrument.type) {
+    if (instrument && !instrument.type && fundingSource !== FUNDING.VENMO) {
         return WalletLabelOld(opts);
     }
 
@@ -229,7 +230,7 @@ export function WalletLabel(opts : WalletLabelOptions) : ?ChildType {
         branded = instrument.branded;
     } else if (fundingSource === FUNDING.PAYPAL || fundingSource === FUNDING.CREDIT) {
         branded = true;
-    } else if (fundingSource === FUNDING.CARD) {
+    } else if (fundingSource === FUNDING.CARD || fundingSource === FUNDING.VENMO) {
         branded = false;
     } else {
         branded = true;
@@ -260,12 +261,18 @@ export function WalletLabel(opts : WalletLabelOptions) : ?ChildType {
 
             label = content && content.balance;
         
+        } else if (instrument.type === WALLET_INSTRUMENT.VENMO && instrument.label) {
+            logo =  <VenmoLogo logoColor={ logoColor } />;
+
+            label = instrument.label;
+
         } else if (instrument.label) {
             label = instrument.label;
         }
     }
 
     const payNow = Boolean((instrument && instrument.oneClick) && commit && !vault);
+    const hidePayWith = Boolean(instrument && instrument.type === WALLET_INSTRUMENT.VENMO);
 
     const attrs = {};
     if (payNow) {
@@ -286,15 +293,18 @@ export function WalletLabel(opts : WalletLabelOptions) : ?ChildType {
                         : null
                 }
 
-                <div class='pay-label' optional={ 2 }>
-                    <Space />
-                    {
-                        (instrument && content)
-                            ? <Text>{ payNow ? content.payNow : content.payWith }</Text>
-                            : <Text><PlaceHolder chars={ 7 } color={ textColor } /></Text>
-                    }
-                    <Space />
-                </div>
+                {
+                    hidePayWith ? null : (
+                        <div class='pay-label' optional={ 2 }>
+                            <Space />
+                            {
+                                (instrument && content)
+                                    ? <Text>{ payNow ? content.payNow : content.payWith }</Text>
+                                    : <Text><PlaceHolder chars={ 7 } color={ textColor } /></Text>
+                            }
+                            <Space />
+                        </div>)
+                }
                 <div class='logo' optional={ 1 }>
                     {
                         (instrument && logo)
@@ -302,6 +312,7 @@ export function WalletLabel(opts : WalletLabelOptions) : ?ChildType {
                             : <Text><PlaceHolder chars={ 4 } color={ textColor } /></Text>
                     }
                 </div>
+                
                 <div class='label'>
                     <Space />
                     {

--- a/src/funding/paypal/template.jsx
+++ b/src/funding/paypal/template.jsx
@@ -2,7 +2,7 @@
 /** @jsx node */
 
 import { node, Fragment, Style, type ChildType } from 'jsx-pragmatic/src';
-import { PPLogo, PayPalLogo, CreditLogo, CreditMark, PayPalMark, GlyphCard, GlyphBank, LOGO_CLASS, VenmoLogo, LOGO_COLOR } from '@paypal/sdk-logos/src';
+import { PPLogo, PayPalLogo, CreditLogo, CreditMark, PayPalMark, GlyphCard, GlyphBank, LOGO_CLASS, VenmoLogo } from '@paypal/sdk-logos/src';
 import { FUNDING, WALLET_INSTRUMENT } from '@paypal/sdk-constants/src';
 
 import { type LogoOptions, type LabelOptions, type WalletLabelOptions, type TagOptions, BasicLabel } from '../common';

--- a/src/funding/venmo/config.jsx
+++ b/src/funding/venmo/config.jsx
@@ -4,8 +4,11 @@
 import { PLATFORM } from '@paypal/sdk-constants/src';
 import { VenmoLogo, LOGO_COLOR } from '@paypal/sdk-logos/src';
 
+import { Text, Space } from '../../ui/text';
 import { BUTTON_COLOR, BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
+import { WalletLabel } from '../paypal/template';
+
 
 export function getVenmoConfig() : FundingSourceConfig {
     return {
@@ -26,8 +29,11 @@ export function getVenmoConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.HORIZONTAL,
             BUTTON_LAYOUT.VERTICAL
         ],
+        
+        Logo:  ({ logoColor, optional }) => VenmoLogo({ logoColor, optional }),
 
-        Logo: ({ logoColor, optional }) => VenmoLogo({ logoColor, optional }),
+        WalletLabel,
+        showWalletMenu: () => false,
 
         colors: [
             BUTTON_COLOR.BLUE,

--- a/src/funding/venmo/config.jsx
+++ b/src/funding/venmo/config.jsx
@@ -4,7 +4,6 @@
 import { PLATFORM } from '@paypal/sdk-constants/src';
 import { VenmoLogo, LOGO_COLOR } from '@paypal/sdk-logos/src';
 
-import { Text, Space } from '../../ui/text';
 import { BUTTON_COLOR, BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
 import { WalletLabel } from '../paypal/template';

--- a/src/types.js
+++ b/src/types.js
@@ -20,7 +20,8 @@ export type WalletPaymentType = {|
 export type Wallet = {|
     paypal : WalletPaymentType,
     card : WalletPaymentType,
-    credit : WalletPaymentType
+    credit : WalletPaymentType,
+    venmo : WalletPaymentType
 |};
 
 export type ContentType = {|


### PR DESCRIPTION

# Description

- Similar to the "Pay Now" button for returning Pay Later users, we need to create a button for returning Venmo Pay buyers that has Venmo branding and has the buyer's Venmo username in there.


## Screenshots

<a href="https://gyazo.com/5af7fbcf3c4515c9085b0b3a1b58d0c6"><img src="https://i.gyazo.com/5af7fbcf3c4515c9085b0b3a1b58d0c6.gif" alt="Image from Gyazo" width="1000"/></a>

