### PR TITLE
onComplete Callback

### DIFF
--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -36,6 +36,8 @@ export type OnApproveData = {|
     paymentID? : string
 |};
 
+export type OnCompleteData = {||};
+
 export type CreateBillingAgreement = () => ZalgoPromise<string> | string;
 
 export type CreateSubscriptionRequest = {||};
@@ -65,7 +67,12 @@ export type OnApproveActions = {|
     |}
 |};
 
+export type OnCompleteActions = {|
+    redirect : (string, CrossDomainWindowType) => ZalgoPromise<void>
+|};
+
 export type OnApprove = (data : OnApproveData, actions : OnApproveActions) => ZalgoPromise<void> | void;
+export type OnComplete = (data : OnCompleteData, actions : OnCompleteActions) => ZalgoPromise<void> | void;
 
 type OnShippingChangeAddress = {|
     city : string,
@@ -283,6 +290,7 @@ export type ButtonProps = {|
     createSubscription : CreateSubscription,
     oncancel : OnCancel,
     onApprove : OnApprove,
+    onComplete : OnComplete,
     onClick : OnClick,
     getPrerenderDetails : GetPrerenderDetails,
     style : ButtonStyle,

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -203,6 +203,11 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 required: false
             },
 
+            onComplete: {
+                type:     'function',
+                required: false
+            },
+
             onShippingChange: {
                 type:       'function',
                 required:   false,

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -47,6 +47,7 @@ type CardFieldsProps = {|
 
     createOrder : () => ZalgoPromise<string> | string,
     onApprove : ({| returnUrl : string |}, {| redirect : (?CrossDomainWindowType, ?string) => ZalgoPromise<void> |}) => ?ZalgoPromise<void>,
+    onComplete : ({| returnUrl : string |}, {| redirect : (?CrossDomainWindowType, ?string) => ZalgoPromise<void> |}) => ?ZalgoPromise<void>,
     onCancel ? : ({| cancelUrl : string |}, {| redirect : (? CrossDomainWindowType, ? string) => ZalgoPromise<void> |}) => ?ZalgoPromise<void>
 |};
 
@@ -163,6 +164,12 @@ export const getCardFieldsComponent : () => CardFieldsComponent = memoize(() : C
                     type:     'function',
                     required: false,
                     value:      ({ props }) => props.parent.props.onApprove
+                },
+
+                onComplete: {
+                    type:     'function',
+                    required: false,
+                    value:      ({ props }) => props.parent.props.onComplete
                 },
 
                 onCancel: {
@@ -332,6 +339,11 @@ export const getCardFieldsComponent : () => CardFieldsComponent = memoize(() : C
             },
 
             onApprove: {
+                type:     'function',
+                required: false
+            },
+
+            onComplete: {
                 type:     'function',
                 required: false
             },

--- a/src/zoid/card-form/component.js
+++ b/src/zoid/card-form/component.js
@@ -103,6 +103,11 @@ export function getCardFormComponent() : CardFormComponent {
                     alias: 'onAuthorize'
                 },
 
+                onComplete: {
+                    type:     'function',
+                    required: false
+                },
+
                 onAuth: {
                     type:       'function',
                     required:   false,

--- a/src/zoid/checkout/component.jsx
+++ b/src/zoid/checkout/component.jsx
@@ -191,6 +191,11 @@ export function getCheckoutComponent() : CheckoutComponent {
                     type:     'function',
                     alias:    'onAuthorize'
                 },
+                
+                onComplete: {
+                    type:     'function',
+                    required: false
+                },
         
                 onShippingChange: {
                     type:     'function',

--- a/src/zoid/checkout/props.js
+++ b/src/zoid/checkout/props.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import type { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
+import type { CrossDomainWindowType } from '@krakenjs/cross-domain-utils/src';
 import { FUNDING, ENV, type LocaleType } from '@paypal/sdk-constants/src';
 
 export type OnApproveData = {|
@@ -13,6 +14,10 @@ export type OnApproveActions = {|
     
 |};
 
+export type OnCompleteData = {||};
+export type OnCompleteActions = {|
+    redirect : (string, CrossDomainWindowType) => ZalgoPromise<void>
+|};
 export type OnCancelData = {|
     orderID : string,
     paymentID? : string
@@ -26,6 +31,7 @@ export type CheckoutPropsType = {|
     createOrder : () => ZalgoPromise<string>,
     createAuthCode : () => ZalgoPromise<string>,
     onApprove : (OnApproveData, OnApproveActions) => ?ZalgoPromise<void>,
+    onComplete : (OnCompleteData, OnCompleteActions) => ?ZalgoPromise<void>,
     onCancel? : (OnCancelData, OnCancelActions) => ?ZalgoPromise<void>,
     fundingSource : $Values<typeof FUNDING>,
     env : $Values<typeof ENV>,


### PR DESCRIPTION
### Description
Adds an `onComplete` callback for all supported components in cases where PayPal captures order and `onApprove` is not required.  This allows a combination of APM and branded FI's to have the appropriate callback to take next steps in the checkout flow.
