### PR TITLE
fix animation for 300-330px button

### DIFF
--- a/src/ui/buttons/button-animations/divide-logo-animation.jsx
+++ b/src/ui/buttons/button-animations/divide-logo-animation.jsx
@@ -34,7 +34,13 @@ export function LabelForDivideLogoAnimation({ animationLabelText } : LabelOption
                     opacity: 0; 
                     color: #142C8E;
                     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-                    font-size: 16px;
+                    font-size: 14px;
+                }
+
+                .${ ANIMATION.CONTAINER } .${ ANIMATION.LABEL_CONTAINER } span {
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: space-around;
                 }
             ` } />;
         </Fragment>

--- a/src/ui/buttons/button-animations/label-text-next-to-logo-animation.jsx
+++ b/src/ui/buttons/button-animations/label-text-next-to-logo-animation.jsx
@@ -27,7 +27,10 @@ function ComponentForAnimation({ animationLabelText } : LabelOptions) : ChildTyp
                     opacity: 0; 
                     color: #142C8E;
                     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-                    font-size: 16px;
+                    font-size: 14px;
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: space-around;
                 }
             ` } />;
         </Fragment>


### PR DESCRIPTION
### Description
 - Text didn't fit for horizontal button when width between 300 and 330px.
 - Lowered font size and centered text.
 
 
 Broken: 
<img width="625" alt="Screen Shot 2021-11-01 at 5 06 41 PM" src="https://user-images.githubusercontent.com/24723396/139909002-bab645c4-bbd3-452e-8605-da12555cffa7.png">

Fixed: 
<img width="621" alt="Screen Shot 2021-11-02 at 9 28 13 AM" src="https://user-images.githubusercontent.com/24723396/139909045-a124b774-cd8c-479c-9a2b-83a37fa6ad8b.png">

Max-size design
<img width="816" alt="Screen Shot 2021-11-02 at 9 29 22 AM" src="https://user-images.githubusercontent.com/24723396/139909056-33c3a298-9159-484d-9291-22f158d75382.png">

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

❤️  Thank you!
