### PR TITLE
mark card button ineligible when using card-fields

### DIFF
--- a/src/funding/card/config.test.jsx
+++ b/src/funding/card/config.test.jsx
@@ -1,0 +1,120 @@
+/* @flow */
+import { describe, test, expect } from "vitest";
+import { FUNDING, COMPONENTS } from "@paypal/sdk-constants/src";
+
+import { getCardConfig } from "./config";
+
+const getEligibility = ({
+  eligible = true,
+  branded = false,
+  vendors = {},
+} = {}) => ({
+  card: {
+    eligible,
+    branded,
+    vendors,
+  },
+});
+
+const getWallet = ({ card = [] } = {}) => ({
+  card: {
+    instruments: card,
+  },
+  credit: {
+    instruments: [],
+  },
+  paypal: {
+    instruments: [],
+  },
+  venmo: {
+    instruments: [],
+  },
+});
+
+describe("card eligibility", () => {
+  // $FlowIssue .eligible is marked as optional in type
+  const getCardConfigEligible = (...args) => getCardConfig().eligible(...args);
+
+  test("should not be eligible when funding eligibility is false", () => {
+    expect(
+      getCardConfigEligible({
+        components: [],
+        fundingSource: FUNDING.PAYPAL,
+        fundingEligibility: getEligibility({ eligible: false }),
+        // $FlowIssue
+        wallet: getWallet(),
+      })
+    ).toEqual(false);
+  });
+
+  test("should be eligible if card funding eligibility says branded is true", () => {
+    expect(
+      getCardConfigEligible({
+        components: [],
+        fundingSource: FUNDING.PAYPAL,
+        fundingEligibility: getEligibility({ branded: true }),
+        wallet: getWallet(),
+      })
+    ).toEqual(true);
+  });
+
+  test("should be eligible if standalone card was rendered", () => {
+    expect(
+      getCardConfigEligible({
+        components: [],
+        fundingSource: FUNDING.CARD,
+        fundingEligibility: getEligibility(),
+        wallet: getWallet(),
+      })
+    ).toEqual(true);
+  });
+
+  test("should be ineligible if card-fields were requested", () => {
+    expect(
+      getCardConfigEligible({
+        // $FlowIssue need to add the new card fields as a constant
+        components: ["card-fields"],
+        fundingSource: FUNDING.PAYPAL,
+        fundingEligibility: getEligibility(),
+        wallet: getWallet(),
+      })
+    ).toEqual(false);
+  });
+
+  test("should be eligible if there is a vaulted card", () => {
+    expect(
+      getCardConfigEligible({
+        components: [],
+        fundingSource: FUNDING.PAYPAL,
+        fundingEligibility: getEligibility(),
+        wallet: getWallet({
+          card: {
+            instruments: ["some instrument"],
+          },
+        }),
+      })
+    ).toEqual(true);
+  });
+
+  test("should be ineligible if hosted-fields was requested", () => {
+    expect(
+      getCardConfigEligible({
+        components: [COMPONENTS.HOSTED_FIELDS],
+        fundingSource: FUNDING.PAYPAL,
+        fundingEligibility: getEligibility(),
+        wallet: getWallet(),
+      })
+    ).toEqual(false);
+  });
+
+  test("should default to true", () => {
+    expect(
+      getCardConfigEligible({
+        components: [],
+        fundingSource: FUNDING.PAYPAL,
+        fundingEligibility: getEligibility(),
+        wallet: getWallet(),
+      })
+    ).toEqual(true);
+  });
+});

--- a/src/funding/card/config.test.jsx
+++ b/src/funding/card/config.test.jsx
@@ -81,6 +81,20 @@ describe("card eligibility", () => {
     ).toEqual(false);
   });
 
+  test("should be ineligible if card-fields were requested, even if there is a vaulted instrument", () => {
+    expect(
+      getCardConfigEligible({
+        // $FlowIssue need to add the new card fields as a constant
+        components: ["card-fields"],
+        fundingSource: FUNDING.PAYPAL,
+        fundingEligibility: getEligibility(),
+        wallet: getWallet({
+          card: ["some instrument"],
+        }),
+      })
+    ).toEqual(false);
+  });
+
   test("should be eligible if there is a vaulted card", () => {
     expect(
       getCardConfigEligible({
@@ -88,9 +102,7 @@ describe("card eligibility", () => {
         fundingSource: FUNDING.PAYPAL,
         fundingEligibility: getEligibility(),
         wallet: getWallet({
-          card: {
-            instruments: ["some instrument"],
-          },
+          card: ["some instrument"],
         }),
       })
     ).toEqual(true);

--- a/src/funding/common.jsx
+++ b/src/funding/common.jsx
@@ -126,10 +126,10 @@ export type FundingSourceConfig = {|
   vendors?: { [$Values<typeof CARD>]: ?CardConfig },
   eligible?: ({|
     components: $ReadOnlyArray<$Values<typeof COMPONENTS>>,
-    experiment: ?Experiment,
+    experiment?: ?Experiment,
     fundingEligibility: FundingEligibilityType,
     fundingSource: ?$Values<typeof FUNDING>,
-    layout: ?$Values<typeof BUTTON_LAYOUT>,
+    layout?: ?$Values<typeof BUTTON_LAYOUT>,
     wallet: ?Wallet,
   |}) => boolean,
   Logo: (LogoOptions) => ChildType,

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,7 @@ import { flowPlugin, esbuildFlowPlugin } from "@bunchtogether/vite-plugin-flow";
 const define = {
   __DEBUG__: false,
   __TEST__: true,
+  __WEB__: true,
   __POST_ROBOT__: JSON.stringify({
     __GLOBAL_KEY__: `__post_robot__`,
     __AUTO_SETUP__: false,
@@ -35,7 +36,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["vitestSetup.js"],
-    include: ["**/test/unit/**/*.test.js"],
+    include: ["**/src/**/*.test.{js,jsx}"],
     deps: {
       inline: ["@krakenjs/post-robot"],
     },


### PR DESCRIPTION
### Description

the black bcdc button or card button should not be eligible in the smart stack when using the new Hosted Card Fields component (card-fields)

I added a description to explain the purpose of the order of the if statements when checking for eligibility and a test to verify