### PR TITLE
set referrerDomain in xprops

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -721,7 +721,13 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
 
       referrer_domain: {
         type: "string",
-        value: () => new URL(window.document.referrer).host,
+        value: () => {
+          const referrer = window.document.referrer;
+          const matches = referrer.match(/:\/\/([^\/\?]+)/);
+          if (matches) {
+            return matches[1];
+          }
+        },
       },
 
       userIDToken: {

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -719,16 +719,11 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
         },
       },
 
-      referrer_domain: {
+      referrerDomain: {
         type: "string",
         required: false,
-        value: () => {
-          const referrer = window.document.referrer;
-          const matches = referrer.match(/:\/\/([^/?]+)/);
-          if (matches) {
-            return matches[1];
-          }
-        },
+        // eslint-disable-next-line compat/compat
+        value: () => new URL(window.document.referrer).host,
       },
 
       userIDToken: {

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -721,6 +721,7 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
 
       referrer_domain: {
         type: "string",
+        required: false,
         value: () => {
           const referrer = window.document.referrer;
           const matches = referrer.match(/:\/\/([^/?]+)/);

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -723,7 +723,7 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
         type: "string",
         value: () => {
           const referrer = window.document.referrer;
-          const matches = referrer.match(/:\/\/([^\/\?]+)/);
+          const matches = referrer.match(/:\/\/([^/?]+)/);
           if (matches) {
             return matches[1];
           }

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -719,6 +719,11 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
         },
       },
 
+      referrer_domain: {
+        type: "string",
+        value: () => new URL(window.document.referrer).host,
+      },
+
       userIDToken: {
         type: "string",
         default: getUserIDToken,

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -724,7 +724,6 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
         required: false,
         value: () => {
           if (window.document.referrer) {
-            // eslint-disable-next-line compat/compat
             return new URL(window.document.referrer).host || undefined;
           }
         },

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -722,8 +722,12 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
       referrerDomain: {
         type: "string",
         required: false,
-        // eslint-disable-next-line compat/compat
-        value: () => new URL(window.document.referrer).host,
+        value: () => {
+          if (window.document.referrer) {
+            // eslint-disable-next-line compat/compat
+            return new URL(window.document.referrer).host || undefined;
+          }
+        },
       },
 
       userIDToken: {

--- a/test/integration/tests/button/props.js
+++ b/test/integration/tests/button/props.js
@@ -158,7 +158,17 @@ describe(`paypal button component props`, () => {
               )} to be queried, got ${queriedRenderedButtons.join(",")}`
             );
           }
+
+          if (xprops.referrer_domain !== "example.com") {
+            throw new Error(
+              `Expected referrer_domain to be example.com, got ${xprops.referrer_domain}`
+            );
+          }
         };
+
+        Object.defineProperty(document, "referrer", {
+          get: () => "https://example.com/path?q=1",
+        });
 
         const instance = window.paypal.Buttons({
           test: {

--- a/test/integration/tests/button/props.js
+++ b/test/integration/tests/button/props.js
@@ -176,8 +176,8 @@ describe(`paypal button component props`, () => {
         "https://not.example.com/path?q=1",
         "not.example.com"
       ),
-      // eslint-disable-next-line no-script-url
       expectReferrerDomainToEqual(
+        // eslint-disable-next-line no-script-url
         "javascript:alert(document.cookie)",
         undefined
       ),

--- a/test/integration/tests/button/props.js
+++ b/test/integration/tests/button/props.js
@@ -155,7 +155,9 @@ describe(`paypal button component props`, () => {
               onRender: expect("onRender", ({ xprops }) => {
                 if (xprops.referrerDomain !== domain) {
                   throw new Error(
-                    `Expected referrerDomain to be ${domain}, got ${xprops.referrerDomain}`
+                    `Expected referrerDomain to be ${domain || ""}, got ${
+                      xprops.referrerDomain
+                    }`
                   );
                 }
               }),
@@ -177,7 +179,11 @@ describe(`paypal button component props`, () => {
       expectReferrerDomainToEqual(
         // eslint-disable-next-line no-script-url
         "javascript:alert(document.cookie)",
-        ""
+        undefined
+      ),
+      expectReferrerDomainToEqual(
+        "", // when there is no referrer
+        undefined
       ),
     ]);
   });

--- a/test/integration/tests/button/props.js
+++ b/test/integration/tests/button/props.js
@@ -155,9 +155,7 @@ describe(`paypal button component props`, () => {
               onRender: expect("onRender", ({ xprops }) => {
                 if (xprops.referrerDomain !== domain) {
                   throw new Error(
-                    `Expected referrerDomain to be ${
-                      domain ?? "undefined"
-                    }, got ${xprops.referrerDomain}`
+                    `Expected referrerDomain to be ${domain}, got ${xprops.referrerDomain}`
                   );
                 }
               }),
@@ -179,7 +177,7 @@ describe(`paypal button component props`, () => {
       expectReferrerDomainToEqual(
         // eslint-disable-next-line no-script-url
         "javascript:alert(document.cookie)",
-        undefined
+        ""
       ),
     ]);
   });


### PR DESCRIPTION
### Description

This PR adds a new prop to the `Buttons` component, which will be used to identify the referrer to a page that loaded the SDK.

### Why are we making these changes? 

The analytics team wants to be able to identify major channels (e.g. facebook / instagram) to SDK uses.

### Reproduction Steps (if applicable)

```
npm run karma
```

❤️ Thank you!
