### PR TITLE
chore: remove isInlineXOEligible log

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -686,15 +686,6 @@ export const getButtonsComponent : () => ButtonsComponent = memoize(() => {
                         vault
                     } });
 
-                    const logger = getLogger();
-
-                    logger
-                        .info('isInlineXOEligible props', { props: JSON.stringify(props) })
-                        .info('isInlineXOEligible eligible', { eligible: String(eligible) })
-                        .track({
-                            [ FPTI_KEY.TRANSITION ]: `inline_xo_eligibility_${ String(eligible) }`
-                        }).flush();
-
                     return eligible ? EXPERIENCE.INLINE : '';
                 }
             },


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
DTPPSDK-1087

Removed `isInlineXOEligible log` log from `zoid/buttons`.  This log is being duplicated due to the nature of prop value functions in Zoid, which are recalculated whenever properties change.
### Screenshots (if applicable)
<img width="1513" alt="Screen Shot 2023-02-10 at 12 47 52 PM" src="https://user-images.githubusercontent.com/69579929/218208951-4927f101-7574-4b4b-84ad-2515f743ee24.png">

❤️  Thank you!
