### PR TITLE
Memoize Shopper Insights API Call

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { getPartnerAttributionID, getSessionID } from "@paypal/sdk-client/src";
-import { request } from "@krakenjs/belter/src";
+import { inlineMemoize, request } from "@krakenjs/belter/src";
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 
 import { HEADERS } from "../constants/api";
@@ -51,4 +51,17 @@ export function callRestAPI({
 
     return body;
   });
+}
+
+export function callMemoizedRestAPI({
+  accessToken,
+  method,
+  url,
+  data,
+}: RestAPIParams): ZalgoPromise<Object> {
+  return inlineMemoize(
+    callMemoizedRestAPI,
+    () => callRestAPI({ accessToken, method, url, data }),
+    [accessToken, method, url, JSON.stringify(data)]
+  );
 }

--- a/src/api/shopper-insights/component.js
+++ b/src/api/shopper-insights/component.js
@@ -17,7 +17,7 @@ import { FPTI_KEY } from "@paypal/sdk-constants/src";
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 import { stringifyError } from "@krakenjs/belter/src";
 
-import { callRestAPI } from "../api";
+import { callMemoizedRestAPI } from "../api";
 import {
   ELIGIBLE_PAYMENT_METHODS,
   FPTI_TRANSITION,
@@ -134,7 +134,7 @@ export function getShopperInsightsComponent(): ShopperInsightsComponent {
       const requestPayload =
         createRecommendedPaymentMethodsRequestPayload(merchantPayload);
 
-      return callRestAPI({
+      return callMemoizedRestAPI({
         method: "POST",
         url: `${getPayPalAPIDomain()}/${ELIGIBLE_PAYMENT_METHODS}`,
         data: requestPayload,

--- a/src/api/shopper-insights/component.test.js
+++ b/src/api/shopper-insights/component.test.js
@@ -73,6 +73,69 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
     expect.assertions(2);
   });
 
+  test("should get recommended payment methods from memoized request for the exact same payload", async () => {
+    const shopperInsightsComponent = getShopperInsightsComponent();
+    const payload = {
+      customer: {
+        email: "email-1.0@test.com",
+        phone: {
+          countryCode: "1",
+          nationalNumber: "2345678901",
+        },
+      },
+    };
+    const response1 =
+      await shopperInsightsComponent.getRecommendedPaymentMethods(payload);
+    expect(request).toHaveBeenCalled();
+    expect(request).toHaveBeenCalledTimes(1);
+    const response2 =
+      await shopperInsightsComponent.getRecommendedPaymentMethods(payload);
+
+    expect(request).toHaveBeenCalled();
+    // This should not change as the payload is same
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(response1).toEqual({
+      isPayPalRecommended: true,
+      isVenmoRecommended: false,
+    });
+    expect(response2).toEqual({
+      isPayPalRecommended: true,
+      isVenmoRecommended: false,
+    });
+    expect.assertions(6);
+  });
+
+  test("should not get recommended payment methods from memoized request for a different payload", async () => {
+    const shopperInsightsComponent = getShopperInsightsComponent();
+    const response1 =
+      await shopperInsightsComponent.getRecommendedPaymentMethods({
+        customer: {
+          email: "email-1.1@test.com",
+        },
+      });
+    expect(request).toHaveBeenCalled();
+    expect(request).toHaveBeenCalledTimes(1);
+    const response2 =
+      await shopperInsightsComponent.getRecommendedPaymentMethods({
+        customer: {
+          email: "email-1.2@test.com",
+        },
+      });
+
+    expect(request).toHaveBeenCalled();
+    // This must change to 2 as the payload is different
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(response1).toEqual({
+      isPayPalRecommended: true,
+      isVenmoRecommended: false,
+    });
+    expect(response2).toEqual({
+      isPayPalRecommended: true,
+      isVenmoRecommended: false,
+    });
+    expect.assertions(6);
+  });
+
   test("catch errors from the API", async () => {
     // $FlowFixMe
     request.mockImplementationOnce(() =>


### PR DESCRIPTION


### Description
* Refactor the existing shopper insights tests to mock the request method of external belter module instead of internal callRestAPI
* Memoize the Shopper Insights API Call to avoid duplicate calls with exact same set of parameters. 

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
