### PR TITLE
Add err.code = 'validation_error' for specific error in Buttons render

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "@paypal/common-components": "^1.0.10",
         "@paypal/funding-components": "^1.0.17",
         "@paypal/sdk-client": "^4.0.151",
-        "@paypal/sdk-constants": "^1.0.57",
+        "@paypal/sdk-constants": "^1.0.105",
         "@paypal/sdk-logos": "^1.0.26",
         "belter": "^1.0.2",
         "cross-domain-utils": "^2.0.1",

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -1,0 +1,13 @@
+/* @flow */
+
+import { ERROR_CODE } from '@paypal/sdk-constants/src';
+
+export class ValidationError extends Error {
+  code : string;
+
+  constructor(message : string) {
+      super(message);
+      this.name = 'ValidationError';
+      this.code = ERROR_CODE.VALIDATION_ERROR;
+  }
+}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 
-export * from './session';
-export * from './security';
+export * from './errors';
 export * from './isRTLLanguage';
+export * from './security';
+export * from './session';

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -8,6 +8,7 @@ import { noop } from 'belter/src';
 import type { Wallet, WalletInstrument } from '../../types';
 import { CLASS, BUTTON_NUMBER, BUTTON_LAYOUT, BUTTON_FLOW } from '../../constants';
 import { determineEligibleFunding, isWalletFundingEligible } from '../../funding';
+import { ValidationError } from '../../lib';
 
 import { normalizeButtonProps, type ButtonPropsInputs, type OnShippingChange } from './props';
 import { Style } from './style';
@@ -102,7 +103,7 @@ export function Buttons(props : ButtonsProps) : ElementNode {
     const multiple = fundingSources.length > 1;
 
     if (!fundingSources.length) {
-        throw new Error(`No eligible funding fundingSources found to render buttons:\n\n${ JSON.stringify(fundingEligibility, null, 4) }`);
+        throw new ValidationError(`No eligible funding fundingSources found to render buttons:\n\n${ JSON.stringify(fundingEligibility, null, 4) }`);
     }
 
     if (fundingSources.indexOf(FUNDING.CARD) !== -1) {

--- a/test/ssr/ssr.test.js
+++ b/test/ssr/ssr.test.js
@@ -3,6 +3,7 @@
 
 import { getWebpackConfig } from 'grumbler-scripts/config/webpack.config';
 import { html, ElementNode } from 'jsx-pragmatic';
+import { ERROR_CODE } from '@paypal/sdk-constants';
 
 import { webpackCompileToString } from '../screenshot/lib/compile';
 import { fundingEligibility } from '../globals';
@@ -78,6 +79,32 @@ test(`Button should fail to render with ssr, with invalid style option`, async (
 
     if (!expectedErr) {
         throw new Error(`Expected button render to error out`);
+    }
+});
+
+test(`Button should fail to render with ssr, with no fundingSources available`, async () => {
+
+    const { Buttons } = await getButtonScript();
+
+    let expectedErr;
+
+    try {
+        Buttons({
+            locale:             { country: 'US', lang: 'en' },
+            platform:           'desktop',
+            sessionID:          'xyz',
+            buttonSessionID:    'abc',
+            fundingEligibility: {}
+        }).render(html());
+    } catch (err) {
+        expectedErr = err;
+    }
+
+    if (!expectedErr) {
+        throw new Error(`Expected button render to error out`);
+    }
+    if (expectedErr.code !== ERROR_CODE.VALIDATION_ERROR) {
+        throw new Error(`Expected button render to error out with err.code = ${ ERROR_CODE.VALIDATION_ERROR }`);
     }
 });
 


### PR DESCRIPTION
This PR is a pre-requisite for https://github.com/paypal/paypal-smart-payment-buttons/pull/161

After some discussion with @gregjopa and @bluepnume, it was suggested that Buttons should throw an error with err.code = 'VALIDATION_ERROR', so it could be catched in smart-payment-buttons as a clientError, thus throwing a 4xx code instead of 5xx.