### PR TITLE
Apple Pay: Prevent Pre-render Click

### DIFF
--- a/src/zoid/buttons/prerender.jsx
+++ b/src/zoid/buttons/prerender.jsx
@@ -41,7 +41,7 @@ export function PrerenderedButtons({ nonce, onRenderCheckout, props } : Prerende
             [ FPTI_KEY.CHOSEN_FUNDING]:      fundingSource
         }).flush();
 
-        if (fundingSource === FUNDING.VENMO) {
+        if (fundingSource === FUNDING.VENMO || fundingSource === FUNDING.APPLEPAY) {
             // wait for button to load
         } else if (supportsPopups() && !props.merchantRequestedPopupsDisabled) {
             // remember the popup window to prevent showing a new popup window on every click in the prerender state


### PR DESCRIPTION
### Description
Clicking on Apple Pay button pre-render opens PayPal popup.  This is an incorrect UX.

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/1324812/152838823-b128e104-efc4-4f1b-8353-a2e6c4bae784.png">

