### PR TITLE
updates applepay errors

### DIFF
--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -208,7 +208,7 @@ export type ApplePayShippingMethod = {|
 |};
 
 export type ApplePayShippingContactUpdate = {|
-    errors? : $ReadOnlyArray<ApplePayErrorCode>,
+    errors? : $ReadOnlyArray<ApplePayError>,
     newShippingMethods? : $ReadOnlyArray<ApplePayShippingMethod>,
     newTotal : ApplePayLineItem,
     newLineItems? : $ReadOnlyArray<ApplePayLineItem>

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -172,12 +172,10 @@ export function applePaySession() : ?ApplePaySessionConfigRequest {
         }
 
         const convertErrorsFromUpdate = (update) => {
-            if (update.errors && update.errors.length) {
-                // $FlowFixMe
-                return update.errors.map(error => new window.ApplePayError(error.code, error.contactField, error.message));
-            }
-
-            return update;
+            return {
+                ...update,
+                errors: (update.errors || []).map(error => new window.ApplePayError(error.code, error.contactField, error.message))
+            };
         };
 
         return (version, request) => {


### PR DESCRIPTION
update incorrect type and mapping.

ref 
https://developer.apple.com/documentation/apple_pay_on_the_web/applepayshippingcontactupdate

```
dictionary ApplePayShippingContactUpdate {
    newTotal;
    newLineItems;
    errors;
    newShippingMethods;
};
``` 