### PR TITLE
chore(package.json): Revert to newest grabthar

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "cz-conventional-changelog": "^2.1.0",
     "flow-bin": "0.70.0",
     "fs-extra": "^4.0.2",
-    "grabthar-release": "1.0.69",
+    "grabthar-release": "^1.0.69",
     "grumbler-scripts": "^3",
     "imagemagick": "^0.1.3",
     "imgur": "^0.2.1",


### PR DESCRIPTION
### Description

I had originally pinned grabthar to an older version but realized it did not work with the new deploy process.  Reverted it back to use the latest.

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

❤️  Thank you!
