### PR TITLE
chore: hardcode bundlemon public key

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,4 +47,4 @@ jobs:
       - name: 🤏 Check bundlesize
         run: npm run check-size
         env:
-          BUNDLEMON_PROJECT_ID: ${{ secrets.BUNDLEMON_PROJECT_ID }}
+          BUNDLEMON_PROJECT_ID: 6166e8ee491d1e00090fee72


### PR DESCRIPTION
Secrets are not accessible from PRs for security.
https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/

This key is not sensitive and intended to be public but I wanted to try to make it private anyways at first.
