### PR TITLE
fix: bump connect loader to beta without polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@krakenjs/zoid": "^10.3.1",
     "@paypal/common-components": "^1.0.35",
     "@paypal/funding-components": "^1.0.31",
-    "@paypal/connect-loader-component": "^1.1.0",
+    "@paypal/connect-loader-component": "1.1.0-beta.1",
     "@paypal/sdk-client": "^4.0.176",
     "@paypal/sdk-constants": "^1.0.133",
     "@paypal/sdk-logos": "^2.2.6"


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

Use the new Connect Loader beta version that removes the polyfill from the downstream asset loader.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

Our build enforces flat deps and the polyfill is a dep required by old Hosted Fields.

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
