### PR TITLE
Validate braintree version and default cmid to sessionId if null

### DIFF
--- a/src/connect/component.jsx
+++ b/src/connect/component.jsx
@@ -20,7 +20,7 @@ const MIN_MAJOR_VERSION = 3;
 const MIN_MINOR_VERSION = 97;
 export const MIN_BT_VERSION = `${MIN_MAJOR_VERSION}.${MIN_MINOR_VERSION}.3-connect-alpha.6.1`; // Minimum for supporting AXO
 
-export function getSdkVersion(version: string | null): string | null {
+export function getSdkVersion(version: string | null): string {
   if (!version) {
     return MIN_BT_VERSION;
   }

--- a/src/connect/component.jsx
+++ b/src/connect/component.jsx
@@ -41,7 +41,7 @@ export function getSdkVersion(version: string | null): string {
     });
 
     throw new Error(
-      `The braintree version used does not support Accelerated Checkout (AXO). Please use version ${MIN_BT_VERSION} or above`
+      `The braintree version used does not support Connect. Please use version ${MIN_BT_VERSION} or above`
     );
   }
 

--- a/src/connect/component.jsx
+++ b/src/connect/component.jsx
@@ -21,7 +21,9 @@ const MIN_MINOR_VERSION = 97;
 export const MIN_BT_VERSION = `${MIN_MAJOR_VERSION}.${MIN_MINOR_VERSION}.3-connect-alpha.6.1`; // Minimum for supporting AXO
 
 export function getSdkVersion(version: string | null): string | null {
-  if (!version) return MIN_BT_VERSION;
+  if (!version) {
+    return MIN_BT_VERSION;
+  }
   const versionSplit = version.split(".");
   const majorVersion = Number(versionSplit[0]);
   const minorVersion = Number(versionSplit[1]);

--- a/src/connect/component.test.js
+++ b/src/connect/component.test.js
@@ -8,7 +8,11 @@ import {
 import { loadAxo } from "@paypal/connect-loader-component";
 import { describe, expect, test, vi } from "vitest";
 
-import { getConnectComponent } from "./component";
+import {
+  getConnectComponent,
+  getSdkVersion,
+  MIN_BT_VERSION,
+} from "./component";
 import { sendCountMetric } from "./sendCountMetric";
 
 vi.mock("@paypal/sdk-client/src", () => {
@@ -105,5 +109,34 @@ describe("getConnectComponent: returns ConnectComponent", () => {
       metadata: undefined,
       platform: "PPCP",
     });
+  });
+});
+
+describe("getSdkVersion", () => {
+  test("returns minimum supported braintree version for AXO if input version is null", () => {
+    const version = getSdkVersion(null);
+
+    expect(version).toEqual(MIN_BT_VERSION);
+  });
+  test("returns the version passed if it is supported for AXO", () => {
+    const result1 = getSdkVersion("3.97.00");
+    const result2 = getSdkVersion("3.97.alpha-test");
+    const result3 = getSdkVersion("4.34.beta-test");
+    const result4 = getSdkVersion("4.34.47");
+
+    expect(result1).toEqual("3.97.00");
+    expect(result2).toEqual("3.97.alpha-test");
+    expect(result3).toEqual("4.34.beta-test");
+    expect(result4).toEqual("4.34.47");
+  });
+
+  test("throws error if the version passed is not supported for AXO and is not null", () => {
+    const result1 = getSdkVersion("3.96.00");
+    const result2 = getSdkVersion("2.87.alpha-test");
+    const result3 = getSdkVersion("3.34.beta-test");
+
+    expect(result1).toThrowError();
+    expect(result2).toThrowError();
+    expect(result3).toThrowError();
   });
 });


### PR DESCRIPTION
### Description

This PR contains 2 changes:

1. When we receive a null `cmid` from the sdk `data-client-metadata-id` data attribute, we will pass the sessionId to AXO as it is a required value.
2. We will validate that the version of braintree being used supports AXO. Otherwise, if an unsupported version is passed we will throw an error, and if no version is passed then it means the client is not using braintree and we can safely default it to the minimum supported version for AXO.

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

[cmid change ticket](https://paypal.atlassian.net/browse/DTPPCPSDK-1403)
[braintree validation ticket](https://paypal.atlassian.net/browse/DTPPCPSDK-1445) 

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
