### PR TITLE
Vault without Purchase: add check for VwoP for wallet render

### DIFF
--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -232,7 +232,9 @@ export function Button({
 
   if (
     WalletLabel &&
-    (!showPayLabel || flow === BUTTON_FLOW.PURCHASE) &&
+    (!showPayLabel ||
+      flow === BUTTON_FLOW.PURCHASE ||
+      flow === BUTTON_FLOW.VAULT_WITHOUT_PURCHASE) &&
     (instrument ||
       (__WEB__ &&
         userIDToken &&


### PR DESCRIPTION
### Description
Adds `VAULT_WITHOUT_PURCHASE` as a flow that triggers rendering a vaulted funding instrument on the PayPal button.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
The PayPal button should display a vaulted funding instrument if it has one. Currently, that's only happening if the payment flow is `CHECKOUT`. This change adds `VAULT_WITHOUT_PURCHASE` as another flow that will display the vaulted funding instrument, which will allow the button to be useful on a page for managing vaulted payment methods.

❤️ Thank you!
