### PR TITLE
Fix BundleMon configuration

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -13,7 +13,7 @@
       "github",
       {
         "checkRun": true,
-        "commitStatus": true,
+        "commitStatus": false,
         "prComment": false
       }
     ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,3 +48,4 @@ jobs:
         run: npm run check-size
         env:
           BUNDLEMON_PROJECT_ID: 6166e8ee491d1e00090fee72
+          CI_COMMIT_SHA: ${{github.event.pull_request.head.sha || github.sha}}


### PR DESCRIPTION
### Description
Currently, BundleMon runs on pull requests & commits to master.
When running on a branch there is no problem and BundleMon creates check run & commit status without a problem.
But when running BundleMon on PR you need to override `CI_COMMIT_SHA` env var to point BundleMon to the right commit SHA, otherwise, you won't see the report. You can read more about it [here](https://frontside.com/blog/2020-05-26-github-actions-pull_request/#how-does-pull_request-affect-actionscheckout)

Also because GitHub check run creates commit status there is no need to use both, otherwise, you will have 2 statues.
![image](https://user-images.githubusercontent.com/6559921/139748124-8422824d-f9f5-406e-8dd1-9bcf709d4f92.png)
