### PR TITLE
chore: pin version of percy cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@bunchtogether/vite-plugin-flow": "^1.0.2",
     "@krakenjs/grumbler-scripts": "^8.0.7",
     "@krakenjs/sync-browser-mocks": "^3.0.0",
-    "@percy/cli": "^1.16.0",
+    "@percy/cli": "1.18.0",
     "@percy/playwright": "^1.0.4",
     "@playwright/test": "^1.28.1",
     "babel-core": "^7.0.0-bridge.0",


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
Pinned version of `@percy/cli` to `1.18.0` due to an issue with versions `1.19.2` and higher, which is preventing screenshots from being captured properly.

Possibly related issue report: https://github.com/percy/cli/issues/1189

### Screenshots (if applicable)
<img width="1246" alt="Screenshot 2023-02-27 at 2 25 39 PM" src="https://user-images.githubusercontent.com/69579929/221663147-6fde177c-9ad9-44af-b9ff-980d75ed53d3.png">

❤️  Thank you!
