### PR TITLE
Export tag before npm version

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -11,9 +11,9 @@ if [ "$current_branch" != "$default_branch" ]
 then
   bump='prerelease';
   tag='alpha';
+  export tag;
   npm --no-git-tag-version version $bump --preid=$tag;
 else
+  export tag;
   npm version $bump;
 fi;
-
-export tag;


### PR DESCRIPTION
### Description

`$tag` needs to be exported as an environment variable before `npm version` runs. 😞 

### Why are we making these changes?

Publishing to npm isn't currently working.

❤️  Thank you!
