### PR TITLE
Test belter version with CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "@paypal/sdk-client": "^4.0.156",
         "@paypal/sdk-constants": "^1.0.107",
         "@paypal/sdk-logos": "^1.0.26",
-        "belter": "^1.0.2",
+        "belter": "1.0.177",
         "cross-domain-utils": "^2.0.1",
         "jsx-pragmatic": "^2",
         "post-robot": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "@paypal/sdk-client": "^4.0.156",
         "@paypal/sdk-constants": "^1.0.107",
         "@paypal/sdk-logos": "^1.0.26",
-        "belter": "1.0.177",
+        "belter": "1.0.180",
         "cross-domain-utils": "^2.0.1",
         "jsx-pragmatic": "^2",
         "post-robot": "^10.0.0",


### PR DESCRIPTION
The following test seems to be failing with `belter@1.0.179`:

https://github.com/paypal/paypal-checkout-components/runs/4742920827?check_suite_focus=true
```
 1) should render multiple buttons including venmo, click on the venmo button, and send the correct url params
     paypal multiple button component happy path on popup
     Error: Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

This Draft PR pins to `belter@1.0.177` and the tests pass.
