### PR TITLE
chore(deps): use grumbler-scripts from krakenjs scope

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 module.exports = {
-    'extends': './node_modules/grumbler-scripts/config/.eslintrc-browser.js',
+    'extends': './node_modules/@krakenjs/grumbler-scripts/config/.eslintrc-browser.js',
 
     'globals': {
         'Promise': false,

--- a/.flowconfig
+++ b/.flowconfig
@@ -10,7 +10,7 @@
 [include]
 [libs]
 flow-typed
-node_modules/grumbler-scripts/declarations.js
+node_modules/@krakenjs/grumbler-scripts/declarations.js
 node_modules/@krakenjs/zoid/src/declarations.js
 node_modules/@krakenjs/post-robot/src/declarations.js
 node_modules/@paypal/sdk-client/src/declarations.js

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm run lint -- --fix
 # attempt to automatically fix any problems
 ```
 
-Runs [eslint](https://eslint.org/) using [definitions](./.eslinter.js) extended from [Grumbler-Scripts](https://github.com/krakenjs/grumbler-scripts/blob/main/config/.eslintrc-browser.js).
+Runs [eslint](https://eslint.org/) using [definitions](./.eslinter.js) extended from [Grumbler-Scripts](https://github.com/krakenjs/@krakenjs/grumbler-scripts/blob/main/config/.eslintrc-browser.js).
 
 ### flow
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "license": "Apache-2.0",
     "readmeFilename": "README.md",
     "devDependencies": {
+        "@krakenjs/grumbler-scripts": "^6.0.2",
         "@krakenjs/sync-browser-mocks": "^3.0.0",
         "babel-core": "^7.0.0-bridge.0",
         "bundlemon": "^1.1.0",


### PR DESCRIPTION
### Description

Update the grumbler-scripts dev dependency to use the `@krakenjs` npm scope.
