### PR TITLE
chore(build): increase bundle size limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "jest-ssr": "jest test/ssr --env=node --no-cache --collectCoverage --collectCoverageFrom='src/' --coverageDirectory='coverage/jest'",
         "jest-e2e": "rm -f ./test/e2e/screenshots/*.png && jest test/e2e",
         "get-size": "gzip -9 < dist/size.min.js | wc -c",
-        "check-size": "npm run webpack-size && if [ $(npm run -s get-size) -ge 70000 ]; then echo 'Bundle size greater than 65k'; exit 1; else npm run delete-size; fi;",
+        "check-size": "npm run webpack-size && if [ $(npm run -s get-size) -ge 72000 ]; then echo 'Bundle size greater than 72k'; exit 1; else npm run delete-size; fi;",
         "delete-size": "rm dist/size.* dist/report.html"
     },
     "files": [


### PR DESCRIPTION
Our bundle size crossed the 70K limit barrier recently. It appears to have been caused by a dependency update. Recall we don't use a `package-lock` file thus we might get updates during fresh installs. We can test this by re-running a more recent passing CI build and seeing it now fails. We can continue to investigate to find the dependency that grew in size, but at this time since there aren't production issues related to this I propose we up the bundle size limits. A discussion has begun around better tracking bundle sizes and maybe comparing by PR delta vs total size of bundle. For example "Ensure no PR increase the current bundle size by more than x%". 

First failing sha: b9ca90db1b0329f541fe1401044804b39e8a8abf
Related PR: #1700 (this did pass at time of merge however so no nothing malicious)
Previous passing build that will now fail: https://github.com/paypal/paypal-checkout-components/runs/3559319075
