### PR TITLE
chore: update minimum height for single name field

### DIFF
--- a/src/zoid/payment-fields/container.jsx
+++ b/src/zoid/payment-fields/container.jsx
@@ -67,20 +67,20 @@ export function PaymentFieldsContainer({ uid, frame, prerenderFrame, event, nonc
                         min-width: 250px;
                         max-width: 100%;
                         font-size: 0;
-                        height: 150px;
-                        min-height: 150px;
+                        height: 91px;
+                        min-height: 91px;
                         transition: all 0.5s ease-in-out;
                     }
 
                     @media only screen and (min-width: 0px) {
                         #${ uid } {
-                            min-height: 150px;
+                            min-height: 91px;
                         }
                     }
 
                     @media only screen and (min-width: 600px) {
                         #${ uid } {
-                            min-height: 150px;
+                            min-height: 91px;
                         }
                     }
 


### PR DESCRIPTION
### Description
Payment fields had minimum height of 150px to accommodate First name and Last name fields
Two fields were combined into one Full name field
Height for payment-fields component updated to 91px to fit Full name field


### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
[DTALTPAY-984](https://engineering.paypalcorp.com/jira/browse/DTALTPAY-984)

### Reproduction Steps (if applicable)
- [alternative-payments-test-tool.herokuapp.com](https://alternative-payments-test-tool.herokuapp.com/)
- select Giropay or MyBank (single input field) and see the fields render

### Screenshots (if applicable)
Before:
![image](https://user-images.githubusercontent.com/29203245/176805323-52069aef-0889-4857-86bb-bd81c58457e0.png)
After:
![image](https://user-images.githubusercontent.com/29203245/176805450-9997fbce-76ec-428c-8502-7287956b6e02.png)


### Dependent Changes (if applicable)
N/A

### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
