### PR TITLE
fix(applepay): Supress ApplePay Button from SPB when User adds standalone

### DIFF
--- a/src/funding/applepay/config.jsx
+++ b/src/funding/applepay/config.jsx
@@ -1,9 +1,8 @@
 /* @flow */
 /** @jsx node */
 
-import { PLATFORM } from '@paypal/sdk-constants/src';
+import { PLATFORM, FUNDING } from '@paypal/sdk-constants/src';
 import { ApplePayLogo, LOGO_COLOR } from '@paypal/sdk-logos/src';
-import { FUNDING } from '@paypal/sdk-constants/src';
 
 import { BUTTON_COLOR, BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
@@ -23,7 +22,7 @@ export function getApplePayConfig() : FundingSourceConfig {
             /** If the JS SDK Script Includes Standalone ApplePay Component the Exclude the ApplePay Button From the Vertical Stack 
              * https://paypal.atlassian.net/browse/DTALTPAY-1232
             */
-           return !components.includes(FUNDING.APPLEPAY);
+           return components? !components.includes(FUNDING.APPLEPAY): true;
         },
 
         platforms: [

--- a/src/funding/applepay/config.jsx
+++ b/src/funding/applepay/config.jsx
@@ -22,7 +22,7 @@ export function getApplePayConfig() : FundingSourceConfig {
             /** If the JS SDK Script Includes Standalone ApplePay Component the Exclude the ApplePay Button From the Vertical Stack 
              * https://paypal.atlassian.net/browse/DTALTPAY-1232
             */
-           return components? !components.includes(FUNDING.APPLEPAY): true;
+           return !components?.includes(FUNDING.APPLEPAY);
         },
 
         platforms: [

--- a/src/funding/applepay/config.jsx
+++ b/src/funding/applepay/config.jsx
@@ -3,6 +3,7 @@
 
 import { PLATFORM } from '@paypal/sdk-constants/src';
 import { ApplePayLogo, LOGO_COLOR } from '@paypal/sdk-logos/src';
+import { FUNDING } from '@paypal/sdk-constants/src';
 
 import { BUTTON_COLOR, BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
@@ -17,6 +18,12 @@ export function getApplePayConfig() : FundingSourceConfig {
             return {
                 applepay: true
             };
+        },
+        eligible: ({components}) => {
+            /** If the JS SDK Script Includes Standalone ApplePay Component the Exclude the ApplePay Button From the Vertical Stack 
+             * https://paypal.atlassian.net/browse/DTALTPAY-1232
+            */
+           return !components.includes(FUNDING.APPLEPAY);
         },
 
         platforms: [

--- a/test/integration/tests/funding/applepay/index.js
+++ b/test/integration/tests/funding/applepay/index.js
@@ -1,0 +1,92 @@
+/* @flow */
+/* eslint max-lines: 0 */
+
+import { FUNDING } from '@paypal/sdk-constants/src';
+import { wrapPromise } from '@krakenjs/belter/src';
+
+import { createTestContainer, destroyTestContainer, IPHONE6_USER_AGENT, mockProp, assert, getElementRecursive } from '../../common';
+
+describe(`applepay standalone buttons`, () => {
+
+    beforeEach(() => {
+        createTestContainer();
+    });
+
+    afterEach(() => {
+        destroyTestContainer();
+    });
+
+    const fundingSource = FUNDING.APPLEPAY
+
+        it(`should render a standalone ${ fundingSource } button and succeed when eligible`, () => {
+            return wrapPromise(({ expect }) => {    
+                    window.navigator.mockUserAgent = IPHONE6_USER_AGENT;
+                    window.ApplePaySession = {
+                        canMakePayments: () => true,
+                        supportsVersion: () => true
+                    };
+                const mockEligibility = mockProp(window.__TEST_FUNDING_ELIGIBILITY__[fundingSource], 'eligible', true);
+                window.__COMPONENTS__ = [ 'buttons' , 'legal' ];
+                const button = window.paypal.Buttons({
+                    test: {
+                        onRender: expect('onRender', ({ fundingSources }) => {
+                            if (fundingSources.length !== 1) {
+                                throw new Error(`Expected only one funding source to be rendered, got ${ fundingSources.length }`);
+                            }
+
+                            if (fundingSources[0] !== fundingSource) {
+                                throw new Error(`Expected rendered funding source to be ${ fundingSource }, got ${ fundingSources[0] }`);
+                            }
+
+                            mockEligibility.cancel();
+                        })
+                    },
+
+                    fundingSource
+
+                });
+
+                if (!button.isEligible()) {
+                    throw new Error(`Expected button to be eligible`);
+                }
+
+                return button.render('#testContainer').then(() => {
+                    assert.ok(getElementRecursive('.paypal-button-label-container'), 'The ApplePay Button Should Exist');
+                    assert.equal(getElementRecursive('.paypal-button').getAttribute('aria-label'), 'applepay');
+                });;
+            });
+        });
+
+        it(`should not render ${ fundingSource } button when applepay standalone applepay component is requested as part of components`, (done) => {
+            return wrapPromise(({ expect }) => {    
+                    window.navigator.mockUserAgent = IPHONE6_USER_AGENT;
+                    window.ApplePaySession = {
+                        canMakePayments: () => true,
+                        supportsVersion: () => true
+                    };
+                const mockEligibility = mockProp(window.__TEST_FUNDING_ELIGIBILITY__[fundingSource], 'eligible', true);
+                window.__COMPONENTS__ = [ 'buttons' , 'applepay' ];
+                const button = window.paypal.Buttons({
+                    test: {
+                        onRender: expect('onRender', ({ fundingSources }) => {
+                            if (fundingSources.length !== 1) {
+                                throw new Error(`Expected only one funding source to be rendered, got ${ fundingSources.length }`);
+                            }
+
+                            if (fundingSources[0] !== fundingSource) {
+                                throw new Error(`Expected rendered funding source to be ${ fundingSource }, got ${ fundingSources[0] }`);
+                            }
+
+                            mockEligibility.cancel();
+                        })
+                    },
+
+                    fundingSource
+
+                });
+
+                assert.equal(button.isEligible(), false , 'The ApplePay Button is ineligible when standalone applepay component is requested');
+                done();
+            });
+        });
+});

--- a/test/integration/tests/index.js
+++ b/test/integration/tests/index.js
@@ -8,4 +8,5 @@ import './fields';
 import './payment-fields';
 import './security';
 import './funding/paylater';
+import './funding/applepay';
 import './funding/venmo';


### PR DESCRIPTION
### Description

When the Merchant is requesting for [standalone applepay component ](https://github.com/paypal/paypal-applepay-components) as  `components=buttons,applepay`

```
https://www.paypal.com/sdk/js?client-id=ATq4kPMhjTp6qrUQybY0SSz6Es1sO0YDF9f67rt2e-dZx36hHGbV1U9Ek3QRwcHcyyBlHXysRr-uXg18&merchant-id=8THX48SJBD4LU&debug=true&components=buttons,applepay
```
We should not show both the buttons. We have to Supress the ApplePay from SPB / Vertical Stack 

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

The Below Screenshots showcase Both SPB and Standalone Integration in a Single Page

**Before Change**
![image](https://user-images.githubusercontent.com/9788837/211678376-7b07eaa9-56c6-478e-a22b-b084defdccb2.png)



**After Change**
![image](https://user-images.githubusercontent.com/9788837/211677767-6df81432-cf7f-416c-af0d-d70dd3aaaa46.png)



### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
