### PR TITLE
Fix Venmo Prerender

### DIFF
--- a/src/zoid/buttons/prerender.jsx
+++ b/src/zoid/buttons/prerender.jsx
@@ -39,7 +39,8 @@ export function PrerenderedButtons({ nonce, onRenderCheckout, props } : Prerende
             [ FPTI_KEY.BUTTON_SESSION_UID ]: props.buttonSessionID,
             [ FPTI_KEY.CONTEXT_TYPE ]:       'button_session_id',
             [ FPTI_KEY.CONTEXT_ID ]:         props.buttonSessionID,
-            [ FPTI_KEY.TRANSITION ]:         'process_button_prerender_click'
+            [ FPTI_KEY.TRANSITION ]:         'process_button_prerender_click',
+            [ FPTI_KEY.CHOSEN_FUNDING]:      fundingSource
         }).flush();
 
         


### PR DESCRIPTION
**Issue**
When an user taps on the Venmo button while it is pre-rendering, a popup is opened from the parent.  Because the popup isn't opened from the SPB iframe, we are unable to communicate back to SPB with events required for the native flow and leaves the user in a state where they are thrown into the web checkout flow with no options for completing the transaction using Venmo.

**Fix**
Disable the Venmo button during pre-render.

**Instrumentation**
Added `fundingSource` to tracking log on pre-render clicks.