### PR TITLE
Custom Styling for InlineXO

### DIFF
--- a/src/constants/class.js
+++ b/src/constants/class.js
@@ -38,5 +38,7 @@ export const CLASS = {
 
     HIDDEN:  ('hidden' : 'hidden'),
 
-    IMMEDIATE: ('immediate' : 'immediate')
+    IMMEDIATE: ('immediate' : 'immediate'),
+
+    CUSTOM: ('custom' : 'custom')
 };

--- a/src/funding/card/config.jsx
+++ b/src/funding/card/config.jsx
@@ -121,7 +121,15 @@ export function getCardConfig() : FundingSourceConfig {
             );
         },
 
-        Label: ({ logo, locale, content }) => {
+        Label: ({ logo, locale, content, custom }) => {
+            if (custom && custom.label) {
+                return (
+                    <Fragment>
+                        <Text>{ custom.label }</Text>
+                        <Space />
+                    </Fragment>
+                );
+            }
             const { lang } = locale;
             const isRTL = isRTLLanguage(lang);
             return (

--- a/src/funding/common.jsx
+++ b/src/funding/common.jsx
@@ -7,7 +7,7 @@ import type { FundingEligibilityType } from '@paypal/sdk-client/src';
 import { PLATFORM, type LocaleType, COUNTRY, CARD, COMPONENTS, FUNDING, ENV } from '@paypal/sdk-constants/src';
 import { LOGO_COLOR } from '@paypal/sdk-logos/src';
 
-import type { ContentType, WalletInstrument, Experiment, Requires, Wallet } from '../types';
+import type { ContentType, CustomStyle, WalletInstrument, Experiment, Requires, Wallet } from '../types';
 import { BUTTON_COLOR, BUTTON_SHAPE, BUTTON_LAYOUT, DEFAULT, BUTTON_LABEL, BUTTON_FLOW, TEXT_COLOR } from '../constants';
 import type { Personalization } from '../ui/buttons/props';
 
@@ -47,7 +47,8 @@ export type LabelOptions = {|
     nonce : ?string,
     tagline : ?boolean,
     content : ?ContentType,
-    experiment? : Experiment
+    experiment? : Experiment,
+    custom? : ?CustomStyle
 |};
 
 export type DesignExperimentLabelOptions = {|

--- a/src/types.js
+++ b/src/types.js
@@ -53,6 +53,10 @@ export type Requires = {|
     native? : boolean
 |};
 
+export type CustomStyle = {|
+    [string] : string
+|};
+
 export type LazyExport<T> = {|
     __get__ : () => T
 |};

--- a/src/types.js
+++ b/src/types.js
@@ -54,7 +54,10 @@ export type Requires = {|
 |};
 
 export type CustomStyle = {|
-    [string] : string
+    css : {|
+        [string] : string
+    |},
+    label : string
 |};
 
 export type LazyExport<T> = {|

--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -97,14 +97,7 @@ export function Button({ fundingSource, style, multiple, locale, env, fundingEli
 
     const { custom, layout, shape } = style;
     
-    let labelText = (fundingConfig.labelText || fundingSource);
-    if (typeof fundingConfig.labelText === 'function') {
-        labelText = fundingConfig.labelText({ content, fundingEligibility });
-    }
-
-    if (inline && fundingSource === FUNDING.CARD) {
-        labelText = custom?.label || 'Checkout';
-    }
+    const labelText = typeof fundingConfig.labelText === 'function' ?  fundingConfig.labelText({ content, fundingEligibility }) : (fundingConfig.labelText || fundingSource);
 
     const logoNode = (
         <Logo

--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -38,11 +38,12 @@ type IndividualButtonProps = {|
     flow : $Values<typeof BUTTON_FLOW>,
     vault : boolean,
     merchantFundingSource : ?$Values<typeof FUNDING>,
-    instrument : ?WalletInstrument
+    instrument : ?WalletInstrument,
+    inline? : boolean
 |};
 
 export function Button({ fundingSource, style, multiple, locale, env, fundingEligibility, i, nonce, flow, vault,
-    userIDToken, personalization, onClick = noop, content, tagline, commit, experiment, instrument } : IndividualButtonProps) : ElementNode {
+    userIDToken, personalization, onClick = noop, content, tagline, commit, experiment, instrument, inline } : IndividualButtonProps) : ElementNode {
 
     const fundingConfig = getFundingConfig()[fundingSource];
 
@@ -94,9 +95,16 @@ export function Button({ fundingSource, style, multiple, locale, env, fundingEli
         }
     };
 
-    const { layout, shape } = style;
+    const { custom, layout, shape } = style;
     
-    const labelText =  typeof fundingConfig.labelText === 'function' ?  fundingConfig.labelText({ content, fundingEligibility }) : (fundingConfig.labelText || fundingSource);
+    let labelText = (fundingConfig.labelText || fundingSource);
+    if (typeof fundingConfig.labelText === 'function') {
+        labelText = fundingConfig.labelText({ content, fundingEligibility });
+    }
+
+    if (inline && fundingSource === FUNDING.CARD) {
+        labelText = custom?.label || 'Checkout';
+    }
 
     const logoNode = (
         <Logo
@@ -129,6 +137,7 @@ export function Button({ fundingSource, style, multiple, locale, env, fundingEli
             personalization={ personalization }
             tagline={ tagline }
             content={ content }
+            custom={ inline ? custom : null }
             experiment={ experiment }
         />
     );
@@ -221,7 +230,7 @@ export function Button({ fundingSource, style, multiple, locale, env, fundingEli
                 } }
                 class={ [
                     CLASS.BUTTON,
-                    style.custom ? CLASS.CUSTOM : '',
+                    inline && fundingSource === FUNDING.CARD ? CLASS.CUSTOM : '',
                     `${ CLASS.NUMBER }-${ i }`,
                     `${ CLASS.LAYOUT }-${ layout }`,
                     `${ CLASS.SHAPE }-${ shape }`,

--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -221,6 +221,7 @@ export function Button({ fundingSource, style, multiple, locale, env, fundingEli
                 } }
                 class={ [
                     CLASS.BUTTON,
+                    style.custom ? CLASS.CUSTOM : '',
                     `${ CLASS.NUMBER }-${ i }`,
                     `${ CLASS.LAYOUT }-${ layout }`,
                     `${ CLASS.SHAPE }-${ shape }`,

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -97,7 +97,7 @@ export function validateButtonProps(props : ButtonPropsInputs) {
 }
 
 export function Buttons(props : ButtonsProps) : ElementNode {
-    const { onClick = noop } = props;
+    const { onClick = noop, inline } = props;
     const { wallet, fundingSource, style, locale, remembered, env, fundingEligibility, platform, commit, vault,
         nonce, components, onShippingChange, personalization, userIDToken, content, flow, experiment, applePaySupport, supportsPopups, supportedNativeBrowser } = normalizeButtonProps(props);
     const { layout, shape, tagline } = style;
@@ -162,6 +162,7 @@ export function Buttons(props : ButtonsProps) : ElementNode {
                         flow={ flow }
                         vault={ vault }
                         instrument={ instruments[source] }
+                        inline={ inline }
                     />
                 ))
             }

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -399,7 +399,8 @@ export function normalizeButtonStyle(props : ?ButtonPropsInputs, style : ButtonS
         tagline = (layout === BUTTON_LAYOUT.HORIZONTAL && !fundingSource),
         height,
         period,
-        menuPlacement = MENU_PLACEMENT.BELOW
+        menuPlacement = MENU_PLACEMENT.BELOW,
+        custom
     } = style;
 
     // $FlowFixMe
@@ -445,7 +446,7 @@ export function normalizeButtonStyle(props : ?ButtonPropsInputs, style : ButtonS
         }
     }
 
-    return { label, layout, color, shape, tagline, height, period, menuPlacement };
+    return { custom, label, layout, color, shape, tagline, height, period, menuPlacement };
 }
 
 const COUNTRIES = values(COUNTRY);

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -12,7 +12,7 @@ import { LOGO_COLOR } from '@paypal/sdk-logos/src';
 import { SUPPORTED_FUNDING_SOURCES } from '@paypal/funding-components/src';
 import type { ComponentFunctionType } from 'jsx-pragmatic/src';
 
-import type { ContentType, Wallet, Experiment } from '../../types';
+import type { ContentType, CustomStyle, Wallet, Experiment } from '../../types';
 import { BUTTON_LABEL, BUTTON_COLOR, BUTTON_LAYOUT, BUTTON_SHAPE, BUTTON_SIZE, BUTTON_FLOW, MENU_PLACEMENT } from '../../constants';
 import { getFundingConfig, isFundingEligible } from '../../funding';
 
@@ -130,7 +130,8 @@ export type ButtonStyle = {|
     layout : $Values<typeof BUTTON_LAYOUT>,
     menuPlacement : $Values<typeof MENU_PLACEMENT>,
     period? : number,
-    height? : number
+    height? : number,
+    custom? : CustomStyle
 |};
 
 export type ButtonStyleInputs = {|
@@ -140,7 +141,8 @@ export type ButtonStyleInputs = {|
     tagline? : boolean | void,
     layout? : $Values<typeof BUTTON_LAYOUT> | void,
     period? : number | void,
-    height? : number | void
+    height? : number | void,
+    custom? : CustomStyle
 |};
 
 type PersonalizationComponentProps = {|

--- a/src/ui/buttons/style.jsx
+++ b/src/ui/buttons/style.jsx
@@ -15,8 +15,8 @@ type StyleProps = {|
 
 export function Style({ style, nonce, fundingEligibility } : StyleProps) : ElementNode {
 
-    const { height } = style;
-    const css = componentStyle({ height, fundingEligibility });
+    const { custom, height } = style;
+    const css = componentStyle({ custom, height, fundingEligibility });
 
     return (
         <style nonce={ nonce } innerHTML={ css } />

--- a/src/ui/buttons/styles/base.js
+++ b/src/ui/buttons/styles/base.js
@@ -2,18 +2,22 @@
 
 import { type FundingEligibilityType } from '@paypal/sdk-constants/src';
 
+import type { CustomStyle } from '../../../types';
+
 import { pageStyle } from './page';
 import { buttonStyle } from './button';
 import { labelStyle } from './labels';
 import { buttonResponsiveStyle } from './responsive';
 import { buttonColorStyle } from './color';
+import { customStyle } from './custom';
 
-export function componentStyle({ height, fundingEligibility } : {| height? : ?number, fundingEligibility : FundingEligibilityType |}) : string {
+export function componentStyle({ custom, height, fundingEligibility } : {| custom? : CustomStyle, height? : ?number, fundingEligibility : FundingEligibilityType |}) : string {
     return `
         ${ pageStyle }
         ${ buttonStyle }
         ${ buttonColorStyle }
         ${ labelStyle }
         ${ buttonResponsiveStyle({ height, fundingEligibility }) }
+        ${ customStyle({ custom }) }
     `;
 }

--- a/src/ui/buttons/styles/custom.js
+++ b/src/ui/buttons/styles/custom.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+import type { CustomStyle } from '../../../types';
+import { CLASS } from '../../../constants';
+
+export const customStyle = ({ custom } : {| custom? : CustomStyle |}) : string => {
+    if (!custom) {
+        return '';
+    }
+
+    let style = Object.keys(custom).reduce((acc, key) => {
+        acc += `${ key }: ${ custom[key] };`;
+        return acc;
+    }, '');
+    style = `.${ CLASS.BUTTON }.${ CLASS.CUSTOM } { ${ style } } `;
+
+    return style;
+};

--- a/src/ui/buttons/styles/custom.js
+++ b/src/ui/buttons/styles/custom.js
@@ -8,8 +8,10 @@ export const customStyle = ({ custom } : {| custom? : CustomStyle |}) : string =
         return '';
     }
 
-    let style = Object.keys(custom).reduce((acc, key) => {
-        acc += `${ key }: ${ custom[key] };`;
+    const { css } = custom || {};
+
+    let style = Object.keys(css).reduce((acc, key) => {
+        acc += `${ key }: ${ css[key] };`;
         return acc;
     }, '');
     style = `.${ CLASS.BUTTON }.${ CLASS.CUSTOM } { ${ style } } `;

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -20,7 +20,7 @@ import { isFundingEligible } from '../../funding';
 import { containerTemplate } from './container';
 import { PrerenderedButtons } from './prerender';
 import { applePaySession, determineFlow, isSupportedNativeBrowser, createVenmoExperiment,
-    createNoPaylaterExperiment, getRenderedButtons, getButtonSize, getButtonExperiments } from './util';
+    createNoPaylaterExperiment, getRenderedButtons, getButtonSize, getButtonExperiments, isInlineEligible } from './util';
 
 export type ButtonsComponent = ZoidComponent<ButtonProps>;
 
@@ -602,8 +602,8 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 required:   false,
                 type:       'boolean',
                 value:      ({ props }) => {
-                    const { style: { custom }, inline, fundingEligibility } = props;
-                    return inline && custom && fundingEligibility[FUNDING.CARD]?.eligible;
+                    const { clientID, style: { custom }, fundingEligibility } = props;
+                    return isInlineEligible({ clientID }) && custom && fundingEligibility[FUNDING.CARD]?.eligible;
                 }
             },
 

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -600,7 +600,11 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
             inline: {
                 queryParam: true,
                 required:   false,
-                type:       'boolean'
+                type:       'boolean',
+                value:      ({ props }) => {
+                    const { style: { custom }, inline, fundingEligibility } = props;
+                    return inline && custom && fundingEligibility[FUNDING.CARD]?.eligible;
+                }
             },
 
             // allowBillingPayments prop is used by Honey Extension to render the one-click button

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -602,8 +602,8 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 required:   false,
                 type:       'boolean',
                 value:      ({ props }) => {
-                    const { inline, style: { custom }, fundingEligibility } = props;
-                    return inline && custom && fundingEligibility[FUNDING.CARD]?.eligible);
+                    const { style: { custom }, fundingEligibility } = props;
+                    return custom && fundingEligibility[FUNDING.CARD]?.eligible;
                 }
             },
 

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -20,7 +20,7 @@ import { isFundingEligible } from '../../funding';
 import { containerTemplate } from './container';
 import { PrerenderedButtons } from './prerender';
 import { applePaySession, determineFlow, isSupportedNativeBrowser, createVenmoExperiment,
-    createNoPaylaterExperiment, getRenderedButtons, getButtonSize, getButtonExperiments, isInlineEligible } from './util';
+    createNoPaylaterExperiment, getRenderedButtons, getButtonSize, getButtonExperiments } from './util';
 
 export type ButtonsComponent = ZoidComponent<ButtonProps>;
 

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -602,8 +602,8 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 required:   false,
                 type:       'boolean',
                 value:      ({ props }) => {
-                    const { clientID, style: { custom }, fundingEligibility } = props;
-                    return isInlineEligible({ clientID }) && custom && fundingEligibility[FUNDING.CARD]?.eligible;
+                    const { inline, style: { custom }, fundingEligibility } = props;
+                    return inline && custom && fundingEligibility[FUNDING.CARD]?.eligible);
                 }
             },
 

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -298,3 +298,11 @@ export function getButtonSize (props : ButtonProps, container : string | HTMLEle
         }
     }
 }
+
+export function isInlineEligible({ clientID } : {| clientID : string |}) : boolean {
+    const inlineAllowList = [
+        'AYLa6UCw47Baut1LJ3TojVJBDe8ZkzAutZjWP7fVOCafaJ8em97GrHFW7EJXKcMjGcueM-R_AFa-cadq', // test app
+        'AZ4oOpMmgJ3zzqD5quh97IHZnuabU1vwRxfnVKe0CqvZOd6Nfcr-qr_sBKCnRJxODfhSd8IQ2qfL-2aZ'  // test app
+    ];
+    return inlineAllowList.indexOf(clientID) !== -1;
+}

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -298,11 +298,3 @@ export function getButtonSize (props : ButtonProps, container : string | HTMLEle
         }
     }
 }
-
-export function isInlineEligible({ clientID } : {| clientID : string |}) : boolean {
-    const inlineAllowList = [
-        'AYLa6UCw47Baut1LJ3TojVJBDe8ZkzAutZjWP7fVOCafaJ8em97GrHFW7EJXKcMjGcueM-R_AFa-cadq', // test app
-        'AZ4oOpMmgJ3zzqD5quh97IHZnuabU1vwRxfnVKe0CqvZOd6Nfcr-qr_sBKCnRJxODfhSd8IQ2qfL-2aZ'  // test app
-    ];
-    return inlineAllowList.indexOf(clientID) !== -1;
-}

--- a/test/integration/tests/button/style.js
+++ b/test/integration/tests/button/style.js
@@ -111,4 +111,32 @@ describe('paypal button color', () => {
 
         }).render('#testContainer');
     });
+
+    it('should allow custom styling for inlinexo', (done) => {
+        const style = {
+            custom: {
+                label: 'Checkout',
+                css:   {
+                    background: 'white',
+                    height:     '24px'
+                }
+            }
+        };
+        const expected = JSON.stringify(style);
+        done = once(done);
+        window.paypal.Buttons({
+            style,
+            test: {
+                onRender() {
+                    if (JSON.stringify(style) !== expected) {
+                        done(new Error(`Expected style object ${ JSON.stringify(style) } to remain unmodified as ${ expected }`));
+                    }
+                    done();
+                }
+            },
+
+            onError: done
+
+        }).render('#testContainer');
+    });
 });


### PR DESCRIPTION
### Description
Provides custom styling for Inline XO merchants.

**Conditions to be met for the inline flag to be set:**
1. Merchant's clientID is whitelisted2. 
2. Custom styling is provided.
3. FUNDING.CARD is eligible

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)
<img width="372" alt="image" src="https://user-images.githubusercontent.com/1324812/160880578-38ae28d1-5df7-477a-95b7-c98b6c2be141.png">

<img width="370" alt="image" src="https://user-images.githubusercontent.com/1324812/160867845-a37cad2b-37ce-4957-86d5-80cd3f648832.png">


### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

❤️  Thank you!
