### PR TITLE
Do not render Powered by PayPal for InlineXO

### DIFF
--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -204,7 +204,7 @@ export function Buttons(props : ButtonsProps) : ElementNode {
             }
 
             {
-                (layout === BUTTON_LAYOUT.VERTICAL && fundingSources.indexOf(FUNDING.CARD) !== -1)
+                (layout === BUTTON_LAYOUT.VERTICAL && fundingSources.indexOf(FUNDING.CARD) !== -1 && !inlineExperience)
                     ? <PoweredByPayPal
                             locale={ locale }
                             nonce={ nonce }


### PR DESCRIPTION
### Description
Prevents rendering of Powered by PayPal in Inline experience.