### PR TITLE
feat(button): Suppress showing Venmo button on tablets

### DIFF
--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { supportsPopups as userAgentSupportsPopups, isAndroid, isChrome, isIos, isSafari, isSFVC, type Experiment, isDevice } from 'belter/src';
+import { supportsPopups as userAgentSupportsPopups, isAndroid, isChrome, isIos, isSafari, isSFVC, type Experiment, isDevice, isTablet } from 'belter/src';
 import { FUNDING } from '@paypal/sdk-constants/src';
 import { getEnableFunding, getDisableFunding, createExperiment, getFundingEligibility, getPlatform, getComponents } from '@paypal/sdk-client/src';
 import { getRefinedFundingEligibility } from '@paypal/funding-components/src';
@@ -58,6 +58,10 @@ export function isSupportedNativeBrowser() : boolean {
     }
 
     if (isSFVC()) {
+        return false;
+    }
+
+    if (isTablet()) {
         return false;
     }
 

--- a/test/integration/tests/funding/venmo/index.js
+++ b/test/integration/tests/funding/venmo/index.js
@@ -87,3 +87,27 @@ describe(`venmo desktop web button test `, () => {
         done();
     });
 });
+
+describe(`venmo on tablet `, () => {
+
+    beforeEach(() => {
+        createTestContainer();
+        window.navigator.mockUserAgent = 'Mozilla/5.0 (iPad; CPU OS 14_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Mobile/15E148 Safari/604.1';
+        
+    });
+
+    afterEach(() => {
+        destroyTestContainer();
+    });
+
+
+    it(`should NOT display button`, (done) => {
+        mockProp(window.__TEST_FUNDING_ELIGIBILITY__[fundingSource], 'eligible', true);
+        
+        const paypalButtons = window.paypal.Buttons({
+            fundingSource
+        });
+        assert.equal(paypalButtons.isEligible(), false);
+        done();
+    });
+});


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for contributing](https://github.com/paypal/paypal-checkout-components/blob/master/CONTRIBUTING.md) to this repository.
🚨 Please review the [guidelines for a good PR Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)

- [ ] Ensure you have a PR description that answers: What? Why? How?
- [ ] Link to any reference tickets if they are available. This includes Jira ticket or Github issues.
- [ ] Include any relevant screenshots for the change set if it modifies any visual functionality.
- [ ] Ensure you have added passing tests to cover new functionality, bug fixes, etc.

### Description

Suppress showing Venmo button on tablet devices.  Detection logic is in `belter` (PR is already merged and npm already published).

#### What is being changed from a technical perspective?

#### Why are we making these changes? Include and reference tickets (Jira, Github Issue, etc)

### Reproduction Steps (if applicable)

Open iPad simulator and hit test site (https://checkout-integrations.vercel.app/venmo/staging/shipping-not-required.html#DO_NOT_CHANGE_THIS_HASH).  Venmo button should not show.

### Screenshots (if applicable)

![Screen Shot 2021-09-15 at 11 41 24 AM](https://user-images.githubusercontent.com/1623146/133640953-785ea3ee-9245-4dd2-8226-fc2088377f29.png)
![Screen Shot 2021-09-15 at 11 41 21 AM](https://user-images.githubusercontent.com/1623146/133640962-22b5bba8-2441-494e-9a29-601048236f21.png)


❤️  Thank you!
