### PR TITLE
Revert "feat(venmo): Surpress showing venmo on tablets"

### DIFF
--- a/src/funding/venmo/config.jsx
+++ b/src/funding/venmo/config.jsx
@@ -1,7 +1,6 @@
 /* @flow */
 /** @jsx node */
 
-import { isTablet } from 'belter/src';
 import { VenmoLogo, LOGO_COLOR } from '@paypal/sdk-logos/src';
 import { PLATFORM } from '@paypal/sdk-constants/src';
 
@@ -22,11 +21,6 @@ export function getVenmoConfig() : FundingSourceConfig {
         ],
         
         eligible: ({ experiment }) => {
-            // If user is using a tablet don't show venmo button
-            if (isTablet()) {
-                return false;
-            }
-
             if (experiment && experiment.enableVenmo === false) {
                 return false;
             }


### PR DESCRIPTION
Reverts paypal/paypal-checkout-components#1740

Need to revert because an additional check is needed for createExperiement.  We don't want to show the button and have them in the experiement.