### PR TITLE
feat: save uses merchant vault token callback to get token

### DIFF
--- a/src/actions/save/index.js
+++ b/src/actions/save/index.js
@@ -23,7 +23,7 @@ export type onErrorCallback = (error: string) => void
 
 export type SaveAction = (SaveActionConfig) => ({|
   type: "save",
-  save: (onError: onErrorCallback, paymentSourceDetails: CardDetails) => ZalgoPromise<void> | Promise<void>,
+  save: (onError: onErrorCallback, paymentSourceDetails: CardDetails) => ZalgoPromise<void>,
 |});
 
 /**
@@ -59,9 +59,9 @@ export const createSaveAction: SaveAction = (config: SaveActionConfig) => {
 
       return ZalgoPromise.try(() => {
         createVaultSetupToken()
-        .then((emptySetupToken) => {
+        .then((/* emptySetupToken */) => {
           // take token and call our PP endpoint with it
-        }).catch((error) => {
+        }).catch((/* error */) => {
           // TODO: Let's make sure we stringify this error safely/idiomatically - Do we define errors elsewhere?
           return onError("Unable to retrieve setup token from 'createVaultSetupToken'")
         })

--- a/src/actions/save/index.js
+++ b/src/actions/save/index.js
@@ -19,12 +19,11 @@ type SaveActionConfig = {|
   onApprove: ({| vaultSetupToken: string |}) => void,
 |};
 
+export type onErrorCallback = (error: string) => void
+
 export type SaveAction = (SaveActionConfig) => ({|
   type: "save",
-  /* TODO: 
-      - We need to define how paymentSourceDetails is typed here
-  */
-  save: ({|onError: (error: string) => void, paymentSourceDetails: CardDetails|}) => ZalgoPromise<void>,
+  save: (onError: onErrorCallback, paymentSourceDetails: CardDetails) => ZalgoPromise<void> | Promise<void>,
 |});
 
 /**
@@ -51,10 +50,14 @@ export const createSaveAction: SaveAction = (config: SaveActionConfig) => {
 
   return {
     type: "save",
-    save: () => {
-      return ZalgoPromise.try(() => {
-        // basics for typing requirements. Implementation to come in next ticket.
-      })
+    save: async (onError, paymentSourceDetails) => {
+      const { createVaultSetupToken } = config;
+
+      // TODO: Do we use ZalgoPromise? Should we? If we do, how do we work with merchant async functions?
+      // DO we do ZalgoPromise.try(() => createVaultSetupToken())???
+      const emptySetupToken = await createVaultSetupToken();
+
+      console.log(`emptySetupToken`, emptySetupToken);
     }
   }
 };

--- a/src/actions/save/index.js
+++ b/src/actions/save/index.js
@@ -50,14 +50,15 @@ export const createSaveAction: SaveAction = (config: SaveActionConfig) => {
 
   return {
     type: "save",
-    save: async (onError, paymentSourceDetails) => {
+    save: (onError, paymentSourceDetails) => {
       const { createVaultSetupToken } = config;
 
-      // TODO: Do we use ZalgoPromise? Should we? If we do, how do we work with merchant async functions?
-      // DO we do ZalgoPromise.try(() => createVaultSetupToken())???
-      const emptySetupToken = await createVaultSetupToken();
-
-      console.log(`emptySetupToken`, emptySetupToken);
+      return ZalgoPromise.try(() => {
+        createVaultSetupToken()
+          .then((emptySetupToken) => {
+            // take token and call our PP endpoint with it
+          })
+      })  
     }
   }
 };

--- a/src/actions/save/index.js
+++ b/src/actions/save/index.js
@@ -21,6 +21,9 @@ type SaveActionConfig = {|
 
 export type onErrorCallback = (error: string) => void
 
+/* 
+ * The onError function passed here is the `onError` callback provided to the component, e.g. Hosted Card Fields.
+*/
 export type SaveAction = (SaveActionConfig) => ({|
   type: "save",
   save: (onError: onErrorCallback, paymentSourceDetails: CardDetails) => ZalgoPromise<void>,

--- a/src/actions/save/index.js
+++ b/src/actions/save/index.js
@@ -52,12 +52,19 @@ export const createSaveAction: SaveAction = (config: SaveActionConfig) => {
     type: "save",
     save: (onError, paymentSourceDetails) => {
       const { createVaultSetupToken } = config;
+    
+      if (!onError || !paymentSourceDetails) {
+        throw new ValidationError("Missing args to #save")
+      }
 
       return ZalgoPromise.try(() => {
         createVaultSetupToken()
-          .then((emptySetupToken) => {
-            // take token and call our PP endpoint with it
-          })
+        .then((emptySetupToken) => {
+          // take token and call our PP endpoint with it
+        }).catch((error) => {
+          // TODO: Let's make sure we stringify this error safely/idiomatically - Do we define errors elsewhere?
+          return onError("Unable to retrieve setup token from 'createVaultSetupToken'")
+        })
       })  
     }
   }

--- a/src/actions/save/index.js
+++ b/src/actions/save/index.js
@@ -57,7 +57,7 @@ export const createSaveAction: SaveAction = (config: SaveActionConfig) => {
       const { createVaultSetupToken } = config;
     
       if (!onError || !paymentSourceDetails) {
-        throw new ValidationError("Missing args to #save")
+        return ZalgoPromise.reject(new ValidationError("Missing args to #save"))
       }
 
       return ZalgoPromise.try(() => {

--- a/test/unit/actions/save.test.js
+++ b/test/unit/actions/save.test.js
@@ -4,7 +4,6 @@ import { ZalgoPromise } from "@krakenjs/zalgo-promise/dist/zalgo-promise";
 import { describe, it, expect, vi } from "vitest";
 
 import { createSaveAction } from "../../../src/actions/save"
-import type { onErrorCallback } from "../../../src/actions/save"
 
 describe('Save', () => {
   const mockCreateVaultSetupToken = () => ZalgoPromise.try(() => "some-fake-token")
@@ -63,7 +62,7 @@ describe('Save', () => {
 
     it("uses merchant config callback to get token", () => {
       const saveAction = createSaveAction(actionInputs)
-      const mockOnError: onErrorCallback = vi.fn()
+      const mockOnError = vi.fn()
 
       saveAction.save(mockOnError, mockCardDetails)
 
@@ -75,7 +74,7 @@ describe('Save', () => {
       // $FlowFixMe
       actionInputs.createVaultSetupToken.mockRejectedValue(mockError)
       const saveAction = createSaveAction(actionInputs)
-      const mockOnError: onErrorCallback = vi.fn()
+      const mockOnError = vi.fn()
       
       saveAction.save(mockOnError, mockCardDetails).then(() => {
         expect(mockOnError).toBeCalledWith("Unable to retrieve setup token from 'createVaultSetupToken'")
@@ -85,7 +84,7 @@ describe('Save', () => {
     
     it('errors if payment details are not provided', () => {
       expect.assertions(1)
-      const mockOnError: onErrorCallback = vi.fn()
+      const mockOnError = vi.fn()
       const saveAction = createSaveAction(actionInputs)
 
       try {

--- a/test/unit/actions/save.test.js
+++ b/test/unit/actions/save.test.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/dist/zalgo-promise";
-import { describe, it, expect, vi, mocked } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { createSaveAction } from "../../../src/actions/save"
 import type { onErrorCallback } from "../../../src/actions/save"
@@ -51,10 +51,10 @@ describe('Save', () => {
   describe('Save#save function', () => {
     const fakeEmptySetupToken = "some-empty-setup-token"
     const actionInputs = {
-      createVaultSetupToken: vi.fn(async () => {
+      createVaultSetupToken: vi.fn(() => {
         return fakeEmptySetupToken
       }),
-      onApprove: () => {}
+      onApprove: vi.fn()
     }
     const mockCardDetails = {
       number: "41111111111",
@@ -63,7 +63,7 @@ describe('Save', () => {
 
     it("uses merchant config callback to get token", () => {
       const saveAction = createSaveAction(actionInputs)
-      const mockOnError: onErrorCallback = () => {}
+      const mockOnError: onErrorCallback = vi.fn()
 
       saveAction.save(mockOnError, mockCardDetails)
 
@@ -98,7 +98,6 @@ describe('Save', () => {
 
     it('errors if onError callback is not provided', () => {
       expect.assertions(1)
-      const mockOnError: onErrorCallback = vi.fn()
       const saveAction = createSaveAction(actionInputs)
 
       try {

--- a/test/unit/actions/save.test.js
+++ b/test/unit/actions/save.test.js
@@ -51,7 +51,7 @@ describe('Save', () => {
     const fakeEmptySetupToken = "some-empty-setup-token"
     const actionInputs = {
       createVaultSetupToken: vi.fn(() => {
-        return fakeEmptySetupToken
+        return ZalgoPromise.resolve(fakeEmptySetupToken)
       }),
       onApprove: vi.fn()
     }
@@ -87,24 +87,22 @@ describe('Save', () => {
       const mockOnError = vi.fn()
       const saveAction = createSaveAction(actionInputs)
 
-      try {
-        // $FlowFixMe - Explicitly testing this case
-        saveAction.save(mockOnError)
-      } catch (error) {
+      // $FlowFixMe - Explicitly testing this case
+      return saveAction.save(mockOnError).catch((error) => {
+        // $FlowFixMe
         expect(error.message).toContain("Missing args to #save")
-      }
+      })
     })
-
+    
     it('errors if onError callback is not provided', () => {
       expect.assertions(1)
       const saveAction = createSaveAction(actionInputs)
-
-      try {
-        // $FlowFixMe - Explicitly testing this case
-        saveAction.save(undefined, mockCardDetails)
-      } catch (error) {
+      
+      // $FlowFixMe - Explicitly testing this case
+      return saveAction.save(undefined, mockCardDetails).catch(error => {
+        // $FlowFixMe
         expect(error.message).toContain("Missing args to #save")
-      }
+      })
     })
   })
 })

--- a/test/unit/actions/save.test.js
+++ b/test/unit/actions/save.test.js
@@ -1,9 +1,10 @@
 /* @flow */
 
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/dist/zalgo-promise";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { createSaveAction } from "../../../src/actions/save"
+import type { onErrorCallback } from "../../../src/actions/save"
 
 describe('Save', () => {
   const mockCreateVaultSetupToken = () => ZalgoPromise.try(() => "some-fake-token")
@@ -44,6 +45,29 @@ describe('Save', () => {
         // $FlowFixMe
         onApprove: "i am not a function",
       })).toThrowError("Save action is missing the required")
+    })
+  })
+
+  describe('Save#save function', () => {
+    const fakeEmptySetupToken = "some-empty-setup-token"
+    const actionInputs = {
+      createVaultSetupToken: vi.fn(async () => {
+        return fakeEmptySetupToken
+      }),
+      onApprove: () => {}
+    }
+
+    it("uses merchant config callback to get token", () => {
+      const saveAction = createSaveAction(actionInputs)
+      const mockOnError: onErrorCallback = () => {}
+      const mockCardDetails = {
+        number: "41111111111",
+        expiry: "05/25"
+      }
+
+      saveAction.save(mockOnError, mockCardDetails)
+
+      expect(actionInputs.createVaultSetupToken).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

DTNOR-547
We need to use the merchant provided callback to retrieve the _empty_ setup token. While it's as simple as us calling an async function and resolving it, the callback itself is defined by the merchant and needs to hit their own API so they can hit the PayPal vaulting API to create an empty setup token.

### Reproduction Steps (if applicable)
n/a
### Screenshots (if applicable)
n/a
### Dependent Changes (if applicable)
n/a
<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
