### PR TITLE
chore: update bundlesize tracking to use bundlemon

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -1,0 +1,21 @@
+{
+  "baseDir": "./dist",
+  "files": [
+    {
+      "path": "size.min.js",
+      "compression": "gzip",
+      "maxPercentIncrease": 3,
+      "maxSize": "75kb"
+    }
+  ],
+  "reportOutput": [
+    [
+      "github",
+      {
+        "checkRun": true,
+        "commitStatus": true,
+        "prComment": false
+      }
+    ]
+  ]
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,3 +43,8 @@ jobs:
         with:
           directory: ./coverage/jest
           flags: jest
+
+      - name: 🤏 Check bundlesize
+        run: npm run check-size
+        env:
+          BUNDLEMON_PROJECT_ID: ${{ secrets.BUNDLEMON_PROJECT_ID }}

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
         "flow-typed": "rm -rf flow-typed && flow-typed install && rm flow-typed/npm/puppeteer_*",
         "flow": "flow",
         "karma": "cross-env NODE_ENV=test babel-node $(npm bin)/karma start",
-        "test": "if [ ! $SKIP_TEST ]; then npm run lint && npm run flow-typed && npm run flow && npm run jest-ssr && npm run karma && npm run jest-screenshot && npm run check-size; fi;",
+        "test": "if [ ! $SKIP_TEST ]; then npm run lint && npm run flow-typed && npm run flow && npm run jest-ssr && npm run karma && npm run jest-screenshot; fi;",
         "webpack": "babel-node $(npm bin)/webpack --progress",
-        "webpack-size": "babel-node $(npm bin)/webpack --progress --config webpack.config.size && echo && echo Final bundle size: $( npm run -s get-size );",
+        "webpack-size": "babel-node $(npm bin)/webpack --progress --config webpack.config.size",
         "build": "npm run test && npm run webpack",
         "release": "./scripts/publish.sh",
         "release:patch": "./scripts/publish.sh patch",
@@ -28,8 +28,7 @@
         "jest-screenshot": "jest test/screenshot --env=node --no-cache",
         "jest-ssr": "jest test/ssr --env=node --no-cache --collectCoverage --collectCoverageFrom='src/' --coverageDirectory='coverage/jest'",
         "jest-e2e": "rm -f ./test/e2e/screenshots/*.png && jest test/e2e",
-        "get-size": "gzip -9 < dist/size.min.js | wc -c",
-        "check-size": "npm run webpack-size && if [ $(npm run -s get-size) -ge 75000 ]; then echo 'Bundle size greater than 75k'; exit 1; else npm run delete-size; fi;",
+        "check-size": "npm run webpack-size && bundlemon && npm run delete-size",
         "delete-size": "rm dist/size.* dist/report.html"
     },
     "files": [
@@ -62,6 +61,7 @@
     "readmeFilename": "README.md",
     "devDependencies": {
         "babel-core": "^7.0.0-bridge.0",
+        "bundlemon": "^1.1.0",
         "conventional-changelog-cli": "^2.0.34",
         "flow-bin": "0.155.0",
         "fs-extra": "^9.0.1",


### PR DESCRIPTION
### Description

Use [bundlemon](https://github.com/LironEr/bundlemon) to enable richer bundle size tracking. Our intent is to move to a percentage based increase model.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

We run into the scenario of updating our bundlesize budget pretty consistently and its output is hidden away in the build. We would like output to be first class on new PRs as well as track via a percent increase.

❤️  Thank you!
