### PR TITLE
add button location to xprops

### DIFF
--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -429,6 +429,7 @@ export type ButtonProps = {|
     remember : ($ReadOnlyArray<$Values<typeof FUNDING>>) => void,
     clientID : string,
     sessionID : string,
+    buttonLocation : string,
     buttonSessionID : string,
     onShippingChange : ?OnShippingChange,
     onShippingAddressChange : ?OnShippingAddressChange,

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -386,6 +386,12 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                 queryParam: true
             },
 
+            buttonLocation: {
+                type: 'string',
+                value: () => window.location.hostname,
+                queryParam: false
+            },
+
             buttonSessionID: {
                 type:       'string',
                 value:      uniqueID,


### PR DESCRIPTION
### Description

This PR adds meta information about which domain loaded the SDK for fraud detection purposes.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

https://engineering.paypalcorp.com/jira/browse/DTCHKINT-1214

### Reproduction Steps (if applicable)

```
npm run dev
```

edit `demo/dev/button.htm` and `console.log(xprops.buttonLocation)`.

Note: This prop is not sent to `/smart/button` as a query param.

### Screenshots (if applicable)

<img width="782" alt="Screen Shot 2022-11-07 at 09 01 42" src="https://user-images.githubusercontent.com/3824954/200342848-8de03d7f-12b3-469c-8256-3031a1a7cbe2.png">

### Dependent Changes (if applicable)

PR incoming to paypal-smart-payment-buttons, stay tuned!

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
