### PR TITLE
fix missing aria-label

### DIFF
--- a/src/funding/paypal/config.jsx
+++ b/src/funding/paypal/config.jsx
@@ -54,7 +54,7 @@ export function getPayPalConfig(): FundingSourceConfig {
         } else {
           text = content["label.installment.withoutPeriod"];
         }
-      } else if (content && label) {
+      } else if (content && label && content[`label.${label}`]) {
         text = content[`label.${label}`];
       }
       return text;

--- a/test/integration/tests/button/style.js
+++ b/test/integration/tests/button/style.js
@@ -137,7 +137,15 @@ describe("paypal button color", () => {
 });
 
 describe("paypal button aria-label", () => {
-  it("uses style.label and style.period", () => {
+  beforeEach(() => {
+    createTestContainer();
+  });
+
+  afterEach(() => {
+    destroyTestContainer();
+  });
+
+  it("uses style.label and style.period", (done) => {
     window.paypal
       .Buttons({
         content: {
@@ -152,11 +160,14 @@ describe("paypal button aria-label", () => {
       .render("#testContainer")
       .then(() => {
         assert.ok(
-          getElementRecursive("[aria-label='Pay up to 3x without interest']")
+          getElementRecursive(
+            ".paypal-button[aria-label='Pay up to 3x without interest']"
+          )
         );
+        done();
       });
   });
-  it("handles style.label == 'installment' without style.period", () => {
+  it("handles style.label == 'installment' without style.period", (done) => {
     window.paypal
       .Buttons({
         content: {
@@ -168,10 +179,15 @@ describe("paypal button aria-label", () => {
       })
       .render("#testContainer")
       .then(() => {
-        assert.ok(getElementRecursive("[aria-label='Interest free payments']"));
+        assert.ok(
+          getElementRecursive(
+            ".paypal-button[aria-label='Interest free payments']"
+          )
+        );
+        done();
       });
   });
-  it("falls back to the funding source if content is unavailable", () => {
+  it("falls back to the funding source if content is unavailable", (done) => {
     window.paypal
       .Buttons({
         style: {
@@ -180,7 +196,24 @@ describe("paypal button aria-label", () => {
       })
       .render("#testContainer")
       .then(() => {
-        assert.ok(getElementRecursive("[aria-label='PayPal']"));
+        assert.ok(getElementRecursive(".paypal-button[aria-label='PayPal']"));
+        done();
+      });
+  });
+  it("falls back to the funding source if the correct content is unavailable", (done) => {
+    window.paypal
+      .Buttons({
+        content: {
+          "label.pay": "Pay with PayPal",
+        },
+        style: {
+          label: "buynow",
+        },
+      })
+      .render("#testContainer")
+      .then(() => {
+        assert.ok(getElementRecursive(".paypal-button[aria-label='PayPal']"));
+        done();
       });
   });
 });


### PR DESCRIPTION
### Description

This PR is a follow up to #2169 (29a18ecc494b1731efab0893f6ce6bb69f1568bb) that introduced an issue related to the correct content not being available.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

If some content is available, but not the correct content, the `aria-label` goes missing because `labelText` is undefined.

Additionally, the tests in style.js were silently passing because `done` was not passed to `it()` and the test reported a success before the button rendered.

### Reproduction Steps

Visit https://developer.paypal.com/demo/checkout/#/pattern/server and update the sdk script url to include a locale that does not have corresponding content:

```html
<script src="https://www.paypal.com/sdk/js?client-id=test&currency=USD&locale=en_GB"></script>
``` 

Then, add a style property with a label property:

```js
paypal.Buttons({
  style: {
    label: 'pay'           
  },
  createOrder: ...
```

Observe that there is no `aria-label` on the `.paypal-button` element 

## Screenshots

<img width="1142" alt="Screen Shot 2023-06-15 at 15 08 27" src="https://github.com/paypal/paypal-checkout-components/assets/3824954/ba782cd6-4bee-4d57-aba8-8b70c7cab7ac">

❤️ Thank you!
