### PR TITLE
Support New displayOnly Confg Option

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@paypal/common-components": "^1.0.35",
     "@paypal/funding-components": "^1.0.31",
     "@paypal/sdk-client": "^4.0.176",
-    "@paypal/sdk-constants": "^1.0.128",
+    "@paypal/sdk-constants": "^1.0.132",
     "@paypal/sdk-logos": "^2.2.6"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@paypal/common-components": "^1.0.35",
     "@paypal/funding-components": "^1.0.31",
     "@paypal/sdk-client": "^4.0.176",
-    "@paypal/sdk-constants": "^1.0.132",
+    "@paypal/sdk-constants": "^1.0.133",
     "@paypal/sdk-logos": "^2.2.6"
   },
   "lint-staged": {

--- a/src/funding/funding.js
+++ b/src/funding/funding.js
@@ -94,7 +94,6 @@ export function isFundingEligible(
       shippingChange:
         onShippingChange || onShippingAddressChange || onShippingOptionsChange,
       wallet,
-      displayOnly,
     })
   ) {
     return false;

--- a/src/funding/funding.js
+++ b/src/funding/funding.js
@@ -47,13 +47,9 @@ function isFundingVaultable({
     const { vendors } = fundingEligibility[source];
 
     // If any vendors are both eligible & vaultable, card is vaultable
-    for (const vendor in vendors) {
-      if (vendors[vendor].eligible && vendors[vendor].vaultable) {
-        return true;
-      }
-    }
-
-    return false;
+    return Object.keys(vendors).some(
+      (vendor) => vendors[vendor].eligible && vendors[vendor].vaultable
+    );
   }
 
   if (!fundingEligibility[source].vaultable) {

--- a/src/funding/funding.test.js
+++ b/src/funding/funding.test.js
@@ -1,0 +1,104 @@
+import { describe, expect } from "vitest";
+import { isFundingEligible } from "./funding";
+import { COMPONENTS, FUNDING } from "@paypal/sdk-constants/src";
+
+const defaultFundingOptions = {
+  platform: "desktop",
+  fundingEligibility: {
+    paylater: {
+      eligible: true,
+      vaultable: false,
+    },
+    venmo: {
+      eligible: true,
+      vaultable: true,
+    },
+    sepa: {
+      eligible: false,
+    },
+    card: {
+      eligible: true,
+      branded: false,
+      installments: false,
+      vendors: {
+        visa: {
+          eligible: true,
+          vaultable: false,
+        },
+        mastercard: {
+          eligible: true,
+          vaultable: false,
+        },
+        amex: {
+          eligible: true,
+          vaultable: false,
+        },
+      },
+      guestEnabled: false,
+    },
+  },
+};
+
+describe("Funding eligibility", () => {
+  test("should not be eligible if funding source is missing from fundingEligibility", () => {
+    const fundingEligible = isFundingEligible("fake_funding", {
+      fundingEligibility: { venmo: { eligible: true } },
+    });
+
+    expect(fundingEligible).toBe(false);
+  });
+
+  test("should not be eligible if displayOnly includes 'vaultable' and vaultable is false", () => {
+    const options = { displayOnly: ["vaultable"], ...defaultFundingOptions };
+    const fundingEligible = isFundingEligible(FUNDING.PAYLATER, options);
+
+    expect(fundingEligible).toBe(false);
+  });
+
+  test("card should not be eligible if displayOnly includes 'vaultable' and no vendors are vaultable", () => {
+    const options = {
+      displayOnly: ["vaultable"],
+      components: COMPONENTS.BUTTONS,
+      ...defaultFundingOptions,
+    };
+    const fundingEligible = isFundingEligible(FUNDING.CARD, options);
+
+    expect(fundingEligible).toBe(false);
+  });
+
+  test("card should be eligible if displayOnly includes 'vaultable' and any vendor is vaultable", () => {
+    const options = {
+      displayOnly: ["vaultable"],
+      components: COMPONENTS.BUTTONS,
+      platform: "desktop",
+      fundingEligibility: {
+        card: {
+          eligible: true,
+          vendors: {
+            visa: {
+              eligible: true,
+              vaultable: true,
+            },
+            mastercard: {
+              eligible: true,
+              vaultable: false,
+            },
+          },
+        },
+      },
+    };
+
+    const fundingEligible = isFundingEligible(FUNDING.CARD, options);
+
+    expect(fundingEligible).toBe(true);
+  });
+
+  test("should not be eligible if fundingSource.eligible is false", () => {
+    const fundingEligible = isFundingEligible(
+      FUNDING.SEPA,
+      defaultFundingOptions
+    );
+
+    expect(fundingEligible).toBe(false);
+  });
+});

--- a/src/funding/funding.test.js
+++ b/src/funding/funding.test.js
@@ -25,6 +25,11 @@ const defaultMockFundingOptions = {
       eligible: false,
       branded: false,
     },
+    oxxo: {
+      eligible: false,
+      vaultable: true,
+      branded: false,
+    },
     card: {
       eligible: true,
       branded: false,
@@ -118,6 +123,15 @@ describe("Funding eligibility", () => {
   test("should not be eligible if fundingSource.eligible is false", () => {
     const fundingEligible = isFundingEligible(
       FUNDING.SEPA,
+      defaultMockFundingOptions
+    );
+
+    expect(fundingEligible).toBe(false);
+  });
+
+  test("should not be eligible if fundingSource.eligible is false and fundingSource.vaultable is true", () => {
+    const fundingEligible = isFundingEligible(
+      FUNDING.OXXO,
       defaultMockFundingOptions
     );
 

--- a/src/funding/funding.test.js
+++ b/src/funding/funding.test.js
@@ -18,8 +18,6 @@ const defaultFundingOptions = {
     },
     card: {
       eligible: true,
-      branded: false,
-      installments: false,
       vendors: {
         visa: {
           eligible: true,
@@ -34,7 +32,6 @@ const defaultFundingOptions = {
           vaultable: false,
         },
       },
-      guestEnabled: false,
     },
   },
 };

--- a/src/funding/funding.test.js
+++ b/src/funding/funding.test.js
@@ -1,6 +1,8 @@
-import { describe, expect } from "vitest";
-import { isFundingEligible } from "./funding";
+/* @flow */
 import { COMPONENTS, FUNDING } from "@paypal/sdk-constants/src";
+import { describe, expect } from "vitest";
+
+import { isFundingEligible } from "./funding";
 
 const defaultMockFundingOptions = {
   platform: "desktop",

--- a/src/funding/funding.test.js
+++ b/src/funding/funding.test.js
@@ -2,7 +2,7 @@ import { describe, expect } from "vitest";
 import { isFundingEligible } from "./funding";
 import { COMPONENTS, FUNDING } from "@paypal/sdk-constants/src";
 
-const defaultFundingOptions = {
+const defaultMockFundingOptions = {
   platform: "desktop",
   fundingEligibility: {
     paylater: {
@@ -46,7 +46,10 @@ describe("Funding eligibility", () => {
   });
 
   test("should not be eligible if displayOnly includes 'vaultable' and vaultable is false", () => {
-    const options = { displayOnly: ["vaultable"], ...defaultFundingOptions };
+    const options = {
+      displayOnly: ["vaultable"],
+      ...defaultMockFundingOptions,
+    };
     const fundingEligible = isFundingEligible(FUNDING.PAYLATER, options);
 
     expect(fundingEligible).toBe(false);
@@ -56,7 +59,7 @@ describe("Funding eligibility", () => {
     const options = {
       displayOnly: ["vaultable"],
       components: COMPONENTS.BUTTONS,
-      ...defaultFundingOptions,
+      ...defaultMockFundingOptions,
     };
     const fundingEligible = isFundingEligible(FUNDING.CARD, options);
 
@@ -93,7 +96,7 @@ describe("Funding eligibility", () => {
   test("should not be eligible if fundingSource.eligible is false", () => {
     const fundingEligible = isFundingEligible(
       FUNDING.SEPA,
-      defaultFundingOptions
+      defaultMockFundingOptions
     );
 
     expect(fundingEligible).toBe(false);

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -178,6 +178,7 @@ export function Buttons(props: ButtonsProps): ElementNode {
     supportsPopups,
     supportedNativeBrowser,
     showPayLabel,
+    displayOnly,
   } = normalizeButtonProps(props);
   const { layout, shape, tagline } = style;
 
@@ -196,6 +197,7 @@ export function Buttons(props: ButtonsProps): ElementNode {
     supportsPopups,
     supportedNativeBrowser,
     experiment,
+    displayOnly,
   });
   const multiple = fundingSources.length > 1;
 

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -24,6 +24,7 @@ import {
   type LocaleType,
   CARD,
   COMPONENTS,
+  DISPLAY_ONLY_VALUES,
 } from "@paypal/sdk-constants/src";
 import { type CrossDomainWindowType } from "@krakenjs/cross-domain-utils/src";
 import { LOGO_COLOR } from "@paypal/sdk-logos/src";
@@ -461,6 +462,7 @@ export type RenderButtonProps = {|
   supportsPopups: boolean,
   supportedNativeBrowser: boolean,
   showPayLabel: boolean,
+  displayOnly?: $ReadOnlyArray<$Values<typeof DISPLAY_ONLY_VALUES>>,
 |};
 
 export type PrerenderDetails = {|
@@ -518,6 +520,7 @@ export type ButtonProps = {|
   meta: {||},
   renderedButtons: $ReadOnlyArray<$Values<typeof FUNDING>>,
   createVaultSetupToken: CreateVaultSetupToken,
+  displayOnly?: $ReadOnlyArray<$Values<typeof DISPLAY_ONLY_VALUES>>,
 |};
 
 // eslint-disable-next-line flowtype/require-exact-type
@@ -559,6 +562,7 @@ export type ButtonPropsInputs = {
   supportsPopups: boolean,
   supportedNativeBrowser: boolean,
   showPayLabel: boolean,
+  displayOnly: $ReadOnlyArray<$Values<typeof DISPLAY_ONLY_VALUES>>,
 };
 
 export const DEFAULT_STYLE = {

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -744,6 +744,7 @@ export function normalizeButtonProps(
     supportsPopups = false,
     supportedNativeBrowser = false,
     showPayLabel = true,
+    displayOnly = [],
   } = props;
 
   const { country, lang } = locale;
@@ -794,6 +795,7 @@ export function normalizeButtonProps(
         applePaySupport,
         supportsPopups,
         supportedNativeBrowser,
+        displayOnly,
       })
     ) {
       throw new Error(`Funding Source not eligible: ${fundingSource}`);
@@ -833,5 +835,6 @@ export function normalizeButtonProps(
     supportsPopups,
     supportedNativeBrowser,
     showPayLabel,
+    displayOnly,
   };
 }

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -833,6 +833,15 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
         required: false,
         value: getExperimentation,
       },
+
+      displayOnly: {
+        type: "array",
+        queryParam: true,
+        required: false,
+        value: ({ props }) => {
+          return props?.displayOnly || [];
+        },
+      },
     },
   });
 });


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

This PR uses the new `displayOnly` config option in the button eligibility logic.

```
paypal.Buttons({
    displayOnly: ["vaultable"]
})
```

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
**Jira:** https://paypal.atlassian.net/browse/DTPPCPSDK-825

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
