### PR TITLE
add payment request prop

### DIFF
--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -350,6 +350,8 @@ export type ApplePayPaymentAuthorizationResult = {|
 
 export type ApplePaySessionConfig = {|
     begin : () => void,
+    abort : () => void,
+    oncancel : () => void,
     addEventListener : (string, Function) => void,
     // eslint-disable-next-line flowtype/no-weak-types
     completeMerchantValidation : (validatedSession : any) => void,

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -461,6 +461,12 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 }
             },
 
+            paymentRequest: {
+                type:       'object',
+                queryParam: false,
+                required: false
+            },
+
             flow: {
                 type:       'string',
                 queryParam: true,

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -192,11 +192,6 @@ export function applePaySession() : ?ApplePaySessionConfigRequest {
                 listeners.paymentauthorized({ payment });
             };
 
-            // eslint-disable-next-line unicorn/prefer-add-event-listener
-            session.oncancel = () => {
-                listeners.cancel();
-            };
-
             return {
                 addEventListener: (name, handler) => {
                     listeners[name] = handler;
@@ -218,7 +213,9 @@ export function applePaySession() : ?ApplePaySessionConfigRequest {
                     const newUpdate = convertErrorsFromUpdate(update);
                     session.completePayment(newUpdate);
                 },
-                begin: () => session.begin()
+                begin: () => session.begin(),
+                abort: () => session.abort(),
+                oncancel: () => session.oncancel()
             };
         };
     } catch (e) {


### PR DESCRIPTION
ref https://github.com/paypal/paypal-smart-payment-buttons/pull/437

adds 

- paymentRequest config prop 

- applepaySession abort and cancel 