### PR TITLE
Add a new sign_out_user prop to zoid checkout component

### DIFF
--- a/src/zoid/checkout/component.jsx
+++ b/src/zoid/checkout/component.jsx
@@ -288,6 +288,12 @@ export function getCheckoutComponent(): CheckoutComponent {
           required: false,
           queryParam: true,
         },
+
+        sign_out_user: {
+          type: "boolean",
+          queryParam: true,
+          required: false,
+        },
       },
 
       dimensions: ({ props }) => {

--- a/test/integration/tests/checkout/happy.js
+++ b/test/integration/tests/checkout/happy.js
@@ -105,6 +105,31 @@ describe(`paypal checkout component happy path`, () => {
     });
   });
 
+  it("should render checkout with sign_out_user=true to enable paying with a different account", () => {
+    return wrapPromise(({ expect, error }) => {
+      return runOnClick(() => {
+        const orderID = generateOrderID();
+
+        return window.paypal
+          .Checkout({
+            buttonSessionID: uniqueID(),
+            fundingSource: FUNDING.PAYPAL,
+            createOrder: expect("createOrder", () => orderID),
+            sign_out_user: true,
+            onApprove: expect("onApprove", (data) => {
+              if (data.currentUrl.indexOf(`sign_out_user=true`) === -1) {
+                throw new Error(
+                  `Expected to find sign_out_user=true in url, got ${data.currentUrl}`
+                );
+              }
+            }),
+            onCancel: error("onCancel"),
+          })
+          .render("body");
+      });
+    });
+  });
+
   it("should render checkout, and click the close button to close the window", () => {
     return wrapPromise(({ expect, error }) => {
       return runOnClick(() => {


### PR DESCRIPTION
### Description

This PR adds a new prop `sign_out_user` that will be used in smart-payment-buttons to log out the buyer when they click on "Pay with a different account".

### Why are we making these changes?

Clicking on "Pay with a different account" does not allow the buyer to change their account. This PR is a prerequisite for some upcoming SPB changes that will add a new query parameter `sign_out_user=true` when opening the popup, which will log out the buyer and allow them to log in with another PayPal account.

See the [sneak peek here](https://github.com/paypal/paypal-smart-payment-buttons/pull/705).

### Reproduction Steps (if applicable)

Vault the PayPal button. Click on the menu, and click "Pay with a different account". There is no option to change the account. 

### Screenshots (if applicable)

<img width="617" alt="Screenshot 2023-10-27 at 15 17 53" src="https://github.com/paypal/paypal-checkout-components/assets/3824954/a5f25a6e-75d4-4dac-9779-5865a297ac62">

❤️ Thank you!
