### PR TITLE
feat(incognito): Log FTPI event if browser can't access localstorage

### DIFF
--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -2,8 +2,10 @@
 /** @jsx node */
 
 import { node, type ElementNode } from 'jsx-pragmatic/src';
-import { FUNDING, WALLET_INSTRUMENT } from '@paypal/sdk-constants/src';
-import { noop } from 'belter/src';
+import { FUNDING, WALLET_INSTRUMENT, FPTI_KEY } from '@paypal/sdk-constants/src';
+import { noop, isLocalStorageEnabled } from 'belter/src';
+import { getLogger } from '@paypal/sdk-client/src';
+
 
 import type { Wallet, WalletInstrument } from '../../types';
 import { CLASS, BUTTON_NUMBER, BUTTON_LAYOUT, BUTTON_FLOW } from '../../constants';
@@ -99,8 +101,17 @@ export function validateButtonProps(props : ButtonPropsInputs) {
 export function Buttons(props : ButtonsProps) : ElementNode {
     const { onClick = noop } = props;
     const { wallet, fundingSource, style, locale, remembered, env, fundingEligibility, platform, commit, vault,
-        nonce, components, onShippingChange, personalization, userIDToken, content, flow, experiment, applePaySupport, supportsPopups, supportedNativeBrowser } = normalizeButtonProps(props);
+        nonce, components, onShippingChange, personalization, userIDToken, content, flow, experiment, applePaySupport, supportsPopups, supportedNativeBrowser, buttonSessionID } = normalizeButtonProps(props);
     const { layout, shape, tagline } = style;
+
+    if (!isLocalStorageEnabled()) {
+        getLogger().info('localstoage_inaccessible_possible_private_browsing').track({
+            [ FPTI_KEY.BUTTON_SESSION_UID ]: buttonSessionID,
+            [ FPTI_KEY.CONTEXT_TYPE ]:       'button_session_id',
+            [ FPTI_KEY.CONTEXT_ID ]:         buttonSessionID,
+            [ FPTI_KEY.TRANSITION ]:         'localstoage_inaccessible_possible_private_browsing'
+        }).flush();
+    }
 
     let fundingSources = determineEligibleFunding({ fundingSource, layout, remembered, platform, fundingEligibility, components, onShippingChange, flow, wallet, applePaySupport, supportsPopups, supportedNativeBrowser, experiment });
     const multiple = fundingSources.length > 1;

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { supportsPopups as userAgentSupportsPopups, isAndroid, isChrome, isIos, isSafari, isSFVC, type Experiment, isDevice, isTablet, getElement } from 'belter/src';
+import { supportsPopups as userAgentSupportsPopups, isAndroid, isChrome, isIos, isSafari, isSFVC, type Experiment, isDevice, isTablet, getElement, isLocalStorageEnabled } from 'belter/src';
 import { ENV, FUNDING } from '@paypal/sdk-constants/src';
 import { getEnableFunding, getDisableFunding, createExperiment, getFundingEligibility, getPlatform, getComponents, getEnv } from '@paypal/sdk-client/src';
 import { getRefinedFundingEligibility } from '@paypal/funding-components/src';
@@ -138,7 +138,14 @@ export function getNoPaylaterExperiment(fundingSource : ?$Values<typeof FUNDING>
 
 export function getVenmoAppLabelExperiment() : EligibilityExperiment  {
     const isEnvForTest = getEnv() === ENV.LOCAL || getEnv() === ENV.TEST || getEnv() === ENV.STAGE;
-    const isEnabledForTest = isEnvForTest ? window.localStorage.getItem('enable_venmo_app_label') : false;
+
+    let isEnabledForTest = false;
+
+    isEnabledForTest = window.localStorage.getItem('enable_venmo_app_label');
+    if (isLocalStorageEnabled() && isEnvForTest) {
+        isEnabledForTest = window.localStorage.getItem('enable_venmo_app_label');
+    }
+
     return {
         enableVenmoAppLabel: isEnabledForTest
     };


### PR DESCRIPTION
### Description

Added event logging for VMORECOMBO-440 to possibility detect if browser is in private mode (Incognito).  This is primarily for Android but good to log all browsers.

![Screen Shot 2022-02-22 at 12 51 51 PM](https://user-images.githubusercontent.com/1623146/155200441-d9463459-dd9e-4c6e-a92e-2353504c2fb0.png)

NOTE: By default Android Chrome has `Block third-party cookies in Incognito` enabled by default.  When accessing cookies from a third party site an exception is thrown because site-data (localStorage) is also disabled.  We use this to detect the possibility of incognito mode.  

To reproduce on the desktop:
1) In Google Chrome go to settings/cookies: chrome://settings/cookies
2) Enable: Block all cookies (not recommended)
3) Hit the test page.  You should see the following log in the console: `localstoage_inaccessible_possible_private_browsing `
### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)
To test:
1) 


### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

❤️  Thank you!
