### PR TITLE
Add tests for venmo experiment

### DIFF
--- a/src/marks/component.jsx
+++ b/src/marks/component.jsx
@@ -11,7 +11,7 @@ import { getComponents, getFundingEligibility, getEnv } from '@paypal/sdk-client
 import type { OnShippingChange } from '../ui/buttons/props';
 import { BUTTON_LAYOUT, BUTTON_FLOW } from '../constants';
 import { determineEligibleFunding, isFundingEligible } from '../funding';
-import { isSupportedNativeBrowser, createVenmoExperiment, getVenmoExperiment } from '../zoid/buttons/util';
+import { isSupportedNativeBrowser, getVenmoExperiment } from '../zoid/buttons/util';
 
 import { MarksElement } from './template';
 
@@ -42,8 +42,7 @@ export const getMarksComponent : () => MarksComponent = memoize(() => {
         const applePaySupport = fundingEligibility?.applepay?.eligible ? isApplePaySupported() : false;
         const supportsPopups = userAgentSupportsPopups();
         const supportedNativeBrowser = isSupportedNativeBrowser();
-        const enableVenmoExperiment = createVenmoExperiment();
-        const experiment = getVenmoExperiment(enableVenmoExperiment);
+        const experiment = getVenmoExperiment();
         const fundingSources = determineEligibleFunding({ fundingSource, fundingEligibility, components, platform, remembered, layout, flow, applePaySupport, supportsPopups, supportedNativeBrowser, experiment });
         const env = getEnv();
 

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -24,8 +24,6 @@ import { applePaySession, determineFlow, isSupportedNativeBrowser, createVenmoEx
 export type ButtonsComponent = ZoidComponent<ButtonProps>;
 
 export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
-    const enableVenmoExperiment = createVenmoExperiment();
-
     const queriedEligibleFunding = [];
     return create({
         tag:  'paypal-buttons',
@@ -70,7 +68,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 fundingEligibility = getRefinedFundingEligibility(),
                 supportsPopups = userAgentSupportsPopups(),
                 supportedNativeBrowser = isSupportedNativeBrowser(),
-                experiment = getVenmoExperiment(enableVenmoExperiment),
+                experiment = getVenmoExperiment(),
                 createBillingAgreement, createSubscription
             } = props;
 
@@ -247,8 +245,11 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 default:  () => noop,
                 decorate: ({ props, value = noop }) => {
                     return (...args) => {
-                        if (enableVenmoExperiment) {
-                            enableVenmoExperiment.logStart({ [ FPTI_KEY.BUTTON_SESSION_UID ]: props.buttonSessionID });
+                        const { experiment: { enableVenmo } } = props;
+                        const venmoExperiment = createVenmoExperiment();
+
+                        if (enableVenmo && venmoExperiment) {
+                            venmoExperiment.logStart({ [ FPTI_KEY.BUTTON_SESSION_UID ]: props.buttonSessionID });
                         }
 
                         return value(...args);
@@ -366,7 +367,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
             experiment: {
                 type:       'object',
                 queryParam: true,
-                value:      () => getVenmoExperiment(enableVenmoExperiment)
+                value:      () => getVenmoExperiment()
             },
 
             flow: {

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -77,10 +77,16 @@ export function createVenmoExperiment() : ?Experiment {
     const isEnableFundingVenmo = enableFunding && enableFunding.indexOf(FUNDING.VENMO) !== -1;
 
     const fundingEligibility = getFundingEligibility();
-    const isEligibleForVenmo = fundingEligibility && fundingEligibility[FUNDING.VENMO] && fundingEligibility[FUNDING.VENMO].eligible;
+    const hasBasicVenmoEligibility = fundingEligibility && fundingEligibility[FUNDING.VENMO] && fundingEligibility[FUNDING.VENMO].eligible;
+    const isEligibleForVenmoNative = isSupportedNativeBrowser() && !isEnableFundingVenmo;
+
+    // basic eligibility must be true for venmo to be eligible for the experiments
+    if (!hasBasicVenmoEligibility) {
+        return;
+    }
 
     if (isDevice()) {
-        if (!isEligibleForVenmo || (isEnableFundingVenmo && isSupportedNativeBrowser()) || !isSupportedNativeBrowser()) {
+        if (!isEligibleForVenmoNative) {
             return;
         }
 

--- a/test/integration/tests/button/eligibility.js
+++ b/test/integration/tests/button/eligibility.js
@@ -1,0 +1,149 @@
+/* @flow */
+/* eslint max-lines: 0 */
+
+import { wrapPromise } from 'belter/src';
+import { FUNDING } from '@paypal/sdk-constants/src';
+
+import {
+    createTestContainer,
+    destroyTestContainer,
+    mockProp,
+    IPHONE6_USER_AGENT,
+    COMMON_DESKTOP_USER_AGENT
+} from '../common';
+
+describe('venmo button eligibility', () => {
+    beforeEach(() => {
+        createTestContainer();
+    });
+
+    afterEach(() => {
+        destroyTestContainer();
+
+        window.navigator.mockUserAgent = IPHONE6_USER_AGENT;
+        window.localStorage.removeItem('enable_venmo_desktop');
+        window.localStorage.removeItem('enable_venmo_ios');
+    });
+
+    it('should render venmo button for desktop', () => {
+        return wrapPromise(({ expect, avoid }) => {
+            window.navigator.mockUserAgent = COMMON_DESKTOP_USER_AGENT;
+            window.localStorage.setItem('enable_venmo_desktop', true);
+            const mockEligibility = mockProp(window.__TEST_FUNDING_ELIGIBILITY__[FUNDING.VENMO], 'eligible', true);
+
+            const instance = window.paypal.Buttons({
+                test: {
+                    onRender: expect('onRender', ({ xprops, fundingSources }) => {
+                        const { experiment: { enableVenmo } } = xprops;
+                        if (!enableVenmo) {
+                            throw new Error(`Expected venmo experiment to be eligible: ${ JSON.stringify(xprops.experiment) }`);
+                        }
+
+                        if (!fundingSources.includes(FUNDING.VENMO)) {
+                            throw new Error(`Venmo is missing from the list of funding sources: ${ fundingSources }`);
+                        }
+
+                        mockEligibility.cancel();
+                    })
+                },
+
+                onApprove: avoid('onApprove'),
+                onCancel:  avoid('onCancel'),
+                onError:   avoid('onError')
+            });
+
+            return instance.render('#testContainer');
+        });
+    });
+
+    it('should not render venmo button for desktop', () => {
+        return wrapPromise(({ expect, avoid }) => {
+            window.navigator.mockUserAgent = COMMON_DESKTOP_USER_AGENT;
+            const mockEligibility = mockProp(window.__TEST_FUNDING_ELIGIBILITY__[FUNDING.VENMO], 'eligible', false);
+
+            const instance = window.paypal.Buttons({
+                test: {
+                    onRender: expect('onRender', ({ xprops, fundingSources }) => {
+                        const { experiment: { enableVenmo } } = xprops;
+                        if (enableVenmo) {
+                            throw new Error(`Expected venmo experiment to be ineligible: ${ JSON.stringify(xprops.experiment) }`);
+                        }
+
+                        if (fundingSources.includes(FUNDING.VENMO)) {
+                            throw new Error(`Venmo shound not be rendered: ${ fundingSources }`);
+                        }
+
+                        mockEligibility.cancel();
+                    })
+                },
+
+                onApprove: avoid('onApprove'),
+                onCancel:  avoid('onCancel'),
+                onError:   avoid('onError')
+            });
+
+            return instance.render('#testContainer');
+        });
+    });
+
+    it('should render venmo button for mobile', () => {
+        return wrapPromise(({ expect, avoid }) => {
+            window.navigator.mockUserAgent = IPHONE6_USER_AGENT;
+            window.localStorage.setItem('enable_venmo_ios', true);
+            const mockEligibility = mockProp(window.__TEST_FUNDING_ELIGIBILITY__[FUNDING.VENMO], 'eligible', true);
+
+            const instance = window.paypal.Buttons({
+                test: {
+                    onRender: expect('onRender', ({ xprops, fundingSources }) => {
+                        const { experiment: { enableVenmo } } = xprops;
+                        if (!enableVenmo) {
+                            throw new Error(`Expected venmo experiment to be eligible: ${ JSON.stringify(xprops.experiment) }`);
+                        }
+
+                        if (!fundingSources.includes(FUNDING.VENMO)) {
+                            throw new Error(`Venmo is missing from the list of funding sources: ${ fundingSources }`);
+                        }
+
+                        mockEligibility.cancel();
+                    })
+                },
+
+                onApprove: avoid('onApprove'),
+                onCancel:  avoid('onCancel'),
+                onError:   avoid('onError')
+            });
+
+            return instance.render('#testContainer');
+        });
+    });
+
+    it('should not render venmo button for mobile', () => {
+        return wrapPromise(({ expect, avoid }) => {
+            window.navigator.mockUserAgent = IPHONE6_USER_AGENT;
+            const mockEligibility = mockProp(window.__TEST_FUNDING_ELIGIBILITY__[FUNDING.VENMO], 'eligible', true);
+
+            const instance = window.paypal.Buttons({
+                test: {
+                    onRender: expect('onRender', ({ xprops, fundingSources }) => {
+                        const { experiment: { enableVenmo } } = xprops;
+                        if (!enableVenmo) {
+                            throw new Error(`Expected venmo experiment to be eligible: ${ JSON.stringify(xprops.experiment) }`);
+                        }
+
+                        if (!fundingSources.includes(FUNDING.VENMO)) {
+                            throw new Error(`Venmo is missing from the list of funding sources: ${ fundingSources }`);
+                        }
+
+                        mockEligibility.cancel();
+                    })
+                },
+
+                onApprove: avoid('onApprove'),
+                onCancel:  avoid('onCancel'),
+                onError:   avoid('onError')
+            });
+
+            return instance.render('#testContainer');
+        });
+    });
+});

--- a/test/integration/tests/button/eligibility.js
+++ b/test/integration/tests/button/eligibility.js
@@ -25,7 +25,7 @@ describe('venmo button eligibility', () => {
         window.localStorage.removeItem('enable_venmo_ios');
     });
 
-    it('should render venmo button for desktop', () => {
+    it('should render venmo button for desktop when eligibility is true', () => {
         return wrapPromise(({ expect, avoid }) => {
             window.navigator.mockUserAgent = COMMON_DESKTOP_USER_AGENT;
             window.localStorage.setItem('enable_venmo_desktop', true);
@@ -56,7 +56,7 @@ describe('venmo button eligibility', () => {
         });
     });
 
-    it('should not render venmo button for desktop', () => {
+    it('should not render venmo button for desktop when eligibility is false', () => {
         return wrapPromise(({ expect, avoid }) => {
             window.navigator.mockUserAgent = COMMON_DESKTOP_USER_AGENT;
             const mockEligibility = mockProp(window.__TEST_FUNDING_ELIGIBILITY__[FUNDING.VENMO], 'eligible', false);
@@ -86,7 +86,7 @@ describe('venmo button eligibility', () => {
         });
     });
 
-    it('should render venmo button for mobile', () => {
+    it('should render venmo button for mobile when eligibility is true', () => {
         return wrapPromise(({ expect, avoid }) => {
             window.navigator.mockUserAgent = IPHONE6_USER_AGENT;
             window.localStorage.setItem('enable_venmo_ios', true);
@@ -117,7 +117,7 @@ describe('venmo button eligibility', () => {
         });
     });
 
-    it('should not render venmo button for mobile', () => {
+    it('should not render venmo button for mobile when eligibility is false', () => {
         return wrapPromise(({ expect, avoid }) => {
             window.navigator.mockUserAgent = IPHONE6_USER_AGENT;
             const mockEligibility = mockProp(window.__TEST_FUNDING_ELIGIBILITY__[FUNDING.VENMO], 'eligible', true);

--- a/test/integration/tests/button/index.js
+++ b/test/integration/tests/button/index.js
@@ -16,3 +16,4 @@ import './standalone';
 import './clone';
 import './renderOrder';
 import './nonce';
+import './eligibility';


### PR DESCRIPTION
This PR improves the test coverage for the venmo experiments. It also removes the `inlineMemoize` feature wrapping the create experiment code. I recently learned that belter experiments are sticky by default so we shoudn't need to memoize them: https://github.com/krakenjs/belter/blob/master/src/experiment.js#L62-L66