### PR TITLE
paymentfields prerender bg color update

### DIFF
--- a/src/zoid/payment-fields/prerender.jsx
+++ b/src/zoid/payment-fields/prerender.jsx
@@ -19,35 +19,12 @@ export function PaymentFieldsPrerender({ nonce } : PrerenderedPaymentFieldsProps
                             margin: 0;
                             width: 100%;
                             height: 100%;
-                            background: transparent;
+                            background: rgba(240,240,240,0.5);
                         }
 
                         body {
-                            background: transparent;
                             position: relative;
                             overflow: hidden;
-                        }
-
-                        body::after {
-                            content: "";
-                            display: block;
-                            background-color: transparent;
-                            overflow: hidden;
-                            position: absolute;
-                            top: 0;
-                            bottom: 0;
-                            width: 100%;
-                            height: 100%;
-                            transform: translateX(0);
-                        }
-
-                        @keyframes loading-placeholder {
-                            0% {
-                                transform: translateX(-150%);
-                            }
-                            100% {
-                                transform: translateX(150%);
-                            }
                         }
                     ` }
                 />


### PR DESCRIPTION
adds subtle gray background to prerender stage for payment fields

before (empty)
![Screen Shot 2021-11-09 at 1 35 04 PM](https://user-images.githubusercontent.com/5710962/141009332-3008df37-b9fe-478b-a54d-da4f1e16b406.png)

doc example gray bg
![image001](https://user-images.githubusercontent.com/5710962/141008760-07ca3cd2-df8e-4691-bc4d-4c97e3f56c66.gif)

on white 
![image001](https://user-images.githubusercontent.com/5710962/141009274-823b4358-2b5c-4847-a9a6-36a71badd07d.gif)


