### PR TITLE
fix(DTUPSTREAM-351): Issue related to one click experience inside of our animation

### DIFF
--- a/src/constants/class.js
+++ b/src/constants/class.js
@@ -5,6 +5,7 @@ export const CLASS = {
     BUTTON_ROW:   ('paypal-button-row' : 'paypal-button-row'),
     BUTTON:       ('paypal-button' : 'paypal-button'),
     BUTTON_LABEL: ('paypal-button-label-container' : 'paypal-button-label-container'),
+    LOGO_PP:      ('paypal-logo-pp' : 'paypal-logo-pp'),
 
     LABEL:       ('paypal-button-label' : 'paypal-button-label'),
     COLOR:       ('paypal-button-color' : 'paypal-button-color'),

--- a/src/ui/buttons/buttonDesigns/divideLogoAnimation.jsx
+++ b/src/ui/buttons/buttonDesigns/divideLogoAnimation.jsx
@@ -21,13 +21,14 @@ export const DIVIDE_LOGO_CONFIG = {
     cssUtilClasses: {
         DOM_READY:                  CLASS.DOM_READY,
         PAYPAL_LOGO:                LOGO_CLASS.LOGO,
-        PAYPAL_BUTTON_LABEL:        CLASS.BUTTON_LABEL
+        PAYPAL_BUTTON_LABEL:        CLASS.BUTTON_LABEL,
+        PAYPAL_LOGO_PP:             CLASS.LOGO_PP,
     }
 };
 
 // Returns props necessary to render the animation as long as they are valid
 export const getDivideLogoProps = function (document : Object, configuration : Object) : DivideLogoAnimationProps | null {
-    const { PAYPAL_BUTTON_LABEL, PAYPAL_LOGO } = configuration.cssUtilClasses;
+    const { PAYPAL_BUTTON_LABEL, PAYPAL_LOGO, PAYPAL_LOGO_PP } = configuration.cssUtilClasses;
 
     const designContainer = (document && document.querySelector('.personalized-design-container')) || null;
     if (!designContainer) {
@@ -47,7 +48,7 @@ export const getDivideLogoProps = function (document : Object, configuration : O
     }
 
     // get starting position for element so it doesn't flicker when animation begins
-    const paypalLogoElement = (paypalLabelContainerElement && paypalLabelContainerElement.querySelector(`.${ PAYPAL_LOGO }`)) || null;
+    const paypalLogoElement = (paypalLabelContainerElement && paypalLabelContainerElement.querySelector(`.${ PAYPAL_LOGO }.${ PAYPAL_LOGO_PP }`)) || null;
     if (!paypalLogoElement) {
         return null;
     }
@@ -66,7 +67,8 @@ export function getDivideLogoAnimation(designProps : DivideLogoAnimationProps, c
         max,
         cssUtilClasses: {
             DOM_READY,
-            PAYPAL_LOGO
+            PAYPAL_LOGO,
+            PAYPAL_LOGO_PP
         }
     } = configuration;
 
@@ -77,7 +79,7 @@ export function getDivideLogoAnimation(designProps : DivideLogoAnimationProps, c
     } = designProps;
 
     const designCss = `
-        .${ DOM_READY } .personalized-design-container img.${ PAYPAL_LOGO }{
+        .${ DOM_READY } .personalized-design-container img.${ PAYPAL_LOGO }.${ PAYPAL_LOGO_PP }{
             animation: 3s divide-logo-animation-left-side 2s infinite alternate;
         }
         

--- a/src/ui/buttons/buttonDesigns/divideLogoAnimation.jsx
+++ b/src/ui/buttons/buttonDesigns/divideLogoAnimation.jsx
@@ -22,7 +22,7 @@ export const DIVIDE_LOGO_CONFIG = {
         DOM_READY:                  CLASS.DOM_READY,
         PAYPAL_LOGO:                LOGO_CLASS.LOGO,
         PAYPAL_BUTTON_LABEL:        CLASS.BUTTON_LABEL,
-        PAYPAL_LOGO_PP:             CLASS.LOGO_PP,
+        PAYPAL_LOGO_PP:             CLASS.LOGO_PP
     }
 };
 


### PR DESCRIPTION
### Description

- Checkout team reported an issue in our button animation, then this PR contains the solution for this issue.
- This issue was happening because for some reason, the arrow icon has the `paypal-logo` class and in our animation code, we are applying the animation in the elements which have the `paypal-logo` class inside of the whole PP button. Then, we are automatically applying the aniomation in the PP logo and also in the arrow icon. 
- To fix this issue, I added one more class inside of the query element `paypal-logo-pp` to get the correct HTML element without the arrow icon. 

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

- Jira card: https://engineering.paypalcorp.com/jira/browse/DTUPSTREAM-351

### Screenshots (if applicable)

Before: 
<img width="800" alt="image" src="https://user-images.githubusercontent.com/25916871/156396779-bbcc2c9b-c695-47f2-8ba0-ac8915ba1e21.png">

After: 
<img width="807" alt="image" src="https://user-images.githubusercontent.com/25916871/156396872-49777d94-ffb3-4655-813c-7d48e8029a29.png">


❤️  Thank you!
