### PR TITLE
fix(ci): npm publish failure

### DIFF
--- a/scripts/preversion.sh
+++ b/scripts/preversion.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Remove the `dist/` folder; we will re-generate later on
-rm dist/*
+rm -rf dist/*
 git checkout dist/
 
 # Make sure the HEAD is clean


### PR DESCRIPTION
### Description

This PR fixes an `npm publish` error when directories exist inside of the `dist/` folder.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

In a [previous publish run](https://github.com/paypal/paypal-checkout-components/actions/runs/5291327680/jobs/9576722265#step:7:19), we encountered the following error message:

```
> preversion
> ./scripts/preversion.sh

rm: cannot remove 'dist/test': Is a directory
```

### Reproduction Steps (if applicable)

1. create a directory inside of `dist/`
2. run `scripts/preversion.sh`
3. observe the same error message

❤️ Thank you!
