### PR TITLE
add demo page for PayPal on File

### DIFF
--- a/demo/dev/ppof.htm
+++ b/demo/dev/ppof.htm
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script src="https://localhost.paypal.com:9001/sdk.js?client-id=BC123&currency=USD"></script>
+</head>
+<body>
+    <div id="button"></div>
+    <script>
+         
+        paypal.Buttons({
+            fundingSource: 'paypal',
+            fundingEligibility: {
+                paypal: {
+                    eligible: true
+                },
+            },
+            wallet: {
+                paypal: {
+                    instruments: [
+                        {
+                            accessToken: null,
+                            instrumentID: 'abc12345',
+                            label: '••1234',
+                            logoUrl: null,
+                            oneClick: true,
+                            planID: null,
+                            secondaryInstruments: [{
+                                instrumentID: "BALANCEUSD",
+                                label: "PayPal Balance",
+                                type: "BALANCE"
+                            }],
+                            tokenID: null,
+                            type:    'bank',
+                            vendor:  'BANK OF AMERICA'
+                        }
+                    ]
+                }
+            },
+            button: {
+                showPayLabel: false
+            }
+        }).render('#button')
+    </script>
+</body>
+</html>


### PR DESCRIPTION
### Description

This PR adds a UI-only demo for PPOF.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

I wanted a way to demo the PPOF styles without going through the click -> auth -> onSmartWalletEligible callback flow

### Reproduction Steps (if applicable)

```
npm run dev
```

Visit https://localhost.paypal.com:9001/demo/dev/ppof.htm

### Screenshots (if applicable)

This demo shows the bank label before the second render.

https://user-images.githubusercontent.com/3824954/214304316-e4434116-cf01-42b9-8a54-5be975cc9ada.mov

### Dependent Changes (if applicable)

n/a

### Groups who should review (if applicable)

### TODO

- How do I prevent the second render from removing the bank label?


❤️  Thank you!
