### PR TITLE
Keep inlinexo internally

### DIFF
--- a/src/zoid/checkout/component.jsx
+++ b/src/zoid/checkout/component.jsx
@@ -50,7 +50,7 @@ export function getCheckoutComponent() : CheckoutComponent {
             },
 
             containerTemplate: ({ context, close, focus, doc, event, frame, prerenderFrame, props }) => {
-                const { nonce, locale: { lang }, inline } = props;
+                const { nonce, locale: { lang }, inlinexo } = props;
                 const content = containerContent[lang];
                 return (
                     <Overlay
@@ -62,7 +62,7 @@ export function getCheckoutComponent() : CheckoutComponent {
                         prerenderFrame={ prerenderFrame }
                         content={ content }
                         nonce={ nonce }
-                        fullScreen={ inline === true }
+                        fullScreen={ inlinexo === true }
                     />
                 ).render(dom({ doc }));
             },

--- a/src/zoid/checkout/component.jsx
+++ b/src/zoid/checkout/component.jsx
@@ -232,7 +232,7 @@ export function getCheckoutComponent() : CheckoutComponent {
                     default: () => (window.__test__ || { action: 'checkout' })
                 },
 
-                inline: {
+                inlinexo: {
                     type:           'boolean',
                     required:       false,
                     queryParam:     true,

--- a/src/zoid/checkout/props.js
+++ b/src/zoid/checkout/props.js
@@ -39,5 +39,5 @@ export type CheckoutPropsType = {|
     csp : {|
         nonce : string
     |},
-    inline : boolean
+    inlinexo : boolean
 |};


### PR DESCRIPTION
### Description
We allow the merchant to set the `inline` prop to use Inline XO.  Because `xo` is an internal naming convention and `inline` is already used in Hermes, we will use `inlinexo` internally back to Hermes.

