### PR TITLE
chore(deps): ignore flow-bin updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,7 @@
   "labels": [
     ":christmas_tree: dependencies"
   ],
+  "ignoreDeps": ["flow-bin"],
   "packageRules": [
     {
       "packagePatterns": "^babel",


### PR DESCRIPTION
### Description

Update renovate config to ignore updates to flow-bin. 

### Why are we making these changes?

We purposely pin flow-bin in our projects since Flow releases breaking changes as patch releases.