### PR TITLE
tech(venmo): Add entry to disable venmo for disney cruises

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -577,6 +577,10 @@ export const config = {
             disable_venmo: true
         },
 
+        'disneycruise.disney.go.com': {
+            disable_venmo: true
+        },
+
         'disneyland.disney.go.com': {
             disable_venmo: true
         },


### PR DESCRIPTION
### Description

Request from Disney account manager to exclude Disney cruise line URL from Pay w/ Venmo

Hi Mark,
 
I hope this email finds you well! Disney had created another new account. As before, can you please assist with blacklisting this account to ensure PwV isn’t shown in PP checkout? THANKS!

Website URL is: https://disneycruise.disney.go.com/

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

❤️  Thank you!
