### PR TITLE
Venmo Desktop - Consumer Feedback collection

### DIFF
--- a/src/zoid/qr-code/component.jsx
+++ b/src/zoid/qr-code/component.jsx
@@ -73,6 +73,9 @@ export function getQRCodeComponent() : QRCodeComponent {
                 onEscapePath: {
                     type: 'function'
                 },
+                onSubmitFeedback: {
+                    type: 'function'
+                },
                 qrPath: {
                     type:       'string',
                     queryParam: true,
@@ -142,6 +145,9 @@ export function QRCodeContainer({
 
         frame.classList.remove(CLASS.INVISIBLE);
         frame.classList.add(CLASS.VISIBLE);
+
+        // Close is now controlled by QRCard on smart-payment-buttons
+        document.querySelector('#close').remove();
 
         setTimeout(() => {
             destroyElement(prerenderFrame);


### PR DESCRIPTION
### Description
Feedback on Desktop XO would need to be collected at only one point on the QR code scanning page when the consumer hits the X option.  We do not want to collect the feedback post the QR scan because we are already collecting the feedback on the mobile experience.

#### Linked PR:
https://github.com/paypal/paypal-smart-payment-buttons/pull/247

#### Changes
- Passing the onSubmitFeedback event as a props to the QRCodeComponent.
- After the iframe is loaded, we remove the close button. A new identical close button is rendered on the QRCodeComponent that controls the survey.
