### PR TITLE
set window.outerHeight on venmo eligibility test

### DIFF
--- a/test/integration/tests/button/eligibility.js
+++ b/test/integration/tests/button/eligibility.js
@@ -176,6 +176,7 @@ describe("venmo button eligibility", () => {
   it("should render venmo button for mobile when eligibility is true", () => {
     return wrapPromise(({ expect, avoid }) => {
       window.navigator.mockUserAgent = IPHONE6_USER_AGENT;
+      window.outerHeight = 667;
       window.localStorage.setItem("enable_venmo_ios", true);
       const mockEligibility = mockProp(
         window.__TEST_FUNDING_ELIGIBILITY__[FUNDING.VENMO],


### PR DESCRIPTION
### Description

This PR fixes an issue where using `describe.only` tests for venmo eligibility would fail.

The test passes when the entire test suite is run because of the side effect set here: https://github.com/paypal/paypal-checkout-components/blob/171cbb28f1e60160d0a907d953b6a0bf62a2116d/test/integration/tests/button/multiple.js#L67-L70



### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

We are going to begin editing the test cases for venmo button eligibility, and being able to run the tests in isolation will decrease the time it takes to red green refactor.

### Reproduction Steps (if applicable)

Apply this change locally:

```diff
diff --git a/test/integration/tests/button/eligibility.js b/test/integration/tests/button/eligibility.js
index 139b1fc..0f84ad5 100644
--- a/test/integration/tests/button/eligibility.js
+++ b/test/integration/tests/button/eligibility.js
@@ -15,7 +15,7 @@ import {
 } from "../common";
 import { testContent } from "../../../content";

-describe("venmo button eligibility", () => {
+describe.only("venmo button eligibility", () => {
   beforeEach(() => {
     createTestContainer();
   });
```

without `window.outerHeight`, the mobile eligibility test fails.

### Screenshots (if applicable)

<img width="645" alt="Screen Shot 2023-05-19 at 13 11 31" src="https://github.com/paypal/paypal-checkout-components/assets/3824954/9952958b-abbb-4503-afa6-508fbea86d9b">

❤️ Thank you!
