### PR TITLE
chore(deps): update lock-threads github action

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -8,14 +8,14 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@v3
         with:
           github-token: ${{ github.token }}
-          issue-exclude-created-before: '2018-01-01T00:00:00Z'
-          issue-lock-inactive-days: '365'
-          issue-exclude-labels: 'sdk-core, feature, work-in-progress, help-wanted'
-          issue-lock-labels: 'outdated'
-          issue-lock-comment: >
+          exclude-issue-created-before: '2018-01-01T00:00:00Z'
+          issue-inactive-days: '365'
+          exclude-any-issue-labels: 'sdk-core, feature, work-in-progress, help-wanted'
+          add-issue-labels: 'outdated'
+          issue-comment: >
             This issue has been automatically locked since there
             has not been any recent activity after it was closed.
             Please open a new issue for related bugs.


### PR DESCRIPTION
### Description

Update GitHub Action for lock-threads.

Changelog: https://github.com/dessant/lock-threads/blob/master/CHANGELOG.md#300-2021-09-27