### PR TITLE
Adding eligibility check to CardFields

### DIFF
--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -306,6 +306,19 @@ export const getCardFieldsComponent : () => CardFieldsComponent = memoize(() : C
             }
         },
 
+        eligible: () => {
+            const fundingEligibility = getRefinedFundingEligibility();
+            if (fundingEligibility?.card?.eligible) {
+                return {
+                    eligible: true
+                };
+            }
+            return {
+                eligible: false,
+                reason: 'card payments are not eligible'
+            };
+        },
+
         props: {
             type: {
                 type:       'string',


### PR DESCRIPTION
### Description

This adds an eligibility check to the `CardFields`, which allows the merchant to call `isEligible` before rendering any of the card fields.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

[DTNOR-497 - [JS] Supported HCFs Methods: isEligible](https://engineering.paypalcorp.com/jira/browse/DTNOR-497)

### Groups who should review (if applicable)
Checkout SDK

### Co-Authored By:
-@bywood
-@jplukarski

❤️  Thank you!
