### PR TITLE
chore: create logo experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@paypal/funding-components": "^1.0.30",
     "@paypal/sdk-client": "^4.0.166",
     "@paypal/sdk-constants": "^1.0.127",
-    "@paypal/sdk-logos": "^2.0.2"
+    "@paypal/sdk-logos": "^2.2.3"
   },
   "lint-staged": {
     "*.sh": "prettier --write"

--- a/src/funding/applepay/config.jsx
+++ b/src/funding/applepay/config.jsx
@@ -5,6 +5,7 @@ import { PLATFORM, FUNDING } from '@paypal/sdk-constants/src';
 import { ApplePayLogo, LOGO_COLOR } from '@paypal/sdk-logos/src';
 
 import { BUTTON_COLOR, BUTTON_LAYOUT } from '../../constants';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
 
 import { Mark } from './template';
@@ -35,7 +36,7 @@ export function getApplePayConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => ApplePayLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(ApplePayLogo, { logoColor, optional }),
         Mark: ({ ...props }) => Mark({ ...props }),
 
         colors: [

--- a/src/funding/applepay/template.jsx
+++ b/src/funding/applepay/template.jsx
@@ -4,12 +4,14 @@
 import { node, Style, type ChildType } from '@krakenjs/jsx-pragmatic/src';
 import { ApplePayMark } from '@paypal/sdk-logos/src';
 
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
+
 import css from './style.scoped.scss';
 
 export function Mark({ ...props } : {||}) : ChildType {
     return (
         <Style css={ css }>
-            <ApplePayMark { ...props } />
+            {enableLogoCDNExperiment(ApplePayMark,  props )}
         </Style>
     );
 }

--- a/src/funding/bancontact/config.jsx
+++ b/src/funding/bancontact/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getBancontactConfig() : FundingSourceConfig {
     return {
@@ -18,7 +19,7 @@ export function getBancontactConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => BancontactLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(BancontactLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/blik/config.jsx
+++ b/src/funding/blik/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getBlikConfig() : FundingSourceConfig {
     return {
@@ -18,7 +19,7 @@ export function getBlikConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => BlikLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(BlikLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/boleto/config.jsx
+++ b/src/funding/boleto/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getBoletoConfig() : FundingSourceConfig {
     return {
@@ -20,7 +21,7 @@ export function getBoletoConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => BoletoLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(BoletoLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/card/amex/config.js
+++ b/src/funding/card/amex/config.js
@@ -3,10 +3,11 @@
 import { AmexLogo } from '@paypal/sdk-logos/src';
 
 import type { CardConfig } from '../../common';
+import { enableLogoCDNExperiment } from '../../../lib/getLogoCDNExperiment';
 
 export function getAmexConfig() : CardConfig {
     return {
-        Label: AmexLogo
+        Label: () => enableLogoCDNExperiment(AmexLogo)
     };
 }
 

--- a/src/funding/card/config.jsx
+++ b/src/funding/card/config.jsx
@@ -10,6 +10,7 @@ import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig, type CardConfig } fro
 import { Text, Space } from '../../ui/text';
 import { isRTLLanguage } from '../../lib';
 import { WalletLabel } from '../paypal/template';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 import { getVisaConfig } from './visa';
 import { getMastercardConfig } from './mastercard';
@@ -116,9 +117,8 @@ export function getCardConfig() : FundingSourceConfig {
         },
 
         Logo: ({ logoColor }) => {
-            return (
-                <GlyphCard logoColor={ logoColor } />
-            );
+          // $FlowFixMe
+            return enableLogoCDNExperiment(GlyphCard, { logoColor });
         },
 
         Label: ({ logo, locale, content, custom }) => {

--- a/src/funding/card/config.jsx
+++ b/src/funding/card/config.jsx
@@ -117,7 +117,6 @@ export function getCardConfig() : FundingSourceConfig {
         },
 
         Logo: ({ logoColor }) => {
-          // $FlowFixMe
             return enableLogoCDNExperiment(GlyphCard, { logoColor });
         },
 

--- a/src/funding/card/discover/config.js
+++ b/src/funding/card/discover/config.js
@@ -3,9 +3,10 @@
 import { DiscoverLogo } from '@paypal/sdk-logos/src';
 
 import type { CardConfig } from '../../common';
+import { enableLogoCDNExperiment } from '../../../lib/getLogoCDNExperiment';
 
 export function getDiscoverConfig() : CardConfig {
     return {
-        Label: DiscoverLogo
+        Label: () => enableLogoCDNExperiment(DiscoverLogo)
     };
 }

--- a/src/funding/card/elo/config.js
+++ b/src/funding/card/elo/config.js
@@ -3,9 +3,10 @@
 import { EloLogo } from '@paypal/sdk-logos/src';
 
 import type { CardConfig } from '../../common';
+import { enableLogoCDNExperiment } from '../../../lib/getLogoCDNExperiment';
 
 export function getEloConfig() : CardConfig {
     return {
-        Label: EloLogo
+        Label: () => enableLogoCDNExperiment(EloLogo)
     };
 }

--- a/src/funding/card/hiper/config.js
+++ b/src/funding/card/hiper/config.js
@@ -3,9 +3,10 @@
 import { HiperLogo } from '@paypal/sdk-logos/src';
 
 import type { CardConfig } from '../../common';
+import { enableLogoCDNExperiment } from '../../../lib/getLogoCDNExperiment';
 
 export function getHiperConfig() : CardConfig {
     return {
-        Label: HiperLogo
+        Label: () => enableLogoCDNExperiment(HiperLogo)
     };
 }

--- a/src/funding/card/jcb/config.js
+++ b/src/funding/card/jcb/config.js
@@ -3,9 +3,10 @@
 import { JcbLogo } from '@paypal/sdk-logos/src';
 
 import type { CardConfig } from '../../common';
+import { enableLogoCDNExperiment } from '../../../lib/getLogoCDNExperiment';
 
 export function getJCBConfig() : CardConfig {
     return {
-        Label: JcbLogo
+        Label: () => enableLogoCDNExperiment(JcbLogo)
     };
 }

--- a/src/funding/card/mastercard/config.js
+++ b/src/funding/card/mastercard/config.js
@@ -3,9 +3,10 @@
 import { MastercardLogo } from '@paypal/sdk-logos/src';
 
 import type { CardConfig } from '../../common';
+import { enableLogoCDNExperiment } from '../../../lib/getLogoCDNExperiment';
 
 export function getMastercardConfig() : CardConfig {
     return {
-        Label: MastercardLogo
+        Label: () => enableLogoCDNExperiment(MastercardLogo)
     };
 }

--- a/src/funding/card/visa/config.js
+++ b/src/funding/card/visa/config.js
@@ -3,9 +3,10 @@
 import { VisaLogo } from '@paypal/sdk-logos/src';
 
 import type { CardConfig } from '../../common';
+import { enableLogoCDNExperiment } from '../../../lib/getLogoCDNExperiment';
 
 export function getVisaConfig() : CardConfig {
     return {
-        Label: VisaLogo
+        Label: () => enableLogoCDNExperiment(VisaLogo)
     };
 }

--- a/src/funding/credit/config.jsx
+++ b/src/funding/credit/config.jsx
@@ -28,7 +28,6 @@ export function getCreditConfig() : FundingSourceConfig {
 
         Logo: ({ locale, logoColor }) => {
             if (locale.country === COUNTRY.DE) {
-                // $FlowFixMe
                 return enableLogoCDNExperiment(CreditLogo, { locale, logoColor });
             }
     
@@ -41,7 +40,6 @@ export function getCreditConfig() : FundingSourceConfig {
                         <Space />
                     </span>
                     {
-                        // $FlowFixMe
                         enableLogoCDNExperiment(CreditLogo, { locale, logoColor })
                     }
                 </Fragment>

--- a/src/funding/credit/config.jsx
+++ b/src/funding/credit/config.jsx
@@ -9,6 +9,7 @@ import { BUTTON_COLOR, BUTTON_LAYOUT, DEFAULT, BUTTON_FLOW } from '../../constan
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
 import { Space } from '../../ui/text';
 import { WalletLabel } from '../paypal/template';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getCreditConfig() : FundingSourceConfig {
     return {
@@ -27,18 +28,22 @@ export function getCreditConfig() : FundingSourceConfig {
 
         Logo: ({ locale, logoColor }) => {
             if (locale.country === COUNTRY.DE) {
-                return <CreditLogo logoColor={ logoColor } locale={ locale } />;
+                // $FlowFixMe
+                return enableLogoCDNExperiment(CreditLogo, { locale, logoColor });
             }
     
             return (
                 <Fragment>
-                    <PPLogo logoColor={ logoColor } />
+                    {enableLogoCDNExperiment(PPLogo, { logoColor })}
                     <Space />
                     <span optional>
-                        <PayPalLogo logoColor={ logoColor } />
+                    {enableLogoCDNExperiment(PayPalLogo, { logoColor }) }
                         <Space />
                     </span>
-                    <CreditLogo logoColor={ logoColor } locale={ locale } />
+                    {
+                        // $FlowFixMe
+                        enableLogoCDNExperiment(CreditLogo, { locale, logoColor })
+                    }
                 </Fragment>
             );
         },

--- a/src/funding/eps/config.jsx
+++ b/src/funding/eps/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getEpsConfig() : FundingSourceConfig {
     return {
@@ -18,7 +19,7 @@ export function getEpsConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => EpsLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(EpsLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/giropay/config.jsx
+++ b/src/funding/giropay/config.jsx
@@ -8,6 +8,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getGiropayConfig() : FundingSourceConfig {
     return {
@@ -19,7 +20,7 @@ export function getGiropayConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
     
-        Logo: ({ logoColor, optional }) => GiropayLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(GiropayLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/ideal/config.jsx
+++ b/src/funding/ideal/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { getLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getIdealConfig() : FundingSourceConfig {
     return {
@@ -18,7 +19,16 @@ export function getIdealConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => IdealLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => {
+          if (__WEB__) {
+            const logoCDNExperiment = getLogoCDNExperiment();
+            const loadFromCDN = logoCDNExperiment.isEnabled()
+
+            return IdealLogo({ logoColor, optional, loadFromCDN })
+          }
+          
+          return IdealLogo({ logoColor, optional })
+        },
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/ideal/config.jsx
+++ b/src/funding/ideal/config.jsx
@@ -7,7 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
-import { getLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getIdealConfig() : FundingSourceConfig {
     return {
@@ -19,16 +19,7 @@ export function getIdealConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => {
-          if (__WEB__) {
-            const logoCDNExperiment = getLogoCDNExperiment();
-            const loadFromCDN = logoCDNExperiment.isEnabled()
-
-            return IdealLogo({ logoColor, optional, loadFromCDN })
-          }
-          
-          return IdealLogo({ logoColor, optional })
-        },
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(IdealLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/itau/config.jsx
+++ b/src/funding/itau/config.jsx
@@ -5,6 +5,7 @@
 import { ItauLogo, LOGO_COLOR } from '@paypal/sdk-logos/src';
 
 import { BUTTON_COLOR, BUTTON_LAYOUT, DEFAULT } from '../../constants';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
 
 export function getItauConfig() : FundingSourceConfig {
@@ -16,7 +17,7 @@ export function getItauConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => ItauLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(ItauLogo, { logoColor, optional }),
 
         colors: [
             BUTTON_COLOR.DARKBLUE,

--- a/src/funding/maxima/config.jsx
+++ b/src/funding/maxima/config.jsx
@@ -4,6 +4,7 @@
 import { MaximaLogo } from '@paypal/sdk-logos/src';
 
 import { BUTTON_COLOR, BUTTON_LAYOUT } from '../../constants';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
 
 export function getMaximaConfig() : FundingSourceConfig {
@@ -16,7 +17,7 @@ export function getMaximaConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => MaximaLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(MaximaLogo, { logoColor, optional }),
 
         colors: [
             BUTTON_COLOR.DEFAULT,

--- a/src/funding/mercadopago/config.jsx
+++ b/src/funding/mercadopago/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getMercadopagoConfig() : FundingSourceConfig {
     return {
@@ -18,7 +19,7 @@ export function getMercadopagoConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => MercadoPagoLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(MercadoPagoLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/multibanco/config.jsx
+++ b/src/funding/multibanco/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getMultibancoConfig() : FundingSourceConfig {
     return {
@@ -20,7 +21,7 @@ export function getMultibancoConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => MultibancoLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(MultibancoLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/mybank/config.jsx
+++ b/src/funding/mybank/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getMybankConfig() : FundingSourceConfig {
     return {
@@ -18,7 +19,7 @@ export function getMybankConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
     
-        Logo: ({ logoColor, optional }) => MybankLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(MybankLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/oxxo/config.jsx
+++ b/src/funding/oxxo/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getOxxoConfig() : FundingSourceConfig {
     return {
@@ -20,7 +21,7 @@ export function getOxxoConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => OxxoLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(OxxoLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/p24/config.jsx
+++ b/src/funding/p24/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getP24Config() : FundingSourceConfig {
     return {
@@ -18,7 +19,7 @@ export function getP24Config() : FundingSourceConfig {
 
         shippingChange: false,
     
-        Logo: ({ logoColor, optional }) => P24Logo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(P24Logo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/paylater/config.jsx
+++ b/src/funding/paylater/config.jsx
@@ -9,6 +9,7 @@ import { PPLogo, LOGO_COLOR } from '@paypal/sdk-logos/src';
 import { BUTTON_COLOR, BUTTON_LAYOUT, DEFAULT } from '../../constants';
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 import css from './style.scoped.scss';
 
@@ -77,7 +78,7 @@ export function getPaylaterConfig() : FundingSourceConfig {
         Logo: ({ logoColor, nonce, fundingEligibility }) => {
             return (
                 <Style css={ css } nonce={ nonce }>
-                    <PPLogo logoColor={ logoColor } />
+                    {enableLogoCDNExperiment(PPLogo, { logoColor })}
                     <Space />
                     <Text>{ getLabelText(fundingEligibility) || 'Pay Later' }</Text>
                 </Style>

--- a/src/funding/paypal/template.jsx
+++ b/src/funding/paypal/template.jsx
@@ -337,7 +337,6 @@ export function WalletLabel(opts : WalletLabelOptions) : ?ChildType {
         if (instrument.type === WALLET_INSTRUMENT.CARD && instrument.label) {
             logo = instrument.logoUrl
                 ? <img class='card-art' src={ instrument.logoUrl } />
-                // $FlowFixMe
                 : enableLogoCDNExperiment(GlyphCard, { logoColor });
 
             label = instrument.label.replace('••••', '••');
@@ -350,13 +349,11 @@ export function WalletLabel(opts : WalletLabelOptions) : ?ChildType {
             label = instrument.label.replace('••••', '••');
 
         } else if (instrument.type === WALLET_INSTRUMENT.CREDIT) {
-            // $FlowFixMe
             logo = enableLogoCDNExperiment(CreditMark, {});
 
             label = content && content.credit;
 
         } else if (instrument.type === WALLET_INSTRUMENT.BALANCE) {
-            // $FlowFixMe
             logo = enableLogoCDNExperiment(PayPalMark, {});
 
             label = content && content.balance;

--- a/src/funding/paypal/template.jsx
+++ b/src/funding/paypal/template.jsx
@@ -18,13 +18,12 @@ import { componentContent } from '../content';
 import { Text, Space, PlaceHolder } from '../../ui/text';
 import { TrackingBeacon } from '../../ui/tracking';
 import { HIDDEN, VISIBLE, COMPRESSED, EXPANDED } from '../../ui/buttons/styles/labels';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 import css from './style.scoped.scss';
 
 export function Logo({ logoColor } : LogoOptions) : ChildType {
-    return (
-        <PayPalLogo logoColor={ logoColor } />
-    );
+    return enableLogoCDNExperiment(PayPalLogo, { logoColor })
 }
 
 function getPersonalizationText({ personalization, layout, multiple } : LabelOptions) : ?string {
@@ -192,18 +191,20 @@ export function WalletLabelOld(opts : WalletLabelOptions) : ?ChildType {
     if (instrument.logoUrl) {
         logo = <img class='card-art' src={ instrument.logoUrl } />;
     } else if (instrument.type === WALLET_INSTRUMENT.CARD) {
-        logo = <GlyphCard logoColor={ logoColor } />;
+      // $FlowFixMe
+        logo = enableLogoCDNExperiment(GlyphCard, { logoColor });
     } else if (instrument.type === WALLET_INSTRUMENT.BANK) {
-        logo = <GlyphBank logoColor={ logoColor } />;
+        logo = enableLogoCDNExperiment(GlyphBank, { logoColor });
     } else if (instrument.type === WALLET_INSTRUMENT.CREDIT) {
-        logo = <CreditLogo locale={ locale } logoColor={ logoColor } />;
+      // $FlowFixMe
+        logo = enableLogoCDNExperiment(CreditLogo, { locale, logoColor });
     }
 
     return (
         <Style css={ css }>
             <div class='wallet-label'>
                 <div class='paypal-mark'>
-                    <PPLogo logoColor={ logoColor } />
+                    {enableLogoCDNExperiment(PPLogo ,{ logoColor })}
                 </div>
                 {
                     (instrument.oneClick && commit && content) &&
@@ -214,7 +215,7 @@ export function WalletLabelOld(opts : WalletLabelOptions) : ?ChildType {
                 }
                 <div class='paypal-wordmark'>
                     <Space />
-                    <PayPalLogo logoColor={ logoColor } />
+                    {enableLogoCDNExperiment(PayPalLogo ,{ logoColor })}
                 </div>
                 <div class='divider'>|</div>
                 {
@@ -338,24 +339,27 @@ export function WalletLabel(opts : WalletLabelOptions) : ?ChildType {
         if (instrument.type === WALLET_INSTRUMENT.CARD && instrument.label) {
             logo = instrument.logoUrl
                 ? <img class='card-art' src={ instrument.logoUrl } />
-                : <GlyphCard logoColor={ logoColor } />;
+                // $FlowFixMe
+                : enableLogoCDNExperiment(GlyphCard, { logoColor });
 
             label = instrument.label.replace('••••', '••');
 
         } else if (instrument.type === WALLET_INSTRUMENT.BANK && instrument.label) {
             logo = instrument.logoUrl
                 ? <img class='card-art' src={ instrument.logoUrl } />
-                : <GlyphBank logoColor={ logoColor } />;
+                : enableLogoCDNExperiment(GlyphBank, { logoColor });
 
             label = instrument.label.replace('••••', '••');
 
         } else if (instrument.type === WALLET_INSTRUMENT.CREDIT) {
-            logo = <CreditMark />;
+            // $FlowFixMe
+            logo = enableLogoCDNExperiment(CreditMark, {});
 
             label = content && content.credit;
 
         } else if (instrument.type === WALLET_INSTRUMENT.BALANCE) {
-            logo = <PayPalMark />;
+            // $FlowFixMe
+            logo = enableLogoCDNExperiment(PayPalMark, {});
 
             label = content && content.balance;
 
@@ -378,7 +382,7 @@ export function WalletLabel(opts : WalletLabelOptions) : ?ChildType {
                     branded
                         ? (
                             <div class='paypal-mark'>
-                                <PPLogo logoColor={ logoColor } />
+                                { enableLogoCDNExperiment(PPLogo, { logoColor }) }
                                 <Space />
                             </div>
                         )

--- a/src/funding/paypal/template.jsx
+++ b/src/funding/paypal/template.jsx
@@ -191,12 +191,10 @@ export function WalletLabelOld(opts : WalletLabelOptions) : ?ChildType {
     if (instrument.logoUrl) {
         logo = <img class='card-art' src={ instrument.logoUrl } />;
     } else if (instrument.type === WALLET_INSTRUMENT.CARD) {
-      // $FlowFixMe
         logo = enableLogoCDNExperiment(GlyphCard, { logoColor });
     } else if (instrument.type === WALLET_INSTRUMENT.BANK) {
         logo = enableLogoCDNExperiment(GlyphBank, { logoColor });
     } else if (instrument.type === WALLET_INSTRUMENT.CREDIT) {
-      // $FlowFixMe
         logo = enableLogoCDNExperiment(CreditLogo, { locale, logoColor });
     }
 

--- a/src/funding/payu/config.jsx
+++ b/src/funding/payu/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel} from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getPayuConfig() : FundingSourceConfig {
     return {
@@ -20,7 +21,7 @@ export function getPayuConfig() : FundingSourceConfig {
 
         shippingChange: false,
     
-        Logo: ({ logoColor, optional }) => PayuLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(PayuLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/satispay/config.jsx
+++ b/src/funding/satispay/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getSatispayConfig() : FundingSourceConfig {
     return {
@@ -20,7 +21,7 @@ export function getSatispayConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
     
-        Logo: ({ logoColor, optional }) => SatispayLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(SatispayLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/sepa/config.jsx
+++ b/src/funding/sepa/config.jsx
@@ -4,6 +4,7 @@
 import { SepaLogo } from '@paypal/sdk-logos/src';
 
 import { BUTTON_LAYOUT } from '../../constants';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
 
 export function getSepaConfig() : FundingSourceConfig {
@@ -14,6 +15,6 @@ export function getSepaConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
     
-        Logo: ({ logoColor, optional }) => SepaLogo({ logoColor, optional })
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(SepaLogo, { logoColor, optional })
     };
 }

--- a/src/funding/sofort/config.jsx
+++ b/src/funding/sofort/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getSofortConfig() : FundingSourceConfig {
     return {
@@ -18,7 +19,7 @@ export function getSofortConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
     
-        Logo: ({ logoColor, optional }) => SofortLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(SofortLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/trustly/config.jsx
+++ b/src/funding/trustly/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getTrustlyConfig() : FundingSourceConfig {
     return {
@@ -20,7 +21,7 @@ export function getTrustlyConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => TrustlyLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(TrustlyLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/venmo/config.jsx
+++ b/src/funding/venmo/config.jsx
@@ -6,9 +6,10 @@ import { PLATFORM } from '@paypal/sdk-constants/src';
 
 import { BUTTON_COLOR, BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 import { WalletLabel, Label, AppLabel } from './template';
-import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
+
 
 export function getVenmoConfig() : FundingSourceConfig {
     return {

--- a/src/funding/venmo/config.jsx
+++ b/src/funding/venmo/config.jsx
@@ -8,6 +8,7 @@ import { BUTTON_COLOR, BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
 
 import { WalletLabel, Label, AppLabel } from './template';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getVenmoConfig() : FundingSourceConfig {
     return {
@@ -39,7 +40,7 @@ export function getVenmoConfig() : FundingSourceConfig {
             return {};
         },
 
-        Logo:  ({ logoColor, optional }) => VenmoLogo({ logoColor, optional }),
+        Logo:  ({ logoColor, optional }) => enableLogoCDNExperiment(VenmoLogo, { logoColor, optional }),
         
         Label: ({ ...props }) => {
             if (props.experiment && props.experiment.enableVenmoAppLabel) {

--- a/src/funding/venmo/template.jsx
+++ b/src/funding/venmo/template.jsx
@@ -9,6 +9,7 @@ import {
     BasicLabel
 } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 import css from './style.scoped.scss';
  
@@ -17,7 +18,7 @@ export function AppLabel(opts : LabelOptions) : ChildType {
 
     const AppLogo : ChildType = (
         <Style css={ css }>
-            <VenmoLogo logoColor={ logoColor } />
+            {enableLogoCDNExperiment(VenmoLogo, { logoColor })}
             <Text className={ [ 'app-label' ] }>
                 App
             </Text>
@@ -38,7 +39,7 @@ export function Label(opts : LabelOptions) : ChildType {
 export function  WalletLabel({ ...props } : WalletLabelOptions) : ChildType {
     const { instrument, logoColor } = props;
     let label;
-    const logo =  <VenmoLogo logoColor={ logoColor } />;
+    const logo =  enableLogoCDNExperiment(VenmoLogo, { logoColor });
 
     if (instrument && instrument.label) {
         label = instrument.label;

--- a/src/funding/verkkopankki/config.jsx
+++ b/src/funding/verkkopankki/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getVerkkopankkiConfig() : FundingSourceConfig {
     return {
@@ -20,7 +21,7 @@ export function getVerkkopankkiConfig() : FundingSourceConfig {
 
         shippingChange: false,
     
-        Logo: ({ logoColor, optional }) => VerkkopankkiLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(VerkkopankkiLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/wechatpay/config.jsx
+++ b/src/funding/wechatpay/config.jsx
@@ -7,6 +7,7 @@ import { Fragment, node } from '@krakenjs/jsx-pragmatic/src';
 import { BUTTON_LAYOUT } from '../../constants';
 import { DEFAULT_APM_FUNDING_CONFIG, type FundingSourceConfig, BasicLabel } from '../common';
 import { Text, Space } from '../../ui/text';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 
 export function getWechatpayConfig() : FundingSourceConfig {
     return {
@@ -18,7 +19,7 @@ export function getWechatpayConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
     
-        Logo: ({ logoColor, optional }) => WechatpayLogo({ logoColor, optional }),
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(WechatpayLogo, { logoColor, optional }),
 
         Label: ({ logo, ...opts }) => {
             if (__WEB__) {

--- a/src/funding/zimpler/config.jsx
+++ b/src/funding/zimpler/config.jsx
@@ -4,6 +4,7 @@
 import { ZimplerLogo } from '@paypal/sdk-logos/src';
 
 import { BUTTON_LAYOUT } from '../../constants';
+import { enableLogoCDNExperiment } from '../../lib/getLogoCDNExperiment';
 import { DEFAULT_FUNDING_CONFIG, type FundingSourceConfig } from '../common';
 
 export function getZimplerConfig() : FundingSourceConfig {
@@ -16,6 +17,6 @@ export function getZimplerConfig() : FundingSourceConfig {
             BUTTON_LAYOUT.VERTICAL
         ],
 
-        Logo: ({ logoColor, optional }) => ZimplerLogo({ logoColor, optional })
+        Logo: ({ logoColor, optional }) => enableLogoCDNExperiment(ZimplerLogo, { logoColor, optional })
     };
 }

--- a/src/lib/getLogoCDNExperiment.js
+++ b/src/lib/getLogoCDNExperiment.js
@@ -1,0 +1,8 @@
+/* @flow */
+
+import { createExperiment } from "@paypal/sdk-client/src";
+import type { Experiment } from "@krakenjs/belter/src";
+
+export function getLogoCDNExperiment(): Experiment {
+  return createExperiment("enable_logo_cdn", 50);
+}

--- a/src/lib/getLogoCDNExperiment.js
+++ b/src/lib/getLogoCDNExperiment.js
@@ -6,7 +6,7 @@ import type { ChildType } from "@krakenjs/jsx-pragmatic/src";
 import { LOGO_COLOR } from "@paypal/sdk-logos/src";
 
 export function getLogoCDNExperiment(): Experiment {
-  return createExperiment("enable_logo_cdn", 100);
+  return createExperiment("enable_logo_cdn", 0);
 }
 
 type LogoProps = {|

--- a/src/lib/getLogoCDNExperiment.js
+++ b/src/lib/getLogoCDNExperiment.js
@@ -4,5 +4,5 @@ import { createExperiment } from "@paypal/sdk-client/src";
 import type { Experiment } from "@krakenjs/belter/src";
 
 export function getLogoCDNExperiment(): Experiment {
-  return createExperiment("enable_logo_cdn", 50);
+  return createExperiment("enable_logo_cdn", 0);
 }

--- a/src/lib/getLogoCDNExperiment.js
+++ b/src/lib/getLogoCDNExperiment.js
@@ -4,14 +4,16 @@ import { createExperiment } from "@paypal/sdk-client/src";
 import type { Experiment } from "@krakenjs/belter/src";
 import type { ChildType } from "@krakenjs/jsx-pragmatic/src";
 import { LOGO_COLOR } from "@paypal/sdk-logos/src";
+import type { LocaleType } from "@paypal/sdk-constants/src";
 
 export function getLogoCDNExperiment(): Experiment {
-  return createExperiment("enable_logo_cdn", 0);
+  return createExperiment("enable_logo_cdn", 100);
 }
 
 type LogoProps = {|
   logoColor?: $Values<typeof LOGO_COLOR>,
-  optional: void | boolean,
+  optional?: void | boolean,
+  locale?: LocaleType,
   loadFromCDN?: boolean,
 |};
 
@@ -19,6 +21,7 @@ export function enableLogoCDNExperiment(
   logo: (LogoProps) => ChildType,
   logoOptions: LogoProps
 ): ChildType {
+  // enable logo CDN experiment for first render only
   if (__WEB__) {
     const logoCDNExperiment = getLogoCDNExperiment();
     const loadFromCDN = logoCDNExperiment.isEnabled();
@@ -26,5 +29,6 @@ export function enableLogoCDNExperiment(
     return logo({ ...logoOptions, loadFromCDN });
   }
 
+  // continue using inline svg for second render
   return logo(logoOptions);
 }

--- a/src/lib/getLogoCDNExperiment.js
+++ b/src/lib/getLogoCDNExperiment.js
@@ -5,7 +5,7 @@ import type { Experiment } from "@krakenjs/belter/src";
 import type { ChildType } from "@krakenjs/jsx-pragmatic/src";
 
 export function getLogoCDNExperiment(): Experiment {
-  return createExperiment("enable_logo_cdn", 100);
+  return createExperiment("enable_logo_cdn_experiment", 0);
 }
 
 export function enableLogoCDNExperiment<T>(

--- a/src/lib/getLogoCDNExperiment.js
+++ b/src/lib/getLogoCDNExperiment.js
@@ -2,7 +2,29 @@
 
 import { createExperiment } from "@paypal/sdk-client/src";
 import type { Experiment } from "@krakenjs/belter/src";
+import type { ChildType } from "@krakenjs/jsx-pragmatic/src";
+import { LOGO_COLOR } from "@paypal/sdk-logos/src";
 
 export function getLogoCDNExperiment(): Experiment {
-  return createExperiment("enable_logo_cdn", 0);
+  return createExperiment("enable_logo_cdn", 100);
+}
+
+type LogoProps = {|
+  logoColor?: $Values<typeof LOGO_COLOR>,
+  optional: void | boolean,
+  loadFromCDN?: boolean,
+|};
+
+export function enableLogoCDNExperiment(
+  logo: (LogoProps) => ChildType,
+  logoOptions: LogoProps
+): ChildType {
+  if (__WEB__) {
+    const logoCDNExperiment = getLogoCDNExperiment();
+    const loadFromCDN = logoCDNExperiment.isEnabled();
+
+    return logo({ ...logoOptions, loadFromCDN });
+  }
+
+  return logo(logoOptions);
 }

--- a/src/lib/getLogoCDNExperiment.js
+++ b/src/lib/getLogoCDNExperiment.js
@@ -3,23 +3,14 @@
 import { createExperiment } from "@paypal/sdk-client/src";
 import type { Experiment } from "@krakenjs/belter/src";
 import type { ChildType } from "@krakenjs/jsx-pragmatic/src";
-import { LOGO_COLOR } from "@paypal/sdk-logos/src";
-import type { LocaleType } from "@paypal/sdk-constants/src";
 
 export function getLogoCDNExperiment(): Experiment {
   return createExperiment("enable_logo_cdn", 100);
 }
 
-type LogoProps = {|
-  logoColor?: $Values<typeof LOGO_COLOR>,
-  optional?: void | boolean,
-  locale?: LocaleType,
-  loadFromCDN?: boolean,
-|};
-
-export function enableLogoCDNExperiment(
-  logo: (LogoProps) => ChildType,
-  logoOptions: LogoProps
+export function enableLogoCDNExperiment<T>(
+  logo: (T) => ChildType,
+  logoOptions: T
 ): ChildType {
   // enable logo CDN experiment for first render only
   if (__WEB__) {

--- a/test/integration/tests/button/cdn.js
+++ b/test/integration/tests/button/cdn.js
@@ -1,0 +1,82 @@
+/* @flow */
+/* eslint max-lines: 0 */
+
+import { createTestContainer, destroyTestContainer } from '../common';
+
+describe('Tests for button CDN rendering', () => {
+    beforeEach(() => {
+        createTestContainer();
+    });
+
+    afterEach(() => {
+        destroyTestContainer();
+    });
+
+    it('should render logo from CDN when experiment is active', (done) => {
+      window.localStorage.setItem('enable_logo_cdn_experiment', true);
+
+        window.paypal.Buttons({
+
+            style: {
+                shape:  'pill',
+                color:  'gold',
+                layout: 'vertical',
+                label:  'paypal'
+            },
+
+            test: {
+                onRender() {
+                    const frame = document.querySelector('#testContainer iframe');
+                    if (!frame) {
+                        throw new Error(`Cannot find frame`);
+                    }
+
+                    // $FlowFixMe
+                    const win = frame.contentWindow;
+                    const logoSVG = win.document.querySelector('.paypal-logo');
+
+                    if (!logoSVG.src.startsWith('https://www.paypalobjects.com')) {
+                      done(new Error('Logo should be loaded from CDN'));
+                    }
+                    done();
+                }
+            },
+
+            onError: done
+
+        }).render('#testContainer');
+    });
+
+    it('should not render logo from CDN when experiment is inactive', (done) => {
+        window.paypal.Buttons({
+
+            style: {
+                shape:  'pill',
+                color:  'gold',
+                layout: 'vertical',
+                label:  'paypal'
+            },
+
+            test: {
+                onRender() {
+                    const frame = document.querySelector('#testContainer iframe');
+                    if (!frame) {
+                        throw new Error(`Cannot find frame`);
+                    }
+
+                    // $FlowFixMe
+                    const win = frame.contentWindow;
+                    const logoSVG = win.document.querySelector('.paypal-logo');
+
+                    if (logoSVG.src.startsWith('https://www.paypalobjects.com')) {
+                      done(new Error('Logo should not be loaded from CDN'));
+                    }
+                    done();
+                }
+            },
+
+            onError: done
+
+        }).render('#testContainer');
+    });
+});

--- a/test/integration/tests/button/cdn.js
+++ b/test/integration/tests/button/cdn.js
@@ -17,13 +17,6 @@ describe('Tests for button CDN rendering', () => {
 
         window.paypal.Buttons({
 
-            style: {
-                shape:  'pill',
-                color:  'gold',
-                layout: 'vertical',
-                label:  'paypal'
-            },
-
             test: {
                 onRender() {
                     const frame = document.querySelector('#testContainer iframe');
@@ -49,13 +42,6 @@ describe('Tests for button CDN rendering', () => {
 
     it('should not render logo from CDN when experiment is inactive', (done) => {
         window.paypal.Buttons({
-
-            style: {
-                shape:  'pill',
-                color:  'gold',
-                layout: 'vertical',
-                label:  'paypal'
-            },
 
             test: {
                 onRender() {

--- a/test/integration/tests/button/index.js
+++ b/test/integration/tests/button/index.js
@@ -17,3 +17,4 @@ import './renderOrder';
 import './nonce';
 import './eligibility';
 import './animation';
+import './cdn';


### PR DESCRIPTION
### Description
DTPPSDK-1035
<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
Logic was added to `paypal-sdk-logos` in https://github.com/paypal/paypal-sdk-logos/pull/89 to allow for serving our logo SVGs from a CDN rather than as inline code.

This feature can be enabled in `paypal-checkout-components` by passing a prop to a logo component (`loadFromCDN = true`).  An experiment has been added to allow us to A/B test this new rendering behavior, and the experiment has been enabled on all logos and marks using a wrapper function (`enableLogoCDNExperiment `).  Additionally, a conditional statement has been added to `enableLogoCDNExperiment` to ensure that only first-render behavior is affected- we will continue to serve our logos as inline SVGs on second render.

### Screenshots (if applicable)
<img width="1622" alt="Screenshot 2023-02-07 at 5 35 22 PM" src="https://user-images.githubusercontent.com/69579929/217382323-60b82cd3-02aa-43c9-9b5b-c0cad0810121.png">

❤️  Thank you!
