### PR TITLE
Venmo - Increase the QR code modal

### DIFF
--- a/src/zoid/qr-code/component.jsx
+++ b/src/zoid/qr-code/component.jsx
@@ -182,7 +182,7 @@ export function QRCodeContainer({
                 box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.4);
                 border-radius: 16px;                        
                 width: 720px;
-                height: 480px;  
+                height: 544px;  
                 display: flex;
                 align-items: center;
                 justify-content: center;


### PR DESCRIPTION
### Venmo - Increase the QR code modal

#### Why
We are adding more content (escape path) on the RQ code component of `smart-payment-buttons`.
The new height is suggested by a Figma design provided by theUX team.

#### Solution
Change the height of `qrModal` from `480px` to `544px`.