### PR TITLE
Fix problem with window.popupBridge.onComplete and queryParams

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -228,7 +228,8 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                             start:     (url) => {
                                 return new ZalgoPromise((resolve, reject) => {
                                     window.popupBridge.onComplete = (err, result) => {
-                                        return err ? reject(err) : resolve(result.queryItems);
+                                        const queryItems = result && result.queryItems ? result.queryItems : {};
+                                        return err ? reject(err) : resolve(queryItems);
                                     };
                                     window.popupBridge.open(url);
                                 });

--- a/test/integration/tests/button/popupBridge.js
+++ b/test/integration/tests/button/popupBridge.js
@@ -82,5 +82,27 @@ for (const flow of [ 'popup', 'iframe' ]) {
                 }).render('#testContainer');
             });
         });
+
+        it('should render a button with popup bridge, cancel the popup flow and return with no errors', () => {
+            return wrapPromise(({ expect }) => {
+                const orderID = generateOrderID();
+
+                window.popupBridge = {
+                    open: expect('open', () => {
+                        window.popupBridge.onComplete(null, null);
+                    }),
+                    getReturnUrlPrefix: expect('getReturnUrlPrefix', () => {
+                        return 'native://foobar';
+                    })
+                };
+
+                return window.paypal.Buttons({
+                    test: { flow, action: 'checkout' },
+
+                    createOrder: expect('createOrder', () => orderID)
+
+                }).render('#testContainer');
+            });
+        });
     });
 }


### PR DESCRIPTION
Added logic to check if `window.popupBridge.onComplete` has or not queryItems before trying to accessing it.

This solves the problem when the flow gets cancelled and there is an error on the popupBridge when the JS SDK tries to get the queryItems from an undefined object.