### PR TITLE
chore: remove __FUNDING_ELIGIBILITY__ global

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,6 @@ module.exports = {
     __HOST__: true,
     __PATH__: true,
     __COMPONENTS__: true,
-    __FUNDING_ELIGIBILITY__: true,
     __INLINE_CHECKOUT_ELIGIBILITY__: true,
   },
 

--- a/src/funding/card/config.jsx
+++ b/src/funding/card/config.jsx
@@ -33,62 +33,16 @@ import { getJCBConfig } from "./jcb";
 
 function getVendorConfig(): { [$Values<typeof CARD>]: ?CardConfig } {
   return {
-    [CARD.VISA]:
-      !__TREE_SHAKE__ ||
-      (__FUNDING_ELIGIBILITY__.card &&
-        __FUNDING_ELIGIBILITY__.card.vendors &&
-        __FUNDING_ELIGIBILITY__.card.vendors.visa &&
-        __FUNDING_ELIGIBILITY__.card.vendors.visa.eligible)
-        ? getVisaConfig()
-        : null,
-    [CARD.AMEX]:
-      !__TREE_SHAKE__ ||
-      (__FUNDING_ELIGIBILITY__.card &&
-        __FUNDING_ELIGIBILITY__.card.vendors &&
-        __FUNDING_ELIGIBILITY__.card.vendors.amex &&
-        __FUNDING_ELIGIBILITY__.card.vendors.amex.eligible)
-        ? getAmexConfig()
-        : null,
-    [CARD.MASTERCARD]:
-      !__TREE_SHAKE__ ||
-      (__FUNDING_ELIGIBILITY__.card &&
-        __FUNDING_ELIGIBILITY__.card.vendors &&
-        __FUNDING_ELIGIBILITY__.card.vendors.mastercard &&
-        __FUNDING_ELIGIBILITY__.card.vendors.mastercard.eligible)
-        ? getMastercardConfig()
-        : null,
-    [CARD.DISCOVER]:
-      !__TREE_SHAKE__ ||
-      (__FUNDING_ELIGIBILITY__.card &&
-        __FUNDING_ELIGIBILITY__.card.vendors &&
-        __FUNDING_ELIGIBILITY__.card.vendors.discover &&
-        __FUNDING_ELIGIBILITY__.card.vendors.discover.eligible)
-        ? getDiscoverConfig()
-        : null,
-    [CARD.JCB]:
-      !__TREE_SHAKE__ ||
-      (__FUNDING_ELIGIBILITY__.card &&
-        __FUNDING_ELIGIBILITY__.card.vendors &&
-        __FUNDING_ELIGIBILITY__.card.vendors.jcb &&
-        __FUNDING_ELIGIBILITY__.card.vendors.jcb.eligible)
-        ? getJCBConfig()
-        : null,
-    [CARD.ELO]:
-      !__TREE_SHAKE__ ||
-      (__FUNDING_ELIGIBILITY__.card &&
-        __FUNDING_ELIGIBILITY__.card.vendors &&
-        __FUNDING_ELIGIBILITY__.card.vendors.elo &&
-        __FUNDING_ELIGIBILITY__.card.vendors.elo.eligible)
-        ? getEloConfig()
-        : null,
-    [CARD.HIPER]:
-      !__TREE_SHAKE__ ||
-      (__FUNDING_ELIGIBILITY__.card &&
-        __FUNDING_ELIGIBILITY__.card.vendors &&
-        __FUNDING_ELIGIBILITY__.card.vendors.hiper &&
-        __FUNDING_ELIGIBILITY__.card.vendors.hiper.eligible)
-        ? getHiperConfig()
-        : null,
+    [CARD.VISA]: getVisaConfig(),
+
+    [CARD.AMEX]: getAmexConfig(),
+
+    [CARD.MASTERCARD]: getMastercardConfig(),
+
+    [CARD.DISCOVER]: getDiscoverConfig(),
+    [CARD.JCB]: getJCBConfig(),
+    [CARD.ELO]: getEloConfig(),
+    [CARD.HIPER]: getHiperConfig(),
   };
 }
 

--- a/src/funding/config.js
+++ b/src/funding/config.js
@@ -35,162 +35,32 @@ export function getFundingConfig(): {
 } {
   return inlineMemoize(getFundingConfig, () => {
     return {
-      [FUNDING.PAYPAL]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.paypal !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.paypal.eligible)
-          ? getPayPalConfig()
-          : null,
-      [FUNDING.VENMO]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.venmo !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.venmo.eligible)
-          ? getVenmoConfig()
-          : null,
-      [FUNDING.APPLEPAY]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.applepay !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.applepay.eligible)
-          ? getApplePayConfig()
-          : null,
-      [FUNDING.ITAU]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.itau !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.itau.eligible)
-          ? getItauConfig()
-          : null,
-      [FUNDING.CREDIT]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.credit !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.credit.eligible)
-          ? getCreditConfig()
-          : null,
-      [FUNDING.PAYLATER]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.paylater !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.paylater.eligible)
-          ? getPaylaterConfig()
-          : null,
-      [FUNDING.CARD]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.card !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.card.eligible)
-          ? getCardConfig()
-          : null,
-      [FUNDING.IDEAL]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.ideal !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.ideal.eligible)
-          ? getIdealConfig()
-          : null,
-      [FUNDING.SEPA]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.sepa !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.sepa.eligible)
-          ? getSepaConfig()
-          : null,
-      [FUNDING.BANCONTACT]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.bancontact !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.bancontact.eligible)
-          ? getBancontactConfig()
-          : null,
-      [FUNDING.GIROPAY]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.giropay !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.giropay.eligible)
-          ? getGiropayConfig()
-          : null,
-      [FUNDING.SOFORT]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.sofort !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.sofort.eligible)
-          ? getSofortConfig()
-          : null,
-      [FUNDING.EPS]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.eps !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.eps.eligible)
-          ? getEpsConfig()
-          : null,
-      [FUNDING.MYBANK]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.mybank !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.mybank.eligible)
-          ? getMybankConfig()
-          : null,
-      [FUNDING.P24]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.p24 !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.p24.eligible)
-          ? getP24Config()
-          : null,
-      [FUNDING.PAYU]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.payu !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.payu.eligible)
-          ? getPayuConfig()
-          : null,
-      [FUNDING.BLIK]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.blik !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.blik.eligible)
-          ? getBlikConfig()
-          : null,
-      [FUNDING.TRUSTLY]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.trustly !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.trustly.eligible)
-          ? getTrustlyConfig()
-          : null,
-      [FUNDING.WECHATPAY]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.wechatpay !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.wechatpay.eligible)
-          ? getWechatpayConfig()
-          : null,
-      [FUNDING.OXXO]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.oxxo !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.oxxo.eligible)
-          ? getOxxoConfig()
-          : null,
-      [FUNDING.BOLETO]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.boleto !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.boleto.eligible)
-          ? getBoletoConfig()
-          : null,
-      [FUNDING.BOLETOBANCARIO]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.boletobancario !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.boletobancario.eligible)
-          ? getBoletoConfig()
-          : null,
-      [FUNDING.MERCADOPAGO]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.mercadopago !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.mercadopago.eligible)
-          ? getMercadopagoConfig()
-          : null,
-      [FUNDING.MULTIBANCO]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.multibanco !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.multibanco.eligible)
-          ? getMultibancoConfig()
-          : null,
-      [FUNDING.SATISPAY]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.satispay !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.satispay.eligible)
-          ? getSatispayConfig()
-          : null,
-      [FUNDING.PAIDY]:
-        !__TREE_SHAKE__ ||
-        (typeof __FUNDING_ELIGIBILITY__.paidy !== "undefined" &&
-          __FUNDING_ELIGIBILITY__.paidy.eligible)
-          ? getPaidyConfig()
-          : null,
+      [FUNDING.PAYPAL]: getPayPalConfig(),
+      [FUNDING.VENMO]: getVenmoConfig(),
+      [FUNDING.APPLEPAY]: getApplePayConfig(),
+      [FUNDING.ITAU]: getItauConfig(),
+      [FUNDING.CREDIT]: getCreditConfig(),
+      [FUNDING.PAYLATER]: getPaylaterConfig(),
+      [FUNDING.CARD]: getCardConfig(),
+      [FUNDING.IDEAL]: getIdealConfig(),
+      [FUNDING.SEPA]: getSepaConfig(),
+      [FUNDING.BANCONTACT]: getBancontactConfig(),
+      [FUNDING.GIROPAY]: getGiropayConfig(),
+      [FUNDING.SOFORT]: getSofortConfig(),
+      [FUNDING.EPS]: getEpsConfig(),
+      [FUNDING.MYBANK]: getMybankConfig(),
+      [FUNDING.P24]: getP24Config(),
+      [FUNDING.PAYU]: getPayuConfig(),
+      [FUNDING.BLIK]: getBlikConfig(),
+      [FUNDING.TRUSTLY]: getTrustlyConfig(),
+      [FUNDING.WECHATPAY]: getWechatpayConfig(),
+      [FUNDING.OXXO]: getOxxoConfig(),
+      [FUNDING.BOLETO]: getBoletoConfig(),
+      [FUNDING.BOLETOBANCARIO]: getBoletoConfig(),
+      [FUNDING.MERCADOPAGO]: getMercadopagoConfig(),
+      [FUNDING.MULTIBANCO]: getMultibancoConfig(),
+      [FUNDING.SATISPAY]: getSatispayConfig(),
+      [FUNDING.PAIDY]: getPaidyConfig(),
     };
   });
 }

--- a/webpack.config.size.js
+++ b/webpack.config.size.js
@@ -25,7 +25,6 @@ const CHECK_SIZE_CONFIG: WebpackConfig = getWebpackConfig({
   analyze: true,
   vars: {
     ...testGlobals,
-    __FUNDING_ELIGIBILITY__: fundingEligibility,
     __INLINE_CHECKOUT_ELIGIBILITY__: inlineCheckoutEligibility,
   },
 });
@@ -38,7 +37,6 @@ const CHECK_SIZE_MIN_CONFIG: WebpackConfig = getWebpackConfig({
   analyze: true,
   vars: {
     ...testGlobals,
-    __FUNDING_ELIGIBILITY__: fundingEligibility,
     __INLINE_CHECKOUT_ELIGIBILITY__: inlineCheckoutEligibility,
   },
 });


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->
Removed the `__FUNDING_ELIGIBILITY__` global variable from `checkout-components`, as well as the tree-shaking logic it enabled at build-time.
### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
Removing the `__FUNDING_ELIGIBILITY__` global variable from the build process is a precursor for caching changes.
### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
