### PR TITLE
Update hover states to work with touch input devices

### DIFF
--- a/src/ui/buttons/styles/color.js
+++ b/src/ui/buttons/styles/color.js
@@ -30,8 +30,10 @@ export const buttonColorStyle = `
         background: #ffc439;
     }
 
-    .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.GOLD }:hover {
-        filter: brightness(0.95);
+    @media (hover:hover) {
+        .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.GOLD }:hover {
+            filter: brightness(0.95);
+        }
     }
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.GOLD }:focus {
@@ -60,8 +62,10 @@ export const buttonColorStyle = `
         background: #008CFF;
     }
 
-    .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.BLUE }:hover {
-        filter: brightness(0.95);
+    @media (hover:hover) {
+        .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.BLUE }:hover {
+            filter: brightness(0.95);
+        }
     }
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.BLUE }:focus {
@@ -85,8 +89,10 @@ export const buttonColorStyle = `
         background: #eee;
     }
 
-    .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.SILVER }:hover {
-        filter: brightness(0.95);
+    @media (hover:hover) {
+        .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.SILVER }:hover {
+            filter: brightness(0.95);
+        }
     }
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.SILVER }:focus {
@@ -163,9 +169,12 @@ export const buttonColorStyle = `
         border: 1px solid #555;
     }
 
-    .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.WHITE }:hover {
-        filter: brightness(0.95);
+    @media (hover:hover) {
+        .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.WHITE }:hover {
+            filter: brightness(0.95);
+        }
     }
+    
 
     .${ CLASS.BUTTON }.${ CLASS.COLOR }-${ BUTTON_COLOR.WHITE }:focus {
         outline: none;


### PR DESCRIPTION

### Description

We had reports that users are seeing sticky hover states on mobile browsers. This is a common pitfall of how hover is implemented on touch supported devices so I'll just link to the css-tricks article and fix I normally use here: https://css-tricks.com/solving-sticky-hover-states-with-media-hover-hover/


### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
DTPPSDK-486

### Reproduction Steps (if applicable)
Run checkout-components locally with `npm run dev` and have Chrome dev tools emulate and mobile browsers (iphone x for instance) and just long click any of the white buttons, then close the popup. You will see it is stuck gray.

### Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/802901/140799561-e777811c-bf61-40f0-894a-52fa43792543.png)

