### PR TITLE
Add getState Method to Unbranded Multi-Card Fields

### DIFF
--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -15,7 +15,6 @@ import { CARD, CURRENCY, INTENT, type FundingEligibilityType } from '@paypal/sdk
 import { getSessionID } from '../../lib';
 
 import { CardPrerender } from './prerender';
-import { string } from '../../../../paypal-smart-payment-buttons/src/config';
 
 const CARD_FIELD_TYPE = {
     SINGLE: 'single',
@@ -71,7 +70,7 @@ type CardFieldsExports = {|
     removeAttribute : () => void,
     addClass : () => void,
     removeClass : () => void,
-    getState : () => String
+    getState : () => Object
 |};
 
 type CardFieldsChildren = {|

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -66,11 +66,11 @@ export type CardFieldComponent = ZoidComponent<CardFieldProps>;
 
 type CardFieldsExports = {|
     submit : () => ZalgoPromise<void>,
-    setAttribute : () => void,
-    removeAttribute : () => void,
-    addClass : () => void,
-    removeClass : () => void,
-    getState : () => Object
+    setAttribute : () => ZalgoPromise<void>,
+    removeAttribute : () => ZalgoPromise<void>,
+    addClass : () => ZalgoPromise<void>,
+    removeClass : () => ZalgoPromise<void>,
+    getState : () => ZalgoPromise<void>
 |};
 
 type CardFieldsChildren = {|

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -15,6 +15,7 @@ import { CARD, CURRENCY, INTENT, type FundingEligibilityType } from '@paypal/sdk
 import { getSessionID } from '../../lib';
 
 import { CardPrerender } from './prerender';
+import { string } from '../../../../paypal-smart-payment-buttons/src/config';
 
 const CARD_FIELD_TYPE = {
     SINGLE: 'single',
@@ -69,7 +70,8 @@ type CardFieldsExports = {|
     setAttribute : () => void,
     removeAttribute : () => void,
     addClass : () => void,
-    removeClass : () => void
+    removeClass : () => void,
+    getState : () => String
 |};
 
 type CardFieldsChildren = {|
@@ -349,7 +351,10 @@ export const getCardFieldsComponent : () => CardFieldsComponent = memoize(() : C
             },
             focus: {
                 type: 'function'
-            }
+            },
+            getState: {
+                type: 'function'
+            },
         },
 
         eligible: () => {

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -70,7 +70,7 @@ type CardFieldsExports = {|
     removeAttribute : () => ZalgoPromise<void>,
     addClass : () => ZalgoPromise<void>,
     removeClass : () => ZalgoPromise<void>,
-    getState : () => ZalgoPromise<void>
+    getState : () => ZalgoPromise<Object>
 |};
 
 type CardFieldsChildren = {|


### PR DESCRIPTION
### Description

This adds the `getState` method to the unbranded multi-card fields. This method returns a state object to the merchant with the following information:

- List of potential card types
- A Field object for each rendered field with the following properties:
   - isFocused
   - isEmpty
   - isPotentiallyValid
   - isValid

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

[DTNOR-487](https://engineering.paypalcorp.com/jira/browse/DTNOR-487)

### Dependent Changes (if applicable)

[PR in Smart Payment Buttons](https://github.com/paypal/paypal-smart-payment-buttons/pull/506)

### Groups who should review (if applicable)
@paypal/checkout-sdk 

❤️  Thank you!

Co-authored-by

@jplukarski
@nidhinarendra
@siddy2181 