### PR TITLE
fix(BNPL): fix aria-label for Pay Later button

### DIFF
--- a/src/funding/common.jsx
+++ b/src/funding/common.jsx
@@ -118,7 +118,7 @@ export type FundingSourceConfig = {|
     secondaryVaultColors : { [$Values<typeof BUTTON_COLOR>] : $Values<typeof BUTTON_COLOR> },
     logoColors : { [$Values<typeof BUTTON_COLOR>] : $Values<typeof LOGO_COLOR> },
     shapes : $ReadOnlyArray<$Values<typeof BUTTON_SHAPE>>,
-    labelText? : string | (({| content : ?ContentType |}) => string),
+    labelText? : string | (({| content : ?ContentType, fundingEligibility : ?FundingEligibilityType |}) => string),
     showWalletMenu : ({| instrument : WalletInstrument |}) => boolean
 |};
 

--- a/src/funding/paylater/config.jsx
+++ b/src/funding/paylater/config.jsx
@@ -1,6 +1,7 @@
 /* @flow */
 /** @jsx node */
 
+import type { FundingEligibilityType } from '@paypal/sdk-client/src';
 import { FUNDING } from '@paypal/sdk-constants/src';
 import { node, Style } from 'jsx-pragmatic/src';
 import { PPLogo, LOGO_COLOR } from '@paypal/sdk-logos/src';
@@ -10,6 +11,46 @@ import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
 import { Text, Space } from '../../ui/text';
 
 import css from './style.scoped.scss';
+
+function getLabelText(fundingEligibility : FundingEligibilityType) : ?string {
+    const { paylater } = fundingEligibility;
+
+    let labelText;
+
+    if (
+        paylater?.products?.paylater?.eligible &&
+        paylater?.products?.paylater?.variant === 'DE'
+    ) {
+        labelText = 'Später Bezahlen';
+    }
+
+    if (
+        paylater?.products?.payIn3?.eligible &&
+        paylater?.products?.payIn3?.variant === 'ES'
+    ) {
+        labelText = 'Paga en 3 plazos';
+    }
+
+    if (
+        paylater?.products?.payIn3?.eligible &&
+        paylater?.products?.payIn3?.variant === 'IT'
+    ) {
+        labelText = 'Paga in 3 rate';
+    }
+
+    if (paylater?.products?.payIn4?.eligible) {
+        labelText = 'Pay in 4';
+    }
+
+    if (
+        paylater?.products?.payIn4?.eligible &&
+        paylater?.products?.payIn4?.variant === 'FR'
+    ) {
+        labelText = '4X PayPal';
+    }
+
+    return labelText;
+}
 
 export function getPaylaterConfig() : FundingSourceConfig {
     return {
@@ -34,47 +75,11 @@ export function getPaylaterConfig() : FundingSourceConfig {
         Label: ({ logo }) => logo,
 
         Logo: ({ logoColor, nonce, fundingEligibility }) => {
-            const { paylater } = fundingEligibility;
-
-            let label = <Text>Pay Later</Text>;
-
-            if (
-                paylater?.products?.paylater?.eligible &&
-                paylater?.products?.paylater?.variant === 'DE'
-            ) {
-                label = <Text>Später Bezahlen</Text>;
-            }
-
-            if (
-                paylater?.products?.payIn3?.eligible &&
-                paylater?.products?.payIn3?.variant === 'ES'
-            ) {
-                label = <Text>Paga en 3 plazos</Text>;
-            }
-
-            if (
-                paylater?.products?.payIn3?.eligible &&
-                paylater?.products?.payIn3?.variant === 'IT'
-            ) {
-                label = <Text>Paga in 3 rate</Text>;
-            }
-
-            if (paylater?.products?.payIn4?.eligible) {
-                label = <Text>Pay in 4</Text>;
-            }
-
-            if (
-                paylater?.products?.payIn4?.eligible &&
-                paylater?.products?.payIn4?.variant === 'FR'
-            ) {
-                label = <Text>4X PayPal</Text>;
-            }
-
             return (
                 <Style css={ css } nonce={ nonce }>
                     <PPLogo logoColor={ logoColor } />
                     <Space />
-                    { label }
+                    <Text>{ getLabelText(fundingEligibility) || 'Pay Later' }</Text>
                 </Style>
             );
         },
@@ -104,6 +109,8 @@ export function getPaylaterConfig() : FundingSourceConfig {
             [BUTTON_COLOR.WHITE]:  LOGO_COLOR.BLUE
         },
         
-        labelText: `${ FUNDING.PAYPAL } ${ FUNDING.PAYLATER }`
+        labelText: ({ fundingEligibility }) => {
+            return (fundingEligibility && getLabelText(fundingEligibility)) || `${ FUNDING.PAYPAL } ${ FUNDING.PAYLATER }`;
+        }
     };
 }

--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -96,7 +96,7 @@ export function Button({ fundingSource, style, multiple, locale, env, fundingEli
 
     const { layout, shape } = style;
     
-    const labelText =  typeof fundingConfig.labelText === 'function' ?  fundingConfig.labelText({ content }) : (fundingConfig.labelText || fundingSource);
+    const labelText =  typeof fundingConfig.labelText === 'function' ?  fundingConfig.labelText({ content, fundingEligibility }) : (fundingConfig.labelText || fundingSource);
 
     const logoNode = (
         <Logo

--- a/test/integration/tests/funding/paylater/index.js
+++ b/test/integration/tests/funding/paylater/index.js
@@ -34,6 +34,7 @@ describe(`paylater button text`, () => {
 
         return button.render('#testContainer').then(() => {
             assert.equal(getElementRecursive('.paypal-button-text').innerHTML, 'Pay in 4');
+            assert.equal(getElementRecursive('.paypal-button').getAttribute('aria-label'), 'Pay in 4');
         });
     });
 
@@ -56,6 +57,7 @@ describe(`paylater button text`, () => {
 
         return button.render('#testContainer').then(() => {
             assert.equal(getElementRecursive('.paypal-button-text').innerHTML, 'Pay Later');
+            assert.equal(getElementRecursive('.paypal-button').getAttribute('aria-label'), 'paypal paylater');
         });
     });
 
@@ -79,6 +81,7 @@ describe(`paylater button text`, () => {
 
         return button.render('#testContainer').then(() => {
             assert.equal(getElementRecursive('.paypal-button-text').innerHTML, 'Später Bezahlen');
+            assert.equal(getElementRecursive('.paypal-button').getAttribute('aria-label'), 'Später Bezahlen');
         });
     });
 
@@ -102,6 +105,7 @@ describe(`paylater button text`, () => {
 
         return button.render('#testContainer').then(() => {
             assert.equal(getElementRecursive('.paypal-button-text').innerHTML, '4X PayPal');
+            assert.equal(getElementRecursive('.paypal-button').getAttribute('aria-label'), '4X PayPal');
         });
     });
 
@@ -125,6 +129,7 @@ describe(`paylater button text`, () => {
 
         return button.render('#testContainer').then(() => {
             assert.equal(getElementRecursive('.paypal-button-text').innerHTML, 'Paga in 3 rate');
+            assert.equal(getElementRecursive('.paypal-button').getAttribute('aria-label'), 'Paga in 3 rate');
         });
     });
 
@@ -148,6 +153,7 @@ describe(`paylater button text`, () => {
 
         return button.render('#testContainer').then(() => {
             assert.equal(getElementRecursive('.paypal-button-text').innerHTML, 'Paga en 3 plazos');
+            assert.equal(getElementRecursive('.paypal-button').getAttribute('aria-label'), 'Paga en 3 plazos');
         });
     });
 
@@ -166,6 +172,7 @@ describe(`paylater button text`, () => {
 
         return button.render('#testContainer').then(() => {
             assert.equal(getElementRecursive('.paypal-button-text').innerHTML, 'Pay Later');
+            assert.equal(getElementRecursive('.paypal-button').getAttribute('aria-label'), 'paypal paylater');
         });
     });
 });


### PR DESCRIPTION
### Description

Fixes aria-label for the Pay Later button in countries other than the US so that screen readers will communicate the product in the corresponding language.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

https://engineering.paypalcorp.com/jira/browse/DTXOUP-48
https://engineering.paypalcorp.com/jira/browse/DTXOUP-50

### Reproduction Steps (if applicable)

Run `npm run alias /path/to/paypal-checkout-components` in clientsdknodeweb and smartcomponentnodeweb, then load a test page with SDK params `enable-funding=paylater`. Inspect the Pay Later button and its parent element should have the proper aria-label.

### Screenshots (if applicable)

### Dependent Changes (if applicable)

Safe to release.
