### PR TITLE
Second Button Experiment Logging

### DIFF
--- a/src/funding/paylater/config.jsx
+++ b/src/funding/paylater/config.jsx
@@ -1,7 +1,7 @@
 /* @flow */
 /** @jsx node */
 
-import type { FundingEligibilityType } from '@paypal/sdk-client/src';
+import { FundingEligibilityType, getLogger, getLocale, getSessionID} from '@paypal/sdk-client/src';
 import { FUNDING } from '@paypal/sdk-constants/src';
 import { node, Style } from '@krakenjs/jsx-pragmatic/src';
 import { PPLogo, LOGO_COLOR } from '@paypal/sdk-logos/src';
@@ -11,6 +11,13 @@ import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
 import { Text, Space } from '../../ui/text';
 
 import css from './style.scoped.scss';
+
+const SECOND_BTN_EXP = {
+    EXPERIMENTATION_EXPERIENCE: '106065',
+    TREATMENT_ID:'127591',
+    CONTROL_ID:'127590',
+    REASON: 'SECOND BUTTON EXPERIMENT CALLED: Trmt_FEATURE_2ND_BUTTON_PI4',
+}
 
 function getLabelText(fundingEligibility : FundingEligibilityType) : ?string {
     const { paylater } = fundingEligibility;
@@ -47,6 +54,19 @@ function getLabelText(fundingEligibility : FundingEligibilityType) : ?string {
         paylater?.products?.payIn4?.variant === 'FR'
     ) {
         labelText = '4X PayPal';
+    }
+
+    if(getLocale().includes("US")) {
+        const payload = {
+            state_name: "elmo_check",
+            transition_name: "process_elmo_check",
+            experimentation_experience: SECOND_BTN_EXP.EXPERIMENTATION_EXPERIENCE,
+            experimentation_treatment: paylater?.products?.payIn4?.reasons.includes(SECOND_BTN_EXP.REASON) ? SECOND_BTN_EXP.TREATMENT_ID : SECOND_BTN_EXP.CONTROL_ID,
+            context_id: getSessionID(),
+            context_type: "button_session_id"
+        }
+    
+        getLogger().info("Second Button Experiment Received", payload)
     }
 
     return labelText;


### PR DESCRIPTION
### Description

Adding logging support to track the result of the second button experiments run in xobuyernodeserv (already merged).

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
https://engineering.paypalcorp.com/jira/browse/DTXOWALCAP-428

The main point of inserting the logging here is because we have access to the button session id, which is not present in the xoybuyer segment that contains the elmo logic.

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
