### PR TITLE
Add a function to log screen information for SFVC path

### DIFF
--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { supportsPopups as userAgentSupportsPopups, isAndroid, isChrome, isIos, isSafari, isSFVC, type Experiment, isDevice, isTablet, getElement, isLocalStorageEnabled } from '@krakenjs/belter/src';
+import { supportsPopups as userAgentSupportsPopups, isAndroid, isChrome, isIos, isIOS14, isSafari, isSFVC, type Experiment, isDevice, isTablet, getElement, isLocalStorageEnabled } from '@krakenjs/belter/src';
 import { COUNTRY, CURRENCY, ENV, FPTI_KEY, FUNDING, type LocaleType } from '@paypal/sdk-constants/src';
 import { getEnableFunding, getDisableFunding, getLogger, createExperiment, getFundingEligibility, getPlatform, getComponents, getEnv, type FundingEligibilityType } from '@paypal/sdk-client/src';
 import { getRefinedFundingEligibility } from '@paypal/funding-components/src';
@@ -26,7 +26,8 @@ function logNativeScreenInformation(key = 'screenInformation') {
     const outerHeight = window.outerHeight;
     const scale = Math.round(window.screen.width / window.innerWidth * 100) / 100;
     const computedHeight = Math.round(height * scale);
-    const screenInformation = { height, outerHeight, scale: `${scale}`, computedHeight: `${computedHeight}` };
+    const ios14 = isIOS14();
+    const screenInformation = { height, ios14, outerHeight, scale: `${scale}`, computedHeight: `${computedHeight}` };
 
     getLogger()
       .info(key, screenInformation)

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -27,9 +27,11 @@ function logNativeScreenInformation(key = 'screenInformation') {
     const scale = Math.round(window.screen.width / window.innerWidth * 100) / 100;
     const computedHeight = Math.round(height * scale);
     const ios14 = isIOS14();
-    const screenInformation = { height, ios14, outerHeight, scale: `${scale}`, computedHeight: `${computedHeight}` };
+
+    const screenInformation = { computedHeight, height, ios14, outerHeight, scale };
 
     getLogger()
+      // $FlowFixMe - object is mixed values when this expects all of the same value types
       .info(key, screenInformation)
   }
 }

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -30,7 +30,6 @@ function logNativeScreenInformation(key = 'screenInformation') {
 
     getLogger()
       .info(key, screenInformation)
-      .flush();
   }
 }
 

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -15,6 +15,25 @@ type DetermineFlowOptions = {|
     createSubscription : CreateSubscription
 |};
 
+/**
+ * log information about screen to debug. currently in use to test if sfvc logic triggers
+ *
+ * @param {string} key for logging
+ */
+function logNativeScreenInformation(key = 'screenInformation') {
+  if (window) {
+    const height = window.innerHeight;
+    const outerHeight = window.outerHeight;
+    const scale = Math.round(window.screen.width / window.innerWidth * 100) / 100;
+    const computedHeight = Math.round(height * scale);
+    const screenInformation = { height, outerHeight, scale: `${scale}`, computedHeight: `${computedHeight}` };
+
+    getLogger()
+      .info(key, screenInformation)
+      .flush();
+  }
+}
+
 export function determineFlow(props : DetermineFlowOptions) : $Values<typeof BUTTON_FLOW> {
 
     if (props.createBillingAgreement) {
@@ -36,6 +55,7 @@ export function isSupportedNativeBrowser() : boolean {
     }
 
     if (isSFVC()) {
+        logNativeScreenInformation('sfvcScreenInformation');
         return false;
     }
 

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { supportsPopups as userAgentSupportsPopups, isAndroid, isChrome, isIos, isIOS14, isSafari, isSFVC, type Experiment, isDevice, isTablet, getElement, isLocalStorageEnabled } from '@krakenjs/belter/src';
+import { supportsPopups as userAgentSupportsPopups, isAndroid, isChrome, isIos, isIOS14, isSafari, isSFVC, type Experiment, isDevice, isTablet, getElement, isLocalStorageEnabled, isStandAlone } from '@krakenjs/belter/src';
 import { COUNTRY, CURRENCY, ENV, FPTI_KEY, FUNDING, type LocaleType } from '@paypal/sdk-constants/src';
 import { getEnableFunding, getDisableFunding, getLogger, createExperiment, getFundingEligibility, getPlatform, getComponents, getEnv, type FundingEligibilityType } from '@paypal/sdk-client/src';
 import { getRefinedFundingEligibility } from '@paypal/funding-components/src';
@@ -27,8 +27,9 @@ function logNativeScreenInformation(key = 'screenInformation') {
     const scale = Math.round(window.screen.width / window.innerWidth * 100) / 100;
     const computedHeight = Math.round(height * scale);
     const ios14 = isIOS14();
+    const standAlone = isStandAlone();
 
-    const screenInformation = { computedHeight, height, ios14, outerHeight, scale };
+    const screenInformation = { computedHeight, height, ios14, outerHeight, scale, standAlone };
 
     getLogger()
       // $FlowFixMe - object is mixed values when this expects all of the same value types


### PR DESCRIPTION

### Description

We believe we might be incorreclty flagging mobile browsers as SFVC.
Adding logging information to display screensize when we think we detect
an SFVC

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

Venmo button appears to not render when SPB is in nested iframes on native Safari in iOS 15+. We suspect the `isSFVC` is blocking it erroneously.
