### PR TITLE
improve button accessibility

### DIFF
--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -309,7 +309,6 @@ export function Button({
         onRender={onButtonRender}
         onKeyPress={keypressHandler}
         tabindex="0"
-        aria-label={labelText}
       >
         <div class={CLASS.BUTTON_LABEL}>{labelNode}</div>
 

--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -141,23 +141,6 @@ export function Button({
     }
   };
 
-  function getAriaLabel(): string {
-    let labelText =
-      typeof fundingConfig.labelText === "function"
-        ? fundingConfig.labelText({ content, fundingEligibility })
-        : fundingConfig.labelText || fundingSource;
-
-    if (!showPayLabel && instrument?.vendor && instrument.label) {
-      labelText = instrument.secondaryInstruments
-        ? `${instrument.secondaryInstruments[0].type} & ${instrument.vendor} ${instrument.label}`
-        : `${instrument.vendor} ${instrument.label}`;
-    }
-
-    return labelText;
-  }
-
-  const labelText = getAriaLabel();
-
   const logoNode = (
     <Logo
       label={label}

--- a/src/ui/text/text.jsx
+++ b/src/ui/text/text.jsx
@@ -25,6 +25,7 @@ export function Text(
 ): ChildType {
   return (
     <span
+      aria-label={children}
       class={[CLASS.TEXT, ...className, animate || CLASS.IMMEDIATE]
         .filter(Boolean)
         .join(" ")}

--- a/test/integration/tests/funding/paylater/index.js
+++ b/test/integration/tests/funding/paylater/index.js
@@ -47,7 +47,7 @@ describe(`paylater button text`, () => {
         "Pay in 4"
       );
       assert.equal(
-        getElementRecursive(".paypal-button").getAttribute("aria-label"),
+        getElementRecursive(".paypal-button-text").getAttribute("aria-label"),
         "Pay in 4"
       );
     });


### PR DESCRIPTION
### Description

This PR moves the `aria-label` from the top level button container to the lower level `span` that wraps both the `label` and the `logo`.

### Why are we making these changes?

Today when a screen reader focuses on a button with a label, the text is read aloud as just "PayPal".  This change (plus [the sdk-logos change](https://github.com/paypal/paypal-sdk-logos/pull/105)) will read the button text aloud _with_ the label, e.g. "Pay with PayPal":


https://user-images.githubusercontent.com/3824954/235690371-4d368b2c-49fd-463f-9d2c-f3aad22cd231.mov


### Reproduction Steps (if applicable)

1. Install the [Screen Reader chrome extension](https://chrome.google.com/webstore/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn).
2. Press tab to focus on a button that has a label "pay"
3. Expect the screenreader to pronounce "pay with paypal"
4. Observe the screenreader _not_ pronouncing the label.

### Screenshots (if applicable)

### Dependent Changes (if applicable)

There will also be a PR incoming for sdk-logos. I will update this PR once that one is open.

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
