### PR TITLE
Fix for firefox hover/filter side-effect

### DIFF
--- a/src/ui/buttons/styles/color.js
+++ b/src/ui/buttons/styles/color.js
@@ -33,6 +33,7 @@ export const buttonColorStyle = `
     @media (hover:hover) {
         .${CLASS.BUTTON}.${CLASS.COLOR}-${BUTTON_COLOR.GOLD}:hover {
             filter: brightness(0.95);
+            overflow: inherit;
         }
     }
 
@@ -156,6 +157,7 @@ export const buttonColorStyle = `
     .${CLASS.BUTTON}[${ATTRIBUTE.FUNDING_SOURCE}=${FUNDING.PAIDY}].${CLASS.COLOR}-${BUTTON_COLOR.DEFAULT}:hover,
     .${CLASS.BUTTON}[${ATTRIBUTE.FUNDING_SOURCE}=${FUNDING.WECHATPAY}].${CLASS.COLOR}-${BUTTON_COLOR.DEFAULT}:hover {
         filter: brightness(1.2);
+        overflow: inherit;
     }
 
     /* APM button on focus actions */
@@ -214,6 +216,7 @@ export const buttonColorStyle = `
     @media (hover:hover) {
         .${CLASS.BUTTON}.${CLASS.COLOR}-${BUTTON_COLOR.BLUE}:hover {
             filter: brightness(0.95);
+            overflow: inherit;
         }
     }
 
@@ -241,6 +244,7 @@ export const buttonColorStyle = `
     @media (hover:hover) {
         .${CLASS.BUTTON}.${CLASS.COLOR}-${BUTTON_COLOR.SILVER}:hover {
             filter: brightness(0.95);
+            overflow: inherit;
         }
     }
 
@@ -267,6 +271,7 @@ export const buttonColorStyle = `
 
     .${CLASS.BUTTON}.${CLASS.COLOR}-${BUTTON_COLOR.DARKBLUE}:hover {
         filter: brightness(1.2);
+        overflow: inherit;
     }
 
     .${CLASS.BUTTON}.${CLASS.COLOR}-${BUTTON_COLOR.DARKBLUE}:focus {
@@ -294,6 +299,7 @@ export const buttonColorStyle = `
 
     .${CLASS.BUTTON}.${CLASS.COLOR}-${BUTTON_COLOR.BLACK}:hover {
         filter: brightness(1.2);
+        overflow: inherit;
     }
 
     .${CLASS.BUTTON}.${CLASS.COLOR}-${BUTTON_COLOR.BLACK}:focus {
@@ -321,6 +327,7 @@ export const buttonColorStyle = `
     @media (hover:hover) {
         .${CLASS.BUTTON}.${CLASS.COLOR}-${BUTTON_COLOR.WHITE}:hover {
             filter: brightness(0.95);
+            overflow: inherit;
         }
     }
     
@@ -357,6 +364,7 @@ export const buttonColorStyle = `
 
     .${CLASS.BUTTON} .${CLASS.CARD}:hover {
         filter: brightness(1.2);
+        overflow: inherit;
     }
 
     .${CLASS.BUTTON} .${CLASS.CARD}:focus {


### PR DESCRIPTION
### Description

Firefox displays a weird side-effect when hovering and applying `filter: brightness(X)` (the element being hovered loses its shape). The root cause of this could be many things (there are a lot of classes being applied to paypal-button). We observed that `overflow: hidden` was having some cascading side-effect on `filter: brightness(X)`. The proposed solution is to **_explicitly_** apply `overflow: inherit` to the hover class. This solution targets the `.paypal-button.paypal-button-color-{COLOR}:hover` only and thus prevents this to cascade onto any other classes. This fixes the bug in firefox and the behavior remains the same in chrome.

eg: `
  .paypal-button.paypal-button-color-{COLOR}:hover {
    filter: brightness(X);
    overflow: inherit;
  }
`

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

Ticket [LI-26326](https://paypal.atlassian.net/browse/LI-26326) pointed out weird behavior when hovering PayPal button in Firefox. 

### Reproduction Steps (if applicable)

Go to this [codepen](https://codepen.io/daniel-paypal/pen/gOqbzyG) (fyi: reproduction is not consistent on all devices)

### Screenshots (if applicable)

Unhovered button:
<img width="1236" alt="Screenshot 2023-11-14 at 13 14 27" src="https://github.com/paypal/paypal-checkout-components/assets/101415858/2feeb4f8-02e2-4f29-a06c-94a17a0df059">

Hovered button:
<img width="1247" alt="Screenshot 2023-11-14 at 13 14 33" src="https://github.com/paypal/paypal-checkout-components/assets/101415858/cc2da795-ce44-41ff-a6a7-b5973a2c764e">

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
