### PR TITLE
removing save wrapper from vaultSetup

### DIFF
--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -75,8 +75,9 @@ type CardFieldsProps = {|
     onInputSubmitRequest?: () => ZalgoPromise<Object> | Object,
   |},
   createOrder: () => ZalgoPromise<string> | string,
+  createVaultSetupToken: () => ZalgoPromise<string>,
   onApprove: (
-    {| returnUrl: string |},
+    {| returnUrl?: string, vaultSetupToken?: string |},
     {| redirect: (?CrossDomainWindowType, ?string) => ZalgoPromise<void> |}
   ) => ?ZalgoPromise<void>,
   onComplete: (
@@ -92,10 +93,6 @@ type CardFieldsProps = {|
   hcfSessionID: string,
   partnerAttributionID: string,
   merchantID: $ReadOnlyArray<string>,
-  save: {|
-    createVaultSetupToken: () => ZalgoPromise<string>,
-    onApprove: ({| vaultSetupToken: string |}) => ?ZalgoPromise<void>,
-  |},
 |};
 
 type CardFieldProps = {|
@@ -223,6 +220,12 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
             type: "function",
             required: false,
             value: ({ props }) => props.parent.props.createOrder,
+          },
+
+          createVaultSetupToken: {
+            type: "function",
+            required: false,
+            value: ({ props }) => props.parent.props.createVaultSetupToken,
           },
 
           cardFieldsSessionID: {
@@ -505,6 +508,11 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
         },
 
         createOrder: {
+          type: "function",
+          required: false,
+        },
+
+        createVaultSetupToken: {
           type: "function",
           required: false,
         },

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -186,18 +186,6 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
         },
 
         props: {
-          save: {
-            type: "object",
-            required: false,
-            value: ({ props }) => {
-              if (props.save) {
-                return props.save;
-              } else if (props.parent.props) {
-                return props.parent.props.save;
-              }
-            },
-          },
-
           type: {
             type: "string",
             value: () => type,
@@ -483,11 +471,6 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
       },
 
       props: {
-        save: {
-          type: "object",
-          required: false,
-        },
-
         type: {
           type: "string",
           value: () => CARD_FIELD_TYPE.SINGLE,


### PR DESCRIPTION
### Description

Removing the save wrapper from hosted cardfields to use

```
paypal.CardFields({
  createVaultSetupToken: ...,
  onApprove: ...,
})
```

Instead of the current way

```
paypal.CardFields({
  save: {
    createVaultSetupToken: ...,
    onApprove: ...,
  }
})
```

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

https://paypal.atlassian.net/browse/DTNOR-868

❤️ Thank you!
