### PR TITLE
Venmo overlay

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -4,7 +4,7 @@
     {
       "path": "size.min.js",
       "compression": "gzip",
-      "maxPercentIncrease": 3,
+      "maxPercentIncrease": 3.6,
       "maxSize": "76kb"
     }
   ],

--- a/src/zoid/checkout/component.jsx
+++ b/src/zoid/checkout/component.jsx
@@ -27,7 +27,11 @@ import {
   inlineMemoize,
 } from "@krakenjs/belter/src";
 import { FUNDING } from "@paypal/sdk-constants/src";
-import { SpinnerPage, Overlay } from "@paypal/common-components/src";
+import {
+  SpinnerPage,
+  Overlay,
+  VenmoOverlay,
+} from "@paypal/common-components/src";
 
 import { getSessionID } from "../../lib";
 import { containerContent } from "../content";
@@ -81,20 +85,38 @@ export function getCheckoutComponent(): CheckoutComponent {
         const {
           nonce,
           locale: { lang },
+          fundingSource,
         } = props;
-        const content = containerContent("PayPal")[lang];
-        return (
-          <Overlay
-            context={context}
-            close={close}
-            focus={focus}
-            event={event}
-            frame={frame}
-            prerenderFrame={prerenderFrame}
-            content={content}
-            nonce={nonce}
-          />
-        ).render(dom({ doc }));
+        const isVenmo: boolean = fundingSource === FUNDING.VENMO;
+        const brand: string = isVenmo ? "Venmo" : "PayPal";
+        const content = containerContent(brand.toLowerCase())[lang];
+        if (isVenmo) {
+          return (
+            <VenmoOverlay
+              context={context}
+              close={close}
+              focus={focus}
+              event={event}
+              frame={frame}
+              prerenderFrame={prerenderFrame}
+              content={content}
+              nonce={nonce}
+            />
+          ).render(dom({ doc }));
+        } else {
+          return (
+            <Overlay
+              context={context}
+              close={close}
+              focus={focus}
+              event={event}
+              frame={frame}
+              prerenderFrame={prerenderFrame}
+              content={content}
+              nonce={nonce}
+            />
+          ).render(dom({ doc }));
+        }
       },
 
       props: {
@@ -197,6 +219,7 @@ export function getCheckoutComponent(): CheckoutComponent {
           type: "string",
           queryParam: true,
           default: () => FUNDING.PAYPAL,
+          allowDelegate: true,
         },
 
         standaloneFundingSource: {

--- a/src/zoid/checkout/component.jsx
+++ b/src/zoid/checkout/component.jsx
@@ -88,8 +88,8 @@ export function getCheckoutComponent(): CheckoutComponent {
           fundingSource,
         } = props;
         const isVenmo = fundingSource === FUNDING.VENMO;
-        const brand = isVenmo ? "Venmo" : "PayPal";
-        const content = containerContent(brand.toLowerCase())[lang];
+        const browserLanguage = isVenmo ? "en" : lang;
+        const content = containerContent(fundingSource)[browserLanguage];
         if (isVenmo) {
           return (
             <VenmoOverlay

--- a/src/zoid/checkout/component.jsx
+++ b/src/zoid/checkout/component.jsx
@@ -87,8 +87,8 @@ export function getCheckoutComponent(): CheckoutComponent {
           locale: { lang },
           fundingSource,
         } = props;
-        const isVenmo: boolean = fundingSource === FUNDING.VENMO;
-        const brand: string = isVenmo ? "Venmo" : "PayPal";
+        const isVenmo = fundingSource === FUNDING.VENMO;
+        const brand = isVenmo ? "Venmo" : "PayPal";
         const content = containerContent(brand.toLowerCase())[lang];
         if (isVenmo) {
           return (

--- a/src/zoid/content.js
+++ b/src/zoid/content.js
@@ -1,162 +1,176 @@
 /* @flow */
 /* eslint max-lines: 0 */
 
-import { LANG } from "@paypal/sdk-constants/src";
+import { LANG, FUNDING } from "@paypal/sdk-constants/src";
 
 type ContentMap = {
   [$Values<typeof LANG>]: {|
     windowMessage?: string,
     continueMessage?: string,
+    cancelMessage?: string,
   |},
 };
 
-export const containerContent: (string) => ContentMap = (fundingSource) => ({
-  ar: {
-    windowMessage: `لا ترى متصفح ${fundingSource} الآمن؟ سنساعدك في إعادة فتح النافذة لاستكمال مشترياتك`,
-    continueMessage: `متابعة`,
-  },
-  bg: {
-    windowMessage: `Не виждате защитения браузър на ${fundingSource}? Ще ви помогнем да отворите отново прозореца, за да завършите покупката си`,
-    continueMessage: `Щракнете, за да продължите`,
-  },
-  cs: {
-    windowMessage: `Nezobrazuje se vám bezpečný prohlížeč ${fundingSource}? Pomůžeme vám okno znovu otevřít, abyste mohli nákup dokončit`,
-    continueMessage: `Pokračovat`,
-  },
-  da: {
-    windowMessage: `Kan du ikke se ${fundingSource}s sikre browser? Vi hjælper dig med at genstarte vinduet, så du kan betale`,
-    continueMessage: `Fortsæt`,
-  },
-  de: {
-    windowMessage: `Sie sehen das sichere Browserfenster von ${fundingSource} nicht? Hier können Sie es wieder öffnen und Ihren Einkauf abschließen`,
-    continueMessage: `Weiter`,
-  },
-  el: {
-    windowMessage: `Δεν βλέπετε το ασφαλές πρόγραμμα περιήγησης ${fundingSource}; Θα σας βοηθήσουμε να επανεκκινήσετε το παράθυρο για να ολοκληρώσετε την αγορά σας`,
-    continueMessage: `Συνέχεια`,
-  },
-  en: {
-    windowMessage: `Don’t see the secure ${fundingSource} browser? We’ll help you re-launch the window to complete your purchase`,
-    continueMessage: `Click to Continue`,
-  },
-  es: {
-    windowMessage: `¿No ve el navegador seguro de ${fundingSource}? Abriremos la ventana nuevamente para que pueda completar su compra`,
-    continueMessage: `Continuar`,
-  },
-  et: {
-    windowMessage: `Kas te ei näe turvalist ${fundingSource}i lehitsejat? Aitame teil ostu lõpuleviimiseks akna uuesti avada.`,
-    continueMessage: `Jätkamiseks klõpsake`,
-  },
-  fi: {
-    windowMessage: `Eikö suojattua ${fundingSource}-selainta näy? Autamme avaamaan ikkunan uudelleen oston viimeistelyä varten`,
-    continueMessage: `Jatka`,
-  },
-  fr: {
-    windowMessage: `Le navigateur sécurisé de ${fundingSource} n’apparaît pas ? Nous allons vous aider à rouvrir la fenêtre pour finaliser votre achat`,
-    continueMessage: `Continuer`,
-  },
-  he: {
-    windowMessage: `לא רואה את דפדפן ${fundingSource} המאובטח? נעזור לך לפתוח מחדש את החלון כדי להשלים את הקנייה שלך`,
-    continueMessage: `המשך`,
-  },
-  hu: {
-    windowMessage: `Nem látja a biztonságos ${fundingSource}-böngészőt? Segítünk újra betölteni az ablakot, hogy befejezhesse a vásárlást`,
-    continueMessage: `Folytatás`,
-  },
-  id: {
-    windowMessage: `Browser ${fundingSource} yang aman tidak terlihat? Kami akan membantu menampilkan ulang jendela untuk menyelesaikan pembayaran Anda`,
-    continueMessage: `Lanjutkan`,
-  },
-  it: {
-    windowMessage: `Non vedi la pagina sicura di ${fundingSource}? Ti aiuteremo a riaprire la finestra per completare l’acquisto`,
-    continueMessage: `Continua`,
-  },
-  ja: {
-    windowMessage: `セキュアなブラウザが表示されない場合は、ウィンドウを再起動して、支払いを完了できるようお手伝いいたします`,
-    continueMessage: `続行`,
-  },
-  ko: {
-    windowMessage: `보안 ${fundingSource} 브라우저가 보이지 않으신가요? 창을 다시 실행하여 결제를 완료할 수 있도록 도와드리겠습니다`,
-    continueMessage: `계속`,
-  },
-  lt: {
-    windowMessage: `Nematote saugios „${fundingSource}“ naršyklės? Padėsime iš naujo paleisti langą, kad užbaigtumėte pirkimą`,
-    continueMessage: `Paspauskite, jei norite tęsti`,
-  },
-  lv: {
-    windowMessage: `Vai neredzat drošo ${fundingSource} pārlūkprogrammu? Mēs palīdzēsim jums atkārtoti palaist logu, lai pabeigtu pirkumu.`,
-    continueMessage: `Noklikšķiniet, lai turpinātu`,
-  },
-  ms: {
-    windowMessage: `Tidak melihat pelayar ${fundingSource} yang selamat? Kami akan membantu anda melancarkan semula tetingkap untuk melengkapkan pembelian anda`,
-    continueMessage: `Klik untuk Meneruskan`,
-  },
-  no: {
-    windowMessage: `Ser du ikke den sikre ${fundingSource}-nettleseren? Vi hjelper deg med å starte vinduet på nytt så du kan fullføre kjøpet`,
-    continueMessage: `Fortsett`,
-  },
-  nl: {
-    windowMessage: `Ziet u de beveiligde ${fundingSource}-browser niet? We helpen u het venster opnieuw te openen om uw aankoop te voltooien`,
-    continueMessage: `Doorgaan`,
-  },
-  pl: {
-    windowMessage: `Nie widzisz bezpiecznej przeglądarki ${fundingSource}? Pomożemy Ci ponownie uruchomić to okno w celu dokonania zakupu`,
-    continueMessage: `Kontynuuj`,
-  },
-  pt: {
-    windowMessage: `Não está vendo o navegador seguro do ${fundingSource}? Ajudaremos você a reabrir a janela para concluir a compra`,
-    continueMessage: `Continuar`,
-  },
-  ro: {
-    windowMessage: `Nu vezi browser-ul securizat ${fundingSource}? Te vom ajuta să lansezi din nou fereastra pentru a finaliza achiziția`,
-    continueMessage: `Dă clic pentru a continua`,
-  },
-  ru: {
-    windowMessage: `Не отображается безопасная страница ${fundingSource} в браузере? Мы поможем вам повторно загрузить окно, чтобы завершить покупку`,
-    continueMessage: `Продолжить`,
-  },
-  si: {
-    windowMessage: `ආරක්ෂිත ${fundingSource} බ්‍රව්සරය නොපෙනේ ද? ඔබේ මිල දී ගැනීම සම්පූර්ණ කිරීම සඳහා අපි ඔබට කවුළුව නැවත දියත් කිරීමට උපකාර කරන්නෙමු`,
-    continueMessage: `ඉදිරියට යාමට ක්ලික් කරන්න`,
-  },
-  sk: {
-    windowMessage: `Nezobrazuje sa vám zabezpečený prehliadač ${fundingSource}? Pomôžeme vám znova otvoriť okno, aby ste mohli nákup dokončiť`,
-    continueMessage: `Pokračovať`,
-  },
-  sl: {
-    windowMessage: `Ne vidite ${fundingSource}ovega varnega brskalnika? Pomagali vam bomo ponovno zagnati okno za dokončanje nakupa`,
-    continueMessage: `Kliknite za nadaljevanje`,
-  },
-  sq: {
-    windowMessage: `Nuk e shikon shfletuesin e sigurt të ${fundingSource}? Do të të ndihmojmë të rihapësh dritaren për të përfunduar blerjen`,
-    continueMessage: `Kliko për të vazhduar`,
-  },
-  sv: {
-    windowMessage: `Ser du inte den säkra ${fundingSource}-webbläsaren? Vi hjälper dig att starta om fönstret för att slutföra ditt köp`,
-    continueMessage: `Fortsätt`,
-  },
-  th: {
-    windowMessage: `ถ้าคุณไม่เห็นเบราว์เซอร์ที่มีระบบความปลอดภัยของ ${fundingSource} เราจะช่วยคุณเปิดหน้าต่างอีกครั้งเพื่อชำระเงินให้เรียบร้อย`,
-    continueMessage: `ดำเนินการต่อ`,
-  },
-  tl: {
-    windowMessage: `Hindi nakikita ang secure na ${fundingSource} browser? Tutulungan ka naming i-launch ulit ang window para makumpleto ang pagbili mo.`,
-    continueMessage: `I-click para Magpatuloy`,
-  },
-  tr: {
-    windowMessage: `Güvenli ${fundingSource} tarayıcısını görmüyor musunuz? Alışverişinizi tamamlamak için pencereyi yeniden başlatmanıza yardımcı olacağız`,
-    continueMessage: `Devam`,
-  },
-  vi: {
-    windowMessage: `Bạn không thấy trình duyệt ${fundingSource} bảo mật? Chúng tôi sẽ giúp bạn mở lại cửa sổ để hoàn tất giao dịch mua hàng`,
-    continueMessage: `Nhấp để tiếp tục`,
-  },
-  zh: {
-    windowMessage: `没有找到安全的${fundingSource}浏览器？我们将帮助您重启窗口以完成付款`,
-    continueMessage: `继续`,
-  },
-  zh_Hant: {
-    windowMessage: `看不到安全 ${fundingSource} 瀏覽器？我們會協助你重新啟動視窗，以完成購物程序`,
-    continueMessage: `按一下並繼續`,
-  },
-});
+export const containerContent: (string) => ContentMap = (fundingSource) => {
+  if (fundingSource === FUNDING.VENMO) {
+    return {
+      en: {
+        windowMessage:
+          "Tap cancel payment to cancel and return to the business. Continue payment will relaunch the payment window.",
+        continueMessage: "Continue payment",
+        cancelMessage: "Cancel payment",
+      },
+    };
+  } else {
+    return {
+      ar: {
+        windowMessage: `لا ترى متصفح ${fundingSource} الآمن؟ سنساعدك في إعادة فتح النافذة لاستكمال مشترياتك`,
+        continueMessage: `متابعة`,
+      },
+      bg: {
+        windowMessage: `Не виждате защитения браузър на ${fundingSource}? Ще ви помогнем да отворите отново прозореца, за да завършите покупката си`,
+        continueMessage: `Щракнете, за да продължите`,
+      },
+      cs: {
+        windowMessage: `Nezobrazuje se vám bezpečný prohlížeč ${fundingSource}? Pomůžeme vám okno znovu otevřít, abyste mohli nákup dokončit`,
+        continueMessage: `Pokračovat`,
+      },
+      da: {
+        windowMessage: `Kan du ikke se ${fundingSource}s sikre browser? Vi hjælper dig med at genstarte vinduet, så du kan betale`,
+        continueMessage: `Fortsæt`,
+      },
+      de: {
+        windowMessage: `Sie sehen das sichere Browserfenster von ${fundingSource} nicht? Hier können Sie es wieder öffnen und Ihren Einkauf abschließen`,
+        continueMessage: `Weiter`,
+      },
+      el: {
+        windowMessage: `Δεν βλέπετε το ασφαλές πρόγραμμα περιήγησης ${fundingSource}; Θα σας βοηθήσουμε να επανεκκινήσετε το παράθυρο για να ολοκληρώσετε την αγορά σας`,
+        continueMessage: `Συνέχεια`,
+      },
+      en: {
+        windowMessage: `Don’t see the secure ${fundingSource} browser? We’ll help you re-launch the window to complete your purchase`,
+        continueMessage: `Click to Continue`,
+      },
+      es: {
+        windowMessage: `¿No ve el navegador seguro de ${fundingSource}? Abriremos la ventana nuevamente para que pueda completar su compra`,
+        continueMessage: `Continuar`,
+      },
+      et: {
+        windowMessage: `Kas te ei näe turvalist ${fundingSource}i lehitsejat? Aitame teil ostu lõpuleviimiseks akna uuesti avada.`,
+        continueMessage: `Jätkamiseks klõpsake`,
+      },
+      fi: {
+        windowMessage: `Eikö suojattua ${fundingSource}-selainta näy? Autamme avaamaan ikkunan uudelleen oston viimeistelyä varten`,
+        continueMessage: `Jatka`,
+      },
+      fr: {
+        windowMessage: `Le navigateur sécurisé de ${fundingSource} n’apparaît pas ? Nous allons vous aider à rouvrir la fenêtre pour finaliser votre achat`,
+        continueMessage: `Continuer`,
+      },
+      he: {
+        windowMessage: `לא רואה את דפדפן ${fundingSource} המאובטח? נעזור לך לפתוח מחדש את החלון כדי להשלים את הקנייה שלך`,
+        continueMessage: `המשך`,
+      },
+      hu: {
+        windowMessage: `Nem látja a biztonságos ${fundingSource}-böngészőt? Segítünk újra betölteni az ablakot, hogy befejezhesse a vásárlást`,
+        continueMessage: `Folytatás`,
+      },
+      id: {
+        windowMessage: `Browser ${fundingSource} yang aman tidak terlihat? Kami akan membantu menampilkan ulang jendela untuk menyelesaikan pembayaran Anda`,
+        continueMessage: `Lanjutkan`,
+      },
+      it: {
+        windowMessage: `Non vedi la pagina sicura di ${fundingSource}? Ti aiuteremo a riaprire la finestra per completare l’acquisto`,
+        continueMessage: `Continua`,
+      },
+      ja: {
+        windowMessage: `セキュアなブラウザが表示されない場合は、ウィンドウを再起動して、支払いを完了できるようお手伝いいたします`,
+        continueMessage: `続行`,
+      },
+      ko: {
+        windowMessage: `보안 ${fundingSource} 브라우저가 보이지 않으신가요? 창을 다시 실행하여 결제를 완료할 수 있도록 도와드리겠습니다`,
+        continueMessage: `계속`,
+      },
+      lt: {
+        windowMessage: `Nematote saugios „${fundingSource}“ naršyklės? Padėsime iš naujo paleisti langą, kad užbaigtumėte pirkimą`,
+        continueMessage: `Paspauskite, jei norite tęsti`,
+      },
+      lv: {
+        windowMessage: `Vai neredzat drošo ${fundingSource} pārlūkprogrammu? Mēs palīdzēsim jums atkārtoti palaist logu, lai pabeigtu pirkumu.`,
+        continueMessage: `Noklikšķiniet, lai turpinātu`,
+      },
+      ms: {
+        windowMessage: `Tidak melihat pelayar ${fundingSource} yang selamat? Kami akan membantu anda melancarkan semula tetingkap untuk melengkapkan pembelian anda`,
+        continueMessage: `Klik untuk Meneruskan`,
+      },
+      no: {
+        windowMessage: `Ser du ikke den sikre ${fundingSource}-nettleseren? Vi hjelper deg med å starte vinduet på nytt så du kan fullføre kjøpet`,
+        continueMessage: `Fortsett`,
+      },
+      nl: {
+        windowMessage: `Ziet u de beveiligde ${fundingSource}-browser niet? We helpen u het venster opnieuw te openen om uw aankoop te voltooien`,
+        continueMessage: `Doorgaan`,
+      },
+      pl: {
+        windowMessage: `Nie widzisz bezpiecznej przeglądarki ${fundingSource}? Pomożemy Ci ponownie uruchomić to okno w celu dokonania zakupu`,
+        continueMessage: `Kontynuuj`,
+      },
+      pt: {
+        windowMessage: `Não está vendo o navegador seguro do ${fundingSource}? Ajudaremos você a reabrir a janela para concluir a compra`,
+        continueMessage: `Continuar`,
+      },
+      ro: {
+        windowMessage: `Nu vezi browser-ul securizat ${fundingSource}? Te vom ajuta să lansezi din nou fereastra pentru a finaliza achiziția`,
+        continueMessage: `Dă clic pentru a continua`,
+      },
+      ru: {
+        windowMessage: `Не отображается безопасная страница ${fundingSource} в браузере? Мы поможем вам повторно загрузить окно, чтобы завершить покупку`,
+        continueMessage: `Продолжить`,
+      },
+      si: {
+        windowMessage: `ආරක්ෂිත ${fundingSource} බ්‍රව්සරය නොපෙනේ ද? ඔබේ මිල දී ගැනීම සම්පූර්ණ කිරීම සඳහා අපි ඔබට කවුළුව නැවත දියත් කිරීමට උපකාර කරන්නෙමු`,
+        continueMessage: `ඉදිරියට යාමට ක්ලික් කරන්න`,
+      },
+      sk: {
+        windowMessage: `Nezobrazuje sa vám zabezpečený prehliadač ${fundingSource}? Pomôžeme vám znova otvoriť okno, aby ste mohli nákup dokončiť`,
+        continueMessage: `Pokračovať`,
+      },
+      sl: {
+        windowMessage: `Ne vidite ${fundingSource}ovega varnega brskalnika? Pomagali vam bomo ponovno zagnati okno za dokončanje nakupa`,
+        continueMessage: `Kliknite za nadaljevanje`,
+      },
+      sq: {
+        windowMessage: `Nuk e shikon shfletuesin e sigurt të ${fundingSource}? Do të të ndihmojmë të rihapësh dritaren për të përfunduar blerjen`,
+        continueMessage: `Kliko për të vazhduar`,
+      },
+      sv: {
+        windowMessage: `Ser du inte den säkra ${fundingSource}-webbläsaren? Vi hjälper dig att starta om fönstret för att slutföra ditt köp`,
+        continueMessage: `Fortsätt`,
+      },
+      th: {
+        windowMessage: `ถ้าคุณไม่เห็นเบราว์เซอร์ที่มีระบบความปลอดภัยของ ${fundingSource} เราจะช่วยคุณเปิดหน้าต่างอีกครั้งเพื่อชำระเงินให้เรียบร้อย`,
+        continueMessage: `ดำเนินการต่อ`,
+      },
+      tl: {
+        windowMessage: `Hindi nakikita ang secure na ${fundingSource} browser? Tutulungan ka naming i-launch ulit ang window para makumpleto ang pagbili mo.`,
+        continueMessage: `I-click para Magpatuloy`,
+      },
+      tr: {
+        windowMessage: `Güvenli ${fundingSource} tarayıcısını görmüyor musunuz? Alışverişinizi tamamlamak için pencereyi yeniden başlatmanıza yardımcı olacağız`,
+        continueMessage: `Devam`,
+      },
+      vi: {
+        windowMessage: `Bạn không thấy trình duyệt ${fundingSource} bảo mật? Chúng tôi sẽ giúp bạn mở lại cửa sổ để hoàn tất giao dịch mua hàng`,
+        continueMessage: `Nhấp để tiếp tục`,
+      },
+      zh: {
+        windowMessage: `没有找到安全的${fundingSource}浏览器？我们将帮助您重启窗口以完成付款`,
+        continueMessage: `继续`,
+      },
+      zh_Hant: {
+        windowMessage: `看不到安全 ${fundingSource} 瀏覽器？我們會協助你重新啟動視窗，以完成購物程序`,
+        continueMessage: `按一下並繼續`,
+      },
+    };
+  }
+};

--- a/src/zoid/content.js
+++ b/src/zoid/content.js
@@ -8,6 +8,7 @@ type ContentMap = {
     windowMessage?: string,
     continueMessage?: string,
     cancelMessage?: string,
+    interrogativeMessage?: string,
   |},
 };
 
@@ -19,6 +20,7 @@ export const containerContent: (string) => ContentMap = (fundingSource) => {
           "Tap cancel payment to cancel and return to the business. Continue payment will relaunch the payment window.",
         continueMessage: "Continue payment",
         cancelMessage: "Cancel payment",
+        interrogativeMessage: "What would you like to do?",
       },
     };
   } else {

--- a/src/zoid/venmo/component.jsx
+++ b/src/zoid/venmo/component.jsx
@@ -75,7 +75,7 @@ export function getVenmoCheckoutComponent(): VenmoCheckoutComponent {
         props,
       }) => {
         const { nonce } = props;
-        const content = containerContent("venmo")["en"];
+        const content = containerContent("venmo").en;
         return (
           <VenmoOverlay
             context={context}

--- a/src/zoid/venmo/component.jsx
+++ b/src/zoid/venmo/component.jsx
@@ -74,11 +74,8 @@ export function getVenmoCheckoutComponent(): VenmoCheckoutComponent {
         prerenderFrame,
         props,
       }) => {
-        const {
-          nonce,
-          locale: { lang },
-        } = props;
-        const content = containerContent("Venmo")[lang];
+        const { nonce } = props;
+        const content = containerContent("venmo")["en"];
         return (
           <VenmoOverlay
             context={context}

--- a/src/zoid/venmo/component.jsx
+++ b/src/zoid/venmo/component.jsx
@@ -27,7 +27,7 @@ import {
   inlineMemoize,
 } from "@krakenjs/belter/src";
 import { FUNDING } from "@paypal/sdk-constants/src";
-import { SpinnerPage, Overlay } from "@paypal/common-components/src";
+import { SpinnerPage, VenmoOverlay } from "@paypal/common-components/src";
 
 import { getSessionID } from "../../lib";
 import { containerContent } from "../content";
@@ -80,7 +80,7 @@ export function getVenmoCheckoutComponent(): VenmoCheckoutComponent {
         } = props;
         const content = containerContent("Venmo")[lang];
         return (
-          <Overlay
+          <VenmoOverlay
             context={context}
             close={close}
             focus={focus}


### PR DESCRIPTION
### Description

This PR adds a Venmo overlay component as requested in DTPPCPSDK-1254. It will be used for all Venmo button clicks, including Venmo Web use cases. The goal was to mimic the look and behavior of the BT SDK Venmo overlay in the PP SDK.

It was decided by Product that we should hard code English for now (English is currently the only language supported by Venmo), and that we should completely separate styles despite there being some duplication with the PayPal overlay.

### Screenshots

Here's a video demonstrating switching between the PayPal and Venmo overlays, including still displaying English in the Venmo overlay after setting the browser language (i.e. `navigator.language`) to Spanish:

https://github.com/paypal/paypal-checkout-components/assets/20399044/387ed62c-436c-4308-8e7e-c8ecb5010401

### Dependent Changes

https://github.com/paypal/paypal-common-components/pull/84 needs to be merged and published first.