### PR TITLE
Use local web server for 'npm run dev'

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "dependencies": {
         "@paypal/common-components": "^1.0.10",
         "@paypal/funding-components": "^1.0.17",
-        "@paypal/sdk-client": "^4.0.151",
+        "@paypal/sdk-client": "^4.0.156",
         "@paypal/sdk-constants": "^1.0.105",
         "@paypal/sdk-logos": "^1.0.26",
         "belter": "^1.0.2",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -28,7 +28,7 @@ const WEBPACK_CONFIG_DEV : WebpackConfig = getWebpackConfig({
         __SDK_HOST__:        `${ HOSTNAME }:${ PORT }`,
         __PORT__:            PORT,
         __PATH__:            `/${ FILE_NAME }.js`,
-        __PAYPAL_DOMAIN__:   'https://sandbox.paypal.com',
+        __PAYPAL_DOMAIN__:   'https://localhost.paypal.com:9001',
         __PAYPAL_CHECKOUT__: {
             ...testGlobals.__PAYPAL_CHECKOUT__,
             __URI__:                {


### PR DESCRIPTION
This PR updates the local dev server (`npm run dev`) to be used as the domain for the popup. This fixes the contents of the popup:

<img width="1226" alt="Screen Shot 2021-06-28 at 8 02 40 PM" src="https://user-images.githubusercontent.com/534034/123721602-4a43bf00-d84c-11eb-9301-70f846c7b504.png">

