### PR TITLE
fix locales issue

### DIFF
--- a/src/zoid/card-form/component.js
+++ b/src/zoid/card-form/component.js
@@ -2,6 +2,7 @@
 /* @jsx jsxDom */
 /* eslint max-lines: 0 */
 
+import { LANG } from '@paypal/sdk-constants/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { create, type ZoidComponent } from 'zoid/src';
 import type { CrossDomainWindowType } from 'cross-domain-utils/src';
@@ -9,6 +10,7 @@ import { inlineMemoize } from 'belter/src';
 import { getLocale, getEnv, getCommit, getSDKMeta, getDisableCard, getPayPalDomain } from '@paypal/sdk-client/src';
 
 import { getSessionID } from '../../lib';
+
 
 type CardProps = {|
     client : {
@@ -89,7 +91,8 @@ export function getCardFormComponent() : CardFormComponent {
                     queryParam:    'locale.x',
                     allowDelegate: true,
                     queryValue({ value }) : string {
-                        const { lang, country } = value;
+                        let { lang, country } = value;
+                        lang = lang === LANG.ZH_HANT ? LANG.ZH : lang;
                         return `${ lang }_${ country }`;
                     },
                     value: getLocale

--- a/test/ssr/ssr.test.js
+++ b/test/ssr/ssr.test.js
@@ -75,6 +75,23 @@ test(`Button should render with ssr, with zh_Hant locale option`, async () => {
     }
 });
 
+test(`Button should render with ssr, with en_HK locale option`, async () => {
+
+    const { Buttons } = await getButtonScript();
+
+    const buttonHTML = Buttons({
+        locale:          { country: 'HK', lang: 'en' },
+        platform:        'desktop',
+        sessionID:       'xyz',
+        buttonSessionID: 'abc',
+        fundingEligibility
+    }).render(html());
+
+    if (!buttonHTML || typeof buttonHTML !== 'string') {
+        throw new Error(`Expected html to be a non-empty string`);
+    }
+});
+
 test(`Button should fail to render with ssr, with invalid style option`, async () => {
 
     const { Buttons } = await getButtonScript();

--- a/test/ssr/ssr.test.js
+++ b/test/ssr/ssr.test.js
@@ -63,24 +63,7 @@ test(`Button should render with ssr, with zh_Hant locale option`, async () => {
     const { Buttons } = await getButtonScript();
 
     const buttonHTML = Buttons({
-        locale:          { country: 'HK', lang: 'zh' },
-        platform:        'desktop',
-        sessionID:       'xyz',
-        buttonSessionID: 'abc',
-        fundingEligibility
-    }).render(html());
-
-    if (!buttonHTML || typeof buttonHTML !== 'string') {
-        throw new Error(`Expected html to be a non-empty string`);
-    }
-});
-
-test(`Button should render with ssr, with en_HK locale option`, async () => {
-
-    const { Buttons } = await getButtonScript();
-
-    const buttonHTML = Buttons({
-        locale:          { country: 'HK', lang: 'en' },
+        locale:          { country: 'HK', lang: 'zh_Hant' },
         platform:        'desktop',
         sessionID:       'xyz',
         buttonSessionID: 'abc',

--- a/test/ssr/ssr.test.js
+++ b/test/ssr/ssr.test.js
@@ -63,7 +63,24 @@ test(`Button should render with ssr, with zh_Hant locale option`, async () => {
     const { Buttons } = await getButtonScript();
 
     const buttonHTML = Buttons({
-        locale:          { country: 'HK', lang: 'zh_Hant' },
+        locale:          { country: 'HK', lang: 'zh' },
+        platform:        'desktop',
+        sessionID:       'xyz',
+        buttonSessionID: 'abc',
+        fundingEligibility
+    }).render(html());
+
+    if (!buttonHTML || typeof buttonHTML !== 'string') {
+        throw new Error(`Expected html to be a non-empty string`);
+    }
+});
+
+test(`Button should render with ssr, with en_HK locale option`, async () => {
+
+    const { Buttons } = await getButtonScript();
+
+    const buttonHTML = Buttons({
+        locale:          { country: 'HK', lang: 'en' },
         platform:        'desktop',
         sessionID:       'xyz',
         buttonSessionID: 'abc',


### PR DESCRIPTION
# Description

Previously, any country that had `zh_Hant` as one of its available languages, the logic returned always `zh_Hant` as lang, ignoring variables as `en` or other supported languages. This fix solves that.

However, some projects like `xo-card-fields` do not support `zh_Hant` as language, and adding it will require several changes in more than one project. For now, it solves the bug in production


- [Jira Ticket](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-193)
- has to do with:  https://github.paypal.com/Checkout-R/clientsdknodeweb/pull/304

## Related PRs

- https://github.paypal.com/Checkout-R/clientsdknodeweb/pull/306
- https://github.com/paypal/paypal-sdk-client/pull/91