### PR TITLE
tweaks for save action

### DIFF
--- a/__sdk__.js
+++ b/__sdk__.js
@@ -48,6 +48,7 @@ const SMART_CARDS = [
 
 module.exports = {
     'actions': {
+        automatic: true,
         entry:          './src/interface/actions',
     },
     'buttons': {

--- a/src/interface/actions.js
+++ b/src/interface/actions.js
@@ -1,15 +1,8 @@
 /* @flow */
 
-import { isPayPalDomain } from "@paypal/sdk-client/src";
-
 import type { LazyProtectedExport } from "../types";
 import { createSaveAction, type CreateSaveAction } from "../actions/save";
-
-function protectedExport<T>(xport: T): ?T {
-  if (isPayPalDomain()) {
-    return xport;
-  }
-}
+import {protectedExport} from '../lib'
 
 export const actions: LazyProtectedExport<{|
   Save: CreateSaveAction,


### PR DESCRIPTION
1st fix: without `automatic: true` in the `__sdk__.js` file, a merchant dev would have to specify the component to put `actions.Save` on the `paypal` window object. We don't want that, we want actions to be included automatically.

2nd fix: we made a helper for `protectedExport`, using that instead of re-defining it.