### PR TITLE
Card holder name field

### DIFF
--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -20,7 +20,8 @@ const CARD_FIELD_TYPE = {
     SINGLE: 'single',
     NUMBER: 'number',
     CVV:    'cvv',
-    EXPIRY: 'expiry'
+    EXPIRY: 'expiry',
+    NAME:   'name'
 };
 
 type CardFieldsProps = {|
@@ -66,7 +67,8 @@ type CardFieldsExports = {|
 type CardFieldsChildren = {|
     NumberField : CardFieldComponent,
     CVVField : CardFieldComponent,
-    ExpiryField : CardFieldComponent
+    ExpiryField : CardFieldComponent,
+    NameField : CardFieldComponent
 |};
 
 const url = () => `${ getPayPalDomain() }${ __PAYPAL_CHECKOUT__.__URI__.__CARD_FIELD__ }`;
@@ -240,6 +242,7 @@ export const getCardFieldsComponent : () => CardFieldsComponent = memoize(() : C
     const NumberField = genericCardField(CARD_FIELD_TYPE.NUMBER);
     const CVVField = genericCardField(CARD_FIELD_TYPE.CVV);
     const ExpiryField = genericCardField(CARD_FIELD_TYPE.EXPIRY);
+    const NameField = genericCardField(CARD_FIELD_TYPE.NAME);
 
     const CardFields = create({
         tag: 'paypal-card-fields',
@@ -267,7 +270,8 @@ export const getCardFieldsComponent : () => CardFieldsComponent = memoize(() : C
             return {
                 NumberField,
                 CVVField,
-                ExpiryField
+                ExpiryField,
+                NameField
             };
         },
 


### PR DESCRIPTION
### Description

Defined a new Zoid component for the Card Holder's Name input for the card fields.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

- https://engineering.paypalcorp.com/jira/browse/DTNOR-288

For the card fields we need an optional hosted field for the card holder's name.

The name is not PCI compliance but for the auto-fill browser autofill feature all the card fields related inputs need to be on an iframe for it to work as expected. 

### Reproduction Steps (if applicable)

It will be used as a child component of the CardField parent component.

### Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/5726810/145277890-2a346a34-5550-4813-bbb1-1c1bf8a2681c.png)


### Dependent Changes (if applicable)

This change will be used on SPB (paypal-smart-payment-buttons).
- https://github.com/paypal/paypal-smart-payment-buttons/pull/307

❤️  Thank you!
