### PR TITLE
Remove QR spinner to wait for SPB

### DIFF
--- a/src/zoid/buttons/prerender.jsx
+++ b/src/zoid/buttons/prerender.jsx
@@ -13,8 +13,6 @@ import { DEFAULT_POPUP_SIZE } from '../checkout';
 import { Buttons } from '../../ui';
 import { type ButtonProps } from '../../ui/buttons/props';
 
-import { supportsQRPay, showButtonLoading } from './util';
-
 type PrerenderedButtonsProps = {|
     nonce : ?string,
     props : ZoidProps<ButtonProps>,
@@ -43,17 +41,7 @@ export function PrerenderedButtons({ nonce, onRenderCheckout, props } : Prerende
             [ FPTI_KEY.CHOSEN_FUNDING]:      fundingSource
         }).flush();
 
-        
-        if (supportsQRPay(fundingSource)) {
-            showButtonLoading(
-                fundingSource,
-                // $FlowFixMe[prop-missing]
-                // $FlowFixMe[incompatible-call]
-                event
-            );
-            onRenderCheckout({ fundingSource, card });
-
-        } else if (fundingSource === FUNDING.VENMO) {
+        if (fundingSource === FUNDING.VENMO) {
             // wait for button to load
         } else if (supportsPopups()) {
             // remember the popup window to prevent showing a new popup window on every click in the prerender state

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -5,7 +5,7 @@ import { getEnableFunding, getDisableFunding, createExperiment, getFundingEligib
 import { getRefinedFundingEligibility } from '@paypal/funding-components/src';
 
 import type { Experiment as EligibilityExperiment } from '../../types';
-import { BUTTON_FLOW, CLASS } from '../../constants';
+import { BUTTON_FLOW } from '../../constants';
 import type { ApplePaySessionConfigRequest, CreateBillingAgreement, CreateSubscription, ButtonProps } from '../../ui/buttons/props';
 import { determineEligibleFunding } from '../../funding';
 
@@ -22,29 +22,6 @@ export function determineFlow(props : DetermineFlowOptions) : $Values<typeof BUT
         return BUTTON_FLOW.SUBSCRIPTION_SETUP;
     } else {
         return BUTTON_FLOW.PURCHASE;
-    }
-}
-
-export function supportsQRPay(funding : $Values<typeof FUNDING>) : boolean {
-    if (funding === FUNDING.VENMO && !isDevice()) {
-        return true;
-    }
-
-    return false;
-}
-
-// eslint-disable-next-line no-undef
-export function showButtonLoading (fundingSource : $Values<typeof FUNDING>, event : SyntheticInputEvent<HTMLInputElement>) : void {
-    const buttonElement = event.target.ownerDocument.querySelector(`[data-funding-source="${ fundingSource }"]`);
-    if (buttonElement) {
-        const spinner = buttonElement.querySelector(`.${ CLASS.SPINNER }`);
-        const label = buttonElement.querySelector(`.${ CLASS.BUTTON_LABEL }`);
-        if (spinner) {
-            spinner.setAttribute('style', 'display:block !important');
-        }
-        if (label) {
-            label.setAttribute('style', 'display:none;');
-        }
     }
 }
 


### PR DESCRIPTION
### Description
This PR removes the QR spinner to wait for SPB to handle the QR code.

### Why are we making these changes?
Removing this spinner logic will fix a bug where clicking on Venmo Desktop during first render will land on the fallback experience and not display the QR code.

### Reproduction Steps (if applicable)
- Fetch branch and run checkout components locally
- Hit a test page and click on Venmo during first render
- Confirm clicking the button waits and does not open the fallback experience
- Click Venmo on second render and confirm the QR code is displayed

### Screenshots (if applicable)
| Before      | After |
| ----------- | ----------- |
|<img width="442" alt="loading-spinner" src="https://user-images.githubusercontent.com/40329316/140386076-5c6d81e6-ac97-47c4-9bcd-05753dca7138.png">| <img width="388" alt="wait-condition" src="https://user-images.githubusercontent.com/40329316/140386144-58344271-7037-49ab-836e-66ecab9fe3a2.png">|

### Dependent Changes (if applicable)
None
