### PR TITLE
feat(incognito): Log FTPI event if browser can't access localstorage

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -50,7 +50,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                     [ FPTI_KEY.CONTEXT_TYPE ]:       'button_session_id',
                     [ FPTI_KEY.CONTEXT_ID ]:         buttonSessionID,
                     [ FPTI_KEY.TRANSITION ]:         'localstorage_inaccessible_possible_private_browsing'
-                }).flush();
+                });
             }
 
             return (

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -49,7 +49,7 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                     [ FPTI_KEY.BUTTON_SESSION_UID ]: buttonSessionID,
                     [ FPTI_KEY.CONTEXT_TYPE ]:       'button_session_id',
                     [ FPTI_KEY.CONTEXT_ID ]:         buttonSessionID,
-                    [ FPTI_KEY.TRANSITION ]:         'localstoage_inaccessible_possible_private_browsing'
+                    [ FPTI_KEY.TRANSITION ]:         'localstorage_inaccessible_possible_private_browsing'
                 }).flush();
             }
 

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -9,7 +9,7 @@ import { getLogger, getLocale, getClientID, getEnv, getIntent, getCommit, getVau
 import { rememberFunding, getRememberedFunding, getRefinedFundingEligibility } from '@paypal/funding-components/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { create, type ZoidComponent } from 'zoid/src';
-import { uniqueID, memoize, isApplePaySupported, supportsPopups as userAgentSupportsPopups, noop } from 'belter/src';
+import { uniqueID, memoize, isApplePaySupported, supportsPopups as userAgentSupportsPopups, noop, isLocalStorageEnabled } from 'belter/src';
 import { FUNDING, FUNDING_BRAND_LABEL, QUERY_BOOL, ENV, FPTI_KEY } from '@paypal/sdk-constants/src';
 import { node, dom } from 'jsx-pragmatic/src';
 
@@ -42,6 +42,17 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
         logger: getLogger(),
 
         prerenderTemplate: ({ state, props, doc }) => {
+            const { buttonSessionID } = props;
+            
+            if (!isLocalStorageEnabled()) {
+                getLogger().info('localstoage_inaccessible_possible_private_browsing').track({
+                    [ FPTI_KEY.BUTTON_SESSION_UID ]: buttonSessionID,
+                    [ FPTI_KEY.CONTEXT_TYPE ]:       'button_session_id',
+                    [ FPTI_KEY.CONTEXT_ID ]:         buttonSessionID,
+                    [ FPTI_KEY.TRANSITION ]:         'localstoage_inaccessible_possible_private_browsing'
+                }).flush();
+            }
+
             return (
                 <PrerenderedButtons
                     nonce={ props.nonce }

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { supportsPopups as userAgentSupportsPopups, isAndroid, isChrome, isIos, isSafari, isSFVC, type Experiment, isDevice, isTablet, getElement } from 'belter/src';
+import { supportsPopups as userAgentSupportsPopups, isAndroid, isChrome, isIos, isSafari, isSFVC, type Experiment, isDevice, isTablet, getElement, isLocalStorageEnabled } from 'belter/src';
 import { ENV, FUNDING } from '@paypal/sdk-constants/src';
 import { getEnableFunding, getDisableFunding, createExperiment, getFundingEligibility, getPlatform, getComponents, getEnv } from '@paypal/sdk-client/src';
 import { getRefinedFundingEligibility } from '@paypal/funding-components/src';
@@ -138,7 +138,13 @@ export function getNoPaylaterExperiment(fundingSource : ?$Values<typeof FUNDING>
 
 export function getVenmoAppLabelExperiment() : EligibilityExperiment  {
     const isEnvForTest = getEnv() === ENV.LOCAL || getEnv() === ENV.TEST || getEnv() === ENV.STAGE;
-    const isEnabledForTest = isEnvForTest ? window.localStorage.getItem('enable_venmo_app_label') : false;
+
+    let isEnabledForTest = false;
+
+    if (isLocalStorageEnabled() && isEnvForTest) {
+        isEnabledForTest = window.localStorage.getItem('enable_venmo_app_label');
+    }
+
     return {
         enableVenmoAppLabel: isEnabledForTest
     };


### PR DESCRIPTION
### Description

Added event logging for VMORECOMBO-440 to possibility detect if browser is in private mode (Incognito).  This is primarily for Android but good to log all browsers.

![Screen Shot 2022-02-22 at 12 51 51 PM](https://user-images.githubusercontent.com/1623146/155200441-d9463459-dd9e-4c6e-a92e-2353504c2fb0.png)

NOTE: By default Android Chrome has `Block third-party cookies in Incognito` enabled by default.  When accessing cookies from a third party site an exception is thrown because site-data (localStorage) is also disabled.  We use this to detect the possibility of incognito mode.  

To reproduce on the desktop:
1) In Google Chrome go to settings/cookies: chrome://settings/cookies
2) Enable: Block all cookies (not recommended)
3) Hit the test page.  You should see the following log in the console: `localstroage_inaccessible_possible_private_browsing `
### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)
To test:
1) 


### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

❤️  Thank you!
