### PR TITLE
Adding onError callback for Hosted Card Fields.

### DIFF
--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -79,6 +79,7 @@ type CardFieldsProps = {|
     {| returnUrl: string |},
     {| redirect: (?CrossDomainWindowType, ?string) => ZalgoPromise<void> |}
   ) => ?ZalgoPromise<void>,
+  onError?: () => ZalgoPromise<Object> | Object,
   onComplete: (
     {| returnUrl: string |},
     {| redirect: (?CrossDomainWindowType, ?string) => ZalgoPromise<void> |}
@@ -254,6 +255,12 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
             type: "function",
             required: false,
             value: ({ props }) => props.parent.props.onApprove,
+          },
+
+          onError: {
+            type: "function",
+            required: false,
+            value: ({ props }) => props.parent.props.onError,
           },
 
           onComplete: {
@@ -535,6 +542,11 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
         },
 
         onApprove: {
+          type: "function",
+          required: false,
+        },
+
+        onError: {
           type: "function",
           required: false,
         },


### PR DESCRIPTION
### Description

This adds the `onError` callback as a property of the Hosted Card Fields component. This is needed for the error logging being added to paypal-smart-payment-buttons. See https://github.com/paypal/paypal-smart-payment-buttons/pull/558

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

Jira: [DTNOR-732](https://paypal.atlassian.net/browse/DTNOR-732)

### Groups who should review (if applicable)

@checkout-sdk
@js-sdk-maintainers

❤️ Thank you!
