### PR TITLE
fix: remove configuration of stageUrl via props

### DIFF
--- a/src/button/component.jsx
+++ b/src/button/component.jsx
@@ -104,7 +104,6 @@ type ButtonOptions = {|
     meta : Object,
     validate? : ({ enable : () => ZalgoPromise<void>, disable : () => ZalgoPromise<void> }) => void,
     stage? : string,
-    stageUrl? : string,
     authCode? : string,
     enableNativeCheckout? : boolean
 |};
@@ -336,20 +335,6 @@ export const Button : Component<ButtonOptions> = create({
             required: false,
             def:      () => {
                 return true;
-            }
-        },
-
-        stageUrl: {
-            type:       'string',
-            required:   false,
-            queryParam: true,
-
-            def(props) : ?string {
-                const env = props.env || config.env;
-
-                if (env === ENV.STAGE || env === ENV.LOCAL) {
-                    return config.stageUrl;
-                }
             }
         },
 

--- a/src/setup.js
+++ b/src/setup.js
@@ -114,14 +114,6 @@ function configure({ env, stage, stageUrl, apiStage, localhostUrl, checkoutUri, 
         delete config.stageUrl;
         // $FlowFixMe
         config.stageUrl = stageUrl;
-    } else if (Button.xprops && Button.xprops.stageUrl) {
-        delete config.stageUrl;
-        // $FlowFixMe
-        config.stageUrl = Button.xprops.stageUrl;
-    } else if (Checkout.xprops && Checkout.xprops.stageUrl) {
-        delete config.stageUrl;
-        // $FlowFixMe
-        config.stageUrl = Checkout.xprops.stageUrl;
     }
 
     authCode = authCode || (Button.xprops && Button.xprops.authCode) || (Checkout.xprops && Checkout.xprops.authCode);
@@ -198,7 +190,7 @@ if (currentScript) {
         env:                currentScript.getAttribute('data-env'),
         stage:              currentScript.getAttribute('data-stage'),
         apiStage:           currentScript.getAttribute('data-api-stage'),
-        stageUrl:           currentScript.getAttribute('data-stage-url'),
+        stageUrl:           isPayPalDomain() ? currentScript.getAttribute('data-stage-url') : undefined,
         localhostUrl:       isPayPalDomain() ? currentScript.getAttribute('data-localhost-url') : undefined,
         checkoutUri:        isPayPalDomain() ? currentScript.getAttribute('data-checkout-uri') : undefined,
         state:              currentScript.getAttribute('data-state'),


### PR DESCRIPTION
This is a continued effort from PR#1922.

We had assumed we caught all of the xss vector around the `localhostUrl`
being used in the window.name of the iframe. It appears there still
existed an attack surface area around `stageUrl` that was reported to us.

PR 1922: https://github.com/paypal/paypal-checkout-components/pull/1922/files
sha: https://github.com/paypal/paypal-checkout-components/commit/e5aa4090a8257a04416f3ce28669c452a6ab4585