### PR TITLE
chore: pass version to /smart/buttons

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -5,7 +5,7 @@
 import { getLogger, getLocale, getClientID, getEnv, getIntent, getCommit, getVault, getDisableFunding, getDisableCard,
     getMerchantID, getPayPalDomainRegex, getCurrency, getSDKMeta, getCSPNonce, getBuyerCountry, getClientAccessToken, getPlatform,
     getPartnerAttributionID, getCorrelationID, getEnableThreeDomainSecure, getDebug, getComponents, getStageHost, getAPIStageHost, getPayPalDomain,
-    getUserIDToken, getClientMetadataID, getAmount, getEnableFunding, getStorageID, getUserExperienceFlow, getMerchantRequestedPopupsDisabled } from '@paypal/sdk-client/src';
+    getUserIDToken, getClientMetadataID, getAmount, getEnableFunding, getStorageID, getUserExperienceFlow, getMerchantRequestedPopupsDisabled, getVersion } from '@paypal/sdk-client/src';
 import { rememberFunding, getRememberedFunding, getRefinedFundingEligibility } from '@paypal/funding-components/src';
 import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 import { create, type ZoidComponent } from '@krakenjs/zoid/src';
@@ -118,6 +118,17 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
         },
 
         props: {
+            /**
+             * Version of the SDK used in first render.
+             * This is passed to the `/smart/buttons` endpoint in order for the second render
+             * in order to be aware of what sdk to load during SSR of the buttons
+             */
+            sdkVersion: {
+                type:        'string',
+                queryParam:  true,
+                sendToChild: false,
+                value:       getVersion
+            },
             fundingSource: {
                 type:       'string',
                 queryParam: true,


### PR DESCRIPTION
### Description

The `/smart/buttons` call needs to be version aware so that we can ensure SSR uses the proper sdk version during rendering. This keeps backend sdk services in sync

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

We are making these changes to prepare for an updated deployment strategy of the sdk

### Reproduction Steps (if applicable)

Run a standard e2e test locally of the sdk and notice the call to `/smart/buttons` has a queryParam added which is `sdkVersion=<semver version of sdk>`.

### Screenshots (if applicable)
<img width="584" alt="image" src="https://user-images.githubusercontent.com/802901/165791618-59ed6b2e-f165-4dd1-a893-9e66fd17a130.png">


### Dependent Changes (if applicable)
None

### Groups who should review (if applicable)
n/a
