### PR TITLE
fix: use unicode emoji for version message

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,5 @@
 registry=https://registry.npmjs.org
 save=false
-message="chore(release): %s :tada:"
+message="chore(release): %s 🎉"
 package-lock=false
 puppeteer_download_host='https://commondatastorage.googleapis.com'


### PR DESCRIPTION
### Description

Very minor. Just uses the 🎉 unicode emoji for the npm version commit message so it appears correctly on all platforms. 

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

Just thought we should see the party popper instead of `:tada:` when looking at `git log` output.
