### PR TITLE
add .vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "javascript.validate.enable": false
+}


### PR DESCRIPTION
currently when you open the project in vscode it will interpolate the typesystem as being typescript rather than flow by default (i've seen multiple people share their screens looking like this)

![Screen Shot 2022-01-31 at 10 56 14 AM](https://user-images.githubusercontent.com/5710962/151855569-a8a11ee8-1992-4383-a5c2-341be765fbad.png)

We want to disable this for the workspace  and let the flow extension then process the types, rather than force the user to disable the typescript extension in their ide.

This is detailed here 
https://stackoverflow.com/questions/48859169/js-types-can-only-be-used-in-a-ts-file-visual-studio-code-using-ts-check

After (the project is now running flow)
![Screen Shot 2022-01-31 at 10 56 37 AM](https://user-images.githubusercontent.com/5710962/151855620-3ff717e7-7822-4865-befc-e97bfaada104.png)

