### PR TITLE
Improve venmo conversion based on browsers

### DIFF
--- a/test/integration/tests/button/eligibility.js
+++ b/test/integration/tests/button/eligibility.js
@@ -162,7 +162,7 @@ describe('venmo button eligibility', () => {
             'Opera/9.80 (iPhone; Opera Mini/8.0.0/34.2336; U; en) Presto/2.8.119 Version/11.10', // Opera mini - iOS
             'Mozilla/5.0 (Linux; Android 11; SAMSUNG SM-G973F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Mobile Safari/537.36', // Samsung 15
             'Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36', // Samsung 10.2
-            'Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G610M Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36', // Samsung 7.4
+            'Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G610M Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36', // Samsung 7
             'Mozilla/5.0 (Linux; Android 11; SAMSUNG SM-G975F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Mobile Safari/537.36' // Samsung 15
         ];
         for (const userAgent of ineligibleUserAgents) {

--- a/test/integration/tests/button/eligibility.js
+++ b/test/integration/tests/button/eligibility.js
@@ -162,7 +162,7 @@ describe('venmo button eligibility', () => {
             'Opera/9.80 (iPhone; Opera Mini/8.0.0/34.2336; U; en) Presto/2.8.119 Version/11.10', // Opera mini - iOS
             'Mozilla/5.0 (Linux; Android 11; SAMSUNG SM-G973F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Mobile Safari/537.36', // Samsung 15
             'Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36', // Samsung 10.2
-            'Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G610M Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36', // Samsung 7
+            'Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G610M Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36', // Samsung 7.4
             'Mozilla/5.0 (Linux; Android 11; SAMSUNG SM-G975F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Mobile Safari/537.36' // Samsung 15
         ];
         for (const userAgent of ineligibleUserAgents) {

--- a/test/integration/tests/button/eligibility.js
+++ b/test/integration/tests/button/eligibility.js
@@ -149,33 +149,51 @@ describe('venmo button eligibility', () => {
         });
     });
 
-    it.only('should not render venmo button for mobile when user agent is not Chrome on android or safari in iOS', () => {
-        return wrapPromise(({ expect, avoid }) => {
-            window.navigator.mockUserAgent = 'Mozilla/5.0 (Linux; Android 11; SAMSUNG SM-G973F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Mobile Safari/537.36';
 
-            const instance = window.paypal.Buttons({
-                test: {
-                    onRender: expect('onRender', ({ xprops, fundingSources }) => {
-                        const { experiment: { enableVenmo } } = xprops;
-                        if (enableVenmo) {
-                            throw new Error(`Expected venmo experiment to be ineligible: ${ JSON.stringify(xprops.experiment) }`);
-                        }
+    describe('noneligible mobile user agents', () => {
+        const ineligibleUserAgents = [
+            'Mozilla/5.0 (Android 4.4; Mobile; rv:70.0) Gecko/70.0 Firefox/70.0', // Firefox - Android mobile
+            'Mozilla/5.0 (Android 4.4; Tablet; rv:70.0) Gecko/70.0 Firefox/70.0', // Firefox - Android tablet
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4', // Firefox - iPhone
+            'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4', // Firefox - iPad
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.1 EdgiOS/44.5.0.10 Mobile/15E148 Safari/604.1', // Microsoft Edge - iPhone
+            'Mozilla/5.0 (Linux; Android 8.1.0; Pixel Build/OPM4.171019.021.D1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36 EdgA/42.0.0.2057', // Microsoft Edge - Android mobile
+            'Opera/12.02 (Android 4.1; Linux; Opera Mobi/ADR-1111101157; U; en-US) Presto/2.9.201 Version/12.02', // Opera - Android mobile
+            'Opera/9.80 (iPhone; Opera Mini/8.0.0/34.2336; U; en) Presto/2.8.119 Version/11.10', // Opera mini - iOS
+            'Mozilla/5.0 (Linux; Android 11; SAMSUNG SM-G973F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Mobile Safari/537.36', // Samsung 15
+            'Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G960U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36', // Samsung 10.2
+            'Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G610M Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36', // Samsung 7.4
+            'Mozilla/5.0 (Linux; Android 11; SAMSUNG SM-G975F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Mobile Safari/537.36' // Samsung 15
+        ];
+        for (const userAgent of ineligibleUserAgents) {
+            it(`should not render venmo button for mobile when user agent ist ${ userAgent } `, () => {
+                return wrapPromise(({ expect, avoid }) => {
+                    window.navigator.mockUserAgent = userAgent;
 
-                        if (fundingSources.includes(FUNDING.VENMO)) {
-                            throw new Error(`Venmo shound not be rendered`);
-                        }
+                    const instance = window.paypal.Buttons({
+                        test: {
+                            onRender: expect('onRender', ({ xprops, fundingSources }) => {
+                                const { experiment: { enableVenmo } } = xprops;
+                                if (enableVenmo) {
+                                    throw new Error(`Expected venmo experiment to be ineligible: ${ JSON.stringify(xprops.experiment) }`);
+                                }
 
-                        // mockEligibility.cancel();
-                    })
-                },
+                                if (fundingSources.includes(FUNDING.VENMO)) {
+                                    throw new Error(`Venmo shound not be rendered`);
+                                }
 
-                onApprove: avoid('onApprove'),
-                onCancel:  avoid('onCancel'),
-                onError:   avoid('onError')
+                            })
+                        },
+
+                        onApprove: avoid('onApprove'),
+                        onCancel:  avoid('onCancel'),
+                        onError:   avoid('onError')
+                    });
+
+                    return instance.render('#testContainer');
+                });
             });
-
-            return instance.render('#testContainer');
-        });
+        }
     });
 });
 

--- a/test/integration/tests/button/eligibility.js
+++ b/test/integration/tests/button/eligibility.js
@@ -86,6 +86,7 @@ describe('venmo button eligibility', () => {
             return instance.render('#testContainer');
         });
     });
+  
 
     it('should render venmo button for mobile when eligibility is true', () => {
         return wrapPromise(({ expect, avoid }) => {
@@ -136,6 +137,35 @@ describe('venmo button eligibility', () => {
                         }
 
                         mockEligibility.cancel();
+                    })
+                },
+
+                onApprove: avoid('onApprove'),
+                onCancel:  avoid('onCancel'),
+                onError:   avoid('onError')
+            });
+
+            return instance.render('#testContainer');
+        });
+    });
+
+    it.only('should not render venmo button for mobile when user agent is not Chrome on android or safari in iOS', () => {
+        return wrapPromise(({ expect, avoid }) => {
+            window.navigator.mockUserAgent = 'Mozilla/5.0 (Linux; Android 11; SAMSUNG SM-G973F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/15.0 Chrome/90.0.4430.210 Mobile Safari/537.36';
+
+            const instance = window.paypal.Buttons({
+                test: {
+                    onRender: expect('onRender', ({ xprops, fundingSources }) => {
+                        const { experiment: { enableVenmo } } = xprops;
+                        if (enableVenmo) {
+                            throw new Error(`Expected venmo experiment to be ineligible: ${ JSON.stringify(xprops.experiment) }`);
+                        }
+
+                        if (fundingSources.includes(FUNDING.VENMO)) {
+                            throw new Error(`Venmo shound not be rendered`);
+                        }
+
+                        // mockEligibility.cancel();
                     })
                 },
 


### PR DESCRIPTION
### Description

- We added the possibility to ban some user agents in Venmo eligibility validation, this aimed to improve conversion avoiding some mobile browsers that broke the usual flow.
- Just a nice to have tests improvement based on [these changes ](https://github.com/krakenjs/belter/pull/72)

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

- https://venmoinc.atlassian.net/browse/VMORECOMBO-401

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

## Before

![image](https://user-images.githubusercontent.com/17114924/146259993-9a094b80-2ac4-482e-ab31-369cd2f4b0fc.png)

Venmo button should not be displayed in Samsung browser

Source URL: http://localhost.paypal.com:8080/
*Device*: Samsung Galaxy S20 Plus
*Browser*: Mobile_samsung
*Operating System*: Android 10.0
*Resolution*: 2400 x 1080 px
*Screen size*: 6.7 in - 6.11 x 2.75 in
*Viewport*: 384 x 853 dp
*Aspect Ratio*: 20 : 9

### Depends on:

- https://github.com/krakenjs/belter/pull/72

