### PR TITLE
Fix webpack json loader error w/ test globals

### DIFF
--- a/test/globals.js
+++ b/test/globals.js
@@ -1,6 +1,6 @@
-/* @flow */
+/* eslint import/no-commonjs: off, flowtype/require-valid-file-annotation: off, flowtype/require-return-type: off */
 
-export const fundingEligibility = {
+const fundingEligibility = {
     bancontact: {
         eligible: false
     },
@@ -103,7 +103,7 @@ export const fundingEligibility = {
     }
 };
 
-export function getTestGlobals(productionGlobals) {
+function getTestGlobals(productionGlobals) {
     return {
         ...productionGlobals,
         __PAYPAL_CHECKOUT__: {
@@ -118,7 +118,7 @@ export function getTestGlobals(productionGlobals) {
             }
         },
 
-        __FUNDING_ELIGIBILITY__: () : string => `window.__TEST_FUNDING_ELIGIBILITY__ || ${ JSON.stringify(fundingEligibility) }`,
+        __FUNDING_ELIGIBILITY__: () => `window.__TEST_FUNDING_ELIGIBILITY__ || ${ JSON.stringify(fundingEligibility) }`,
 
         __PROTOCOL__:          'http',
         __PORT__:              8000,
@@ -144,5 +144,10 @@ export function getTestGlobals(productionGlobals) {
             ...productionGlobals.__POST_ROBOT__,
             __SCRIPT_NAMESPACE__: false
         }
-    }
+    };
 }
+
+module.exports = {
+    fundingEligibility,
+    getTestGlobals
+};

--- a/test/globals.js
+++ b/test/globals.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-import { __POST_ROBOT__, __ZOID__ } from '../globals';
-
 export const fundingEligibility = {
     bancontact: {
         eligible: false
@@ -105,44 +103,46 @@ export const fundingEligibility = {
     }
 };
 
-export const testGlobals = {
-    __PAYPAL_CHECKOUT__: {
-        __URI__:                {
-            __CHECKOUT__:    `/base/test/integration/windows/checkout/index.htm?checkouturl=true`,
-            __BUTTONS__:     `/base/test/integration/windows/button/index.htm`,
-            __MENU__:        `/base/test/integration/windows/menu/index.htm`,
-            __CARD_FIELDS__: `/base/test/integration/windows/card-fields/index.htm`,
-            __CARD_FIELD__:  `/base/test/integration/windows/card-field/index.htm`,
-            __WALLET__:      `/base/test/integration/windows/wallet/index.htm`,
-            __FIELDS__:      `/base/test/integration/windows/fields/index.htm`
+export function getTestGlobals(productionGlobals) {
+    return {
+        ...productionGlobals,
+        __PAYPAL_CHECKOUT__: {
+            __URI__:                {
+                __CHECKOUT__:    `/base/test/integration/windows/checkout/index.htm?checkouturl=true`,
+                __BUTTONS__:     `/base/test/integration/windows/button/index.htm`,
+                __MENU__:        `/base/test/integration/windows/menu/index.htm`,
+                __CARD_FIELDS__: `/base/test/integration/windows/card-fields/index.htm`,
+                __CARD_FIELD__:  `/base/test/integration/windows/card-field/index.htm`,
+                __WALLET__:      `/base/test/integration/windows/wallet/index.htm`,
+                __FIELDS__:      `/base/test/integration/windows/fields/index.htm`
+            }
+        },
+
+        __FUNDING_ELIGIBILITY__: () : string => `window.__TEST_FUNDING_ELIGIBILITY__ || ${ JSON.stringify(fundingEligibility) }`,
+
+        __PROTOCOL__:          'http',
+        __PORT__:              8000,
+        __STAGE_HOST__:        'msmaster.qa.paypal.com',
+        __HOST__:              'test.paypal.com',
+        __HOSTNAME__:          'test.paypal.com',
+        __SDK_HOST__:          'test.paypal.com',
+        __PATH__:              '/sdk/js',
+        __VERSION__:           '1.0.55',
+        __NAMESPACE__:         'paypal',
+        __COMPONENTS__:        [ 'buttons' ],
+        __CORRELATION_ID__:    'abc123',
+        __PAYPAL_DOMAIN__:     'mock://www.paypal.com',
+        __PAYPAL_API_DOMAIN__: 'mock://msmaster.qa.paypal.com',
+
+        __ZOID__: {
+            ...productionGlobals.__ZOID__,
+            __SCRIPT_NAMESPACE__: false
+
+        },
+
+        __POST_ROBOT__: {
+            ...productionGlobals.__POST_ROBOT__,
+            __SCRIPT_NAMESPACE__: false
         }
-    },
-
-    __FUNDING_ELIGIBILITY__: () : string => `window.__TEST_FUNDING_ELIGIBILITY__ || ${ JSON.stringify(fundingEligibility) }`,
-
-    __PROTOCOL__:          'http',
-    __PORT__:              8000,
-    __STAGE_HOST__:        'msmaster.qa.paypal.com',
-    __HOST__:              'test.paypal.com',
-    __HOSTNAME__:          'test.paypal.com',
-    __SDK_HOST__:          'test.paypal.com',
-    __PATH__:              '/sdk/js',
-    __VERSION__:           '1.0.55',
-    __NAMESPACE__:         'paypal',
-    __COMPONENTS__:        [ 'buttons' ],
-    __CORRELATION_ID__:    'abc123',
-    __PAYPAL_DOMAIN__:     'mock://www.paypal.com',
-    __PAYPAL_API_DOMAIN__: 'mock://msmaster.qa.paypal.com',
-
-    __ZOID__: {
-        ...__ZOID__,
-        __SCRIPT_NAMESPACE__: false
-
-    },
-
-    __POST_ROBOT__: {
-        ...__POST_ROBOT__,
-        __SCRIPT_NAMESPACE__: false
     }
-
-};
+}

--- a/test/screenshot/screenshot.test.js
+++ b/test/screenshot/screenshot.test.js
@@ -4,7 +4,7 @@
 import fs from 'fs-extra';
 import { getWebpackConfig } from 'grumbler-scripts/config/webpack.config';
 
-import { testGlobals } from '../globals';
+import { getTestGlobals } from '../globals';
 import globals from '../../globals';
 import { testContent } from '../content';
 
@@ -29,7 +29,7 @@ const setupBrowserPage = (async () => {
         libraryTarget: 'window',
         test:          true,
         web:           false,
-        vars:          { ...globals, ...testGlobals }
+        vars:          { ...getTestGlobals(globals) }
     })), { headless: HEADLESS, devtools: DEVTOOLS });
 
     for (const filename of await fs.readdir(IMAGE_DIR)) {
@@ -150,7 +150,7 @@ for (const config of buttonConfigs) {
                 await screenshot.write(filepath);
 
                 let imgurUrl = '';
-                
+
                 if (process.env.TRAVIS) {
                     imgurUrl = await uploadToImgur(filepath);
                 }
@@ -161,7 +161,7 @@ for (const config of buttonConfigs) {
         } else {
             await screenshot.write(filepath);
         }
-            
+
     });
 
     (only ? test.only : test)(`Render button with ${ description }`, async () => {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -5,7 +5,7 @@ import type { WebpackConfig } from 'grumbler-scripts/config/types';
 import { getWebpackConfig } from 'grumbler-scripts/config/webpack.config';
 import { ENV } from '@paypal/sdk-constants';
 
-import { testGlobals } from './test/globals';
+import { getTestGlobals } from './test/globals';
 import globals from './globals';
 
 const FILE_NAME = 'sdk';
@@ -14,6 +14,8 @@ const PROTOCOL = 'https';
 const HOSTNAME = 'localhost.paypal.com';
 const PORT = 9001;
 
+const testGlobals = getTestGlobals(globals);
+
 const WEBPACK_CONFIG_DEV : WebpackConfig = getWebpackConfig({
     entry:         './paypal.dev.js',
     filename:      `${ FILE_NAME }.js`,
@@ -21,7 +23,6 @@ const WEBPACK_CONFIG_DEV : WebpackConfig = getWebpackConfig({
     minify:        false,
     env:           ENV.LOCAL,
     vars:          {
-        ...globals,
         ...testGlobals,
         __PROTOCOL__:        PROTOCOL,
         __HOST__:            `${ HOSTNAME }:${ PORT }`,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@
 import type { WebpackConfig } from 'grumbler-scripts/config/types';
 import { getWebpackConfig } from 'grumbler-scripts/config/webpack.config';
 
-import { testGlobals } from './test/globals';
+import { getTestGlobals } from './test/globals';
 import globals from './globals';
 
 const MODULE_NAME = 'paypal';
@@ -17,8 +17,7 @@ export const WEBPACK_CONFIG_TEST : WebpackConfig = getWebpackConfig({
     debug:  true,
 
     vars: {
-        ...globals,
-        ...testGlobals,
+        ...getTestGlobals(globals),
         __CLIENT_ID__:   'abcxyz123',
         __MERCHANT_ID__: 'abc'
     }

--- a/webpack.config.size.js
+++ b/webpack.config.size.js
@@ -4,8 +4,10 @@
 import type { WebpackConfig } from 'grumbler-scripts/config/types';
 import { getWebpackConfig } from 'grumbler-scripts/config/webpack.config';
 
-import { testGlobals, fundingEligibility } from './test/globals';
+import { getTestGlobals, fundingEligibility } from './test/globals';
 import globals from './globals';
+
+const testGlobals = getTestGlobals(globals);
 
 for (const fundingSource of Object.keys(fundingEligibility)) {
     fundingEligibility[fundingSource].eligible = (fundingSource === 'paypal');
@@ -18,7 +20,6 @@ const CHECK_SIZE_CONFIG : WebpackConfig = getWebpackConfig({
     sourcemaps: false,
     analyze:    true,
     vars:       {
-        ...globals,
         ...testGlobals,
         __FUNDING_ELIGIBILITY__: fundingEligibility
     }
@@ -31,7 +32,6 @@ const CHECK_SIZE_MIN_CONFIG : WebpackConfig = getWebpackConfig({
     sourcemaps: false,
     analyze:    true,
     vars:       {
-        ...globals,
         ...testGlobals,
         __FUNDING_ELIGIBILITY__: fundingEligibility
     }


### PR DESCRIPTION
This PR fixes a error related to webpack 4 raw-loader and json files. It resolves the following error that happens when running `npm run karma`:

```
WARNING in ./test/globals.js 135:31-45
"export '__POST_ROBOT__' was not found in '../globals'

WARNING in ./test/globals.js 132:25-33
"export '__ZOID__' was not found in '../globals'

ERROR in ./node_modules/post-robot/package.json
Module parse failed: Unexpected token e in JSON at position 0 while parsing near 'export default "{\n ...'
File was processed with these loaders:
 * ./node_modules/raw-loader/dist/cjs.js
You may need an additional loader to handle the result of these loaders.
SyntaxError: Unexpected token e in JSON at position 0 while parsing near 'export default "{\n ...'
    at JSON.parse (<anonymous>)
    at parseJson (/Users/gjopa/projects/paypal-checkout-components/node_modules/json-parse-better-errors/index.js:7:17)
    at JsonParser.parse (/Users/gjopa/projects/paypal-checkout-components/node_modules/webpack/lib/JsonParser.js:16:16)
    at /Users/gjopa/projects/paypal-checkout-components/node_modules/webpack/lib/NormalModule.js:482:32
    at /Users/gjopa/projects/paypal-checkout-components/node_modules/webpack/lib/NormalModule.js:358:12
    at /Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at iterateNormalLoaders (/Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
    at /Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:236:3
    at runSyncOrAsync (/Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:130:11)
    at iterateNormalLoaders (/Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:232:2)
    at /Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:205:4
    at /Users/gjopa/projects/paypal-checkout-components/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:85:15
    at processTicksAndRejections (internal/process/task_queues.js:79:11)
 @ ./node_modules/post-robot/globals.js 2:10-35
 @ ./globals.js
 @ ./test/globals.js

ERROR in ./node_modules/zoid/package.json
Module parse failed: Unexpected token e in JSON at position 0 while parsing near 'export default "{\n ...'
File was processed with these loaders:
 * ./node_modules/raw-loader/dist/cjs.js
You may need an additional loader to handle the result of these loaders.
SyntaxError: Unexpected token e in JSON at position 0 while parsing near 'export default "{\n ...'
    at JSON.parse (<anonymous>)
    at parseJson (/Users/gjopa/projects/paypal-checkout-components/node_modules/json-parse-better-errors/index.js:7:17)
    at JsonParser.parse (/Users/gjopa/projects/paypal-checkout-components/node_modules/webpack/lib/JsonParser.js:16:16)
    at /Users/gjopa/projects/paypal-checkout-components/node_modules/webpack/lib/NormalModule.js:482:32
    at /Users/gjopa/projects/paypal-checkout-components/node_modules/webpack/lib/NormalModule.js:358:12
    at /Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at iterateNormalLoaders (/Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
    at /Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:236:3
    at runSyncOrAsync (/Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:130:11)
    at iterateNormalLoaders (/Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:232:2)
    at /Users/gjopa/projects/paypal-checkout-components/node_modules/loader-runner/lib/LoaderRunner.js:205:4
    at /Users/gjopa/projects/paypal-checkout-components/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:85:15
    at processTicksAndRejections (internal/process/task_queues.js:79:11)
 @ ./node_modules/zoid/globals.js 6:10-35
 @ ./globals.js
 @ ./test/globals.js
 Failed to compile.
```

The long term solution is to update the test suite to support the `__SCRIPT_NAMESPACE__` feature of zoid/post-robot so we can reduce the complexity of our test globals.