### PR TITLE
chore(docs): fix github actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm version][version-badge]][package]
 [![apache license][license-badge]][license]
 
-[build-badge]: https://img.shields.io/github/workflow/status/paypal/paypal-checkout-components/build?logo=github&style=flat-square
+[build-badge]: https://img.shields.io/github/actions/workflow/status/paypal/paypal-checkout-components/main.yml?branch=main&logo=github&style=flat-square
 [build]: https://github.com/paypal/paypal-checkout-components/actions?query=workflow%3Abuild
 [coverage-badge]: https://img.shields.io/codecov/c/github/paypal/paypal-checkout-components.svg?style=flat-square
 [coverage]: https://codecov.io/github/paypal/paypal-checkout-components/


### PR DESCRIPTION
### Description

The GitHub Actions badge is currently broken in the readme. There was a breaking change recently with shields.io. Details here: https://github.com/badges/shields/issues/8671

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

We want the badge to look pretty. 
