### PR TITLE
Add "publish alpha release to npm" workflow

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -1,0 +1,35 @@
+name: publish alpha release to npm
+# manually run this action using the GitHub UI
+# https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
+on: workflow_dispatch
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: ⎔ Setup node
+        # sets up the .npmrc file to publish to npm
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: 📥 Download deps
+        uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
+
+      - name: Configure git user
+        run: |
+          git config --global user.email ${{ github.actor }}@users.noreply.github.com
+          git config --global user.name ${{ github.actor }}
+
+      - name: Publish alpha release to npm
+        run: npm run release:alpha
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "webpack-size": "babel-node $(npm bin)/webpack --progress --config webpack.config.size",
         "build": "npm run test && npm run webpack",
         "release": "./scripts/publish.sh",
+        "release:alpha": "./scripts/publish.sh alpha",
         "release:patch": "./scripts/publish.sh patch",
         "release:minor": "./scripts/publish.sh minor",
         "release:major": "./scripts/publish.sh major",


### PR DESCRIPTION
### Description

This PR adds a GitHub Actions workflow for publishing an alpha release to npm. This will only work for base branches, as there are security risks with running workflows from forks.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

We are making these changes in order to avoid having to grant publishing rights to every new contributor, and also to do as little locally as possible.

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

❤️  Thank you!
