### PR TITLE
Fix flow by ignoring 'resolve' node dep

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,7 @@
 .*/node_modules/npm
 .*/node_modules/jsonlint
 .*/node_modules/**/test
+.*/node_modules/resolve
 .*/dist/module
 .*/flow-typed/npm/puppeteer_v1.20.x.js
 [include]


### PR DESCRIPTION
### Description

Fix `flow` by ignoring the `resolve` dev dependency.