### PR TITLE
Re-add button size queryParam

### DIFF
--- a/src/ui/buttons/buttonDesigns/divideLogoAnimation.jsx
+++ b/src/ui/buttons/buttonDesigns/divideLogoAnimation.jsx
@@ -141,6 +141,11 @@ export function getDivideLogoAnimation(designProps : DivideLogoAnimationProps, c
                 && paypalLabelContainerElement.contains(style)
             ) {
                 paypalLabelContainerElement.removeChild(style);
+            } else if (
+                (designContainer.offsetWidth <= max || designContainer.offsetWidth >= min)
+                && !paypalLabelContainerElement.contains(style)
+            ) {
+                paypalLabelContainerElement.appendChild(style);
             }
         });
     }

--- a/src/ui/buttons/buttonDesigns/inlineLogoTextDesign.jsx
+++ b/src/ui/buttons/buttonDesigns/inlineLogoTextDesign.jsx
@@ -90,6 +90,11 @@ export const getInlineLabelTextDesign = function (designProps : InlineLogoTextPr
                 && paypalLabelContainerElement.contains(style)
             ) {
                 paypalLabelContainerElement.removeChild(style);
+            } else if (
+                (designContainer.offsetWidth <= max || designContainer.offsetWidth >= min)
+                && !paypalLabelContainerElement.contains(style)
+            ) {
+                paypalLabelContainerElement.appendChild(style);
             }
         });
     }

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -20,7 +20,7 @@ import { isFundingEligible } from '../../funding';
 import { containerTemplate } from './container';
 import { PrerenderedButtons } from './prerender';
 import { applePaySession, determineFlow, isSupportedNativeBrowser, createVenmoExperiment,
-    getVenmoExperiment, createNoPaylaterExperiment, getNoPaylaterExperiment, getRenderedButtons } from './util';
+    getVenmoExperiment, createNoPaylaterExperiment, getNoPaylaterExperiment, getRenderedButtons, getButtonSize } from './util';
 
 export type ButtonsComponent = ZoidComponent<ButtonProps>;
 
@@ -350,6 +350,15 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 type:       'string',
                 value:      getStageHost,
                 required:   false
+            },
+
+            buttonSize: {
+                type:       'string',
+                required:   false,
+                value:      ({ props, container }) => {
+                    return getButtonSize(props, container);
+                },
+                queryParam: true
             },
 
             apiStageHost: {

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -228,7 +228,7 @@ export function getButtonSize(props : ButtonProps, container : string | HTMLElem
     let containerWidth = 0;
 
     if (container && typeof container !== 'string') {
-        containerWidth =  container ? getElement(container)?.offsetWidth : null;
+        containerWidth = container ? getElement(container)?.offsetWidth : null;
     }
 
     if (container && typeof container === 'string') {

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -225,17 +225,17 @@ export function applePaySession() : ?ApplePaySessionConfigRequest {
 }
 
 export function getButtonSize(props : ButtonProps, container : string | HTMLElement | void) : string | void {
-    let containerWidth = 0;
-
-    if (container && typeof container !== 'string') {
-        containerWidth = container ? getElement(container)?.offsetWidth : null;
+    if (!container) {
+        return;
     }
 
-    if (container && typeof container === 'string') {
+    let containerWidth = 0;
+
+    if (typeof container === 'string') {
         const containerElement = document.querySelector(container);
-        containerWidth = containerElement
-            ? containerElement.offsetWidth
-            : 0;
+        containerWidth = containerElement?.offsetWidth || 0;
+    } else {
+        containerWidth = getElement(container)?.offsetWidth;
     }
 
     const layout = props?.style?.layout || BUTTON_LAYOUT.HORIZONTAL;
@@ -250,8 +250,9 @@ export function getButtonSize(props : ButtonProps, container : string | HTMLElem
 
     if (containerWidth) {
         let buttonWidth = Math.min(containerWidth, 750);
+        const spaceBetweenHorizontalButtons = 8;
         if (layout === BUTTON_LAYOUT.HORIZONTAL && numButtonsRendered === 2) {
-            buttonWidth = (buttonWidth - 8) / 2;
+            buttonWidth = (buttonWidth - spaceBetweenHorizontalButtons) / 2;
         }
 
         if (tiny.minWidth <= buttonWidth && buttonWidth <= tiny.maxWidth) {

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -1,13 +1,14 @@
 /* @flow */
-import { supportsPopups as userAgentSupportsPopups, isAndroid, isChrome, isIos, isSafari, isSFVC, type Experiment, isDevice, isTablet } from 'belter/src';
+import { supportsPopups as userAgentSupportsPopups, isAndroid, isChrome, isIos, isSafari, isSFVC, type Experiment, isDevice, isTablet, getElement } from 'belter/src';
 import { FUNDING } from '@paypal/sdk-constants/src';
 import { getEnableFunding, getDisableFunding, createExperiment, getFundingEligibility, getPlatform, getComponents } from '@paypal/sdk-client/src';
 import { getRefinedFundingEligibility } from '@paypal/funding-components/src';
 
 import type { Experiment as EligibilityExperiment } from '../../types';
-import { BUTTON_FLOW } from '../../constants';
+import { BUTTON_FLOW, BUTTON_SIZE, BUTTON_LAYOUT } from '../../constants';
 import type { ApplePaySessionConfigRequest, CreateBillingAgreement, CreateSubscription, ButtonProps } from '../../ui/buttons/props';
 import { determineEligibleFunding } from '../../funding';
+import { BUTTON_SIZE_STYLE } from '../../ui/buttons/config';
 
 type DetermineFlowOptions = {|
     createBillingAgreement : CreateBillingAgreement,
@@ -220,5 +221,57 @@ export function applePaySession() : ?ApplePaySessionConfigRequest {
         };
     } catch (e) {
         return undefined;
+    }
+}
+
+export function getButtonSize(props : ButtonProps, container : string | HTMLElement | void) : string | void {
+    let containerWidth = 0;
+
+    if (container && typeof container !== 'string') {
+        containerWidth =  container ? getElement(container)?.offsetWidth : null;
+    }
+
+    if (container && typeof container === 'string') {
+        const containerElement = document.querySelector(container);
+        containerWidth = containerElement
+            ? containerElement.offsetWidth
+            : 0;
+    }
+
+    const layout = props?.style?.layout || BUTTON_LAYOUT.HORIZONTAL;
+    const numButtonsRendered = props?.renderedButtons?.length || 1;
+    const {
+        tiny,
+        small,
+        medium,
+        large,
+        huge
+    } = BUTTON_SIZE_STYLE;
+
+    if (containerWidth) {
+        let buttonWidth = Math.min(containerWidth, 750);
+        if (layout === BUTTON_LAYOUT.HORIZONTAL && numButtonsRendered === 2) {
+            buttonWidth = (buttonWidth - 8) / 2;
+        }
+
+        if (tiny.minWidth <= buttonWidth && buttonWidth <= tiny.maxWidth) {
+            return BUTTON_SIZE.TINY;
+        }
+
+        if (small.minWidth < buttonWidth && buttonWidth <= small.maxWidth) {
+            return BUTTON_SIZE.SMALL;
+        }
+
+        if (medium.minWidth < buttonWidth && buttonWidth <= medium.maxWidth) {
+            return BUTTON_SIZE.MEDIUM;
+        }
+
+        if (large.minWidth < buttonWidth && buttonWidth <= large.maxWidth) {
+            return BUTTON_SIZE.LARGE;
+        }
+
+        if (huge.minWidth < buttonWidth) {
+            return BUTTON_SIZE.HUGE;
+        }
     }
 }


### PR DESCRIPTION
### Description

- Add a query Param that calculates the buttons size to use for upstream presentment
- Dependent on https://github.com/krakenjs/zoid/pull/384
- https://engineering.paypalcorp.com/jira/browse/DTUPSTREAM-262
- Removal of the code the first time https://github.com/paypal/paypal-checkout-components/pull/1787

<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

❤️  Thank you!
