### PR TITLE
validate sdk-token required in getRecommendedPaymentMethods() method

### DIFF
--- a/src/api/shopper-insights/component.js
+++ b/src/api/shopper-insights/component.js
@@ -125,10 +125,9 @@ export function getShopperInsightsComponent(): ShopperInsightsComponent {
     [FPTI_KEY.EVENT_NAME]: FPTI_TRANSITION.SHOPPER_INSIGHTS_API_INIT,
   });
 
-  validateMerchantConfig({ sdkToken, pageType, userIDToken, clientToken });
-
   const shopperInsights = {
     getRecommendedPaymentMethods: (merchantPayload) => {
+      validateMerchantConfig({ sdkToken, pageType, userIDToken, clientToken });
       validateMerchantPayload(merchantPayload);
 
       const requestPayload =

--- a/src/api/shopper-insights/component.test.js
+++ b/src/api/shopper-insights/component.test.js
@@ -1,6 +1,6 @@
 /* @flow */
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
-import { getEnv, getBuyerCountry } from "@paypal/sdk-client/src";
+import { getEnv, getBuyerCountry, getSDKToken } from "@paypal/sdk-client/src";
 import { vi, describe, expect } from "vitest";
 import { request } from "@krakenjs/belter/src";
 
@@ -347,5 +347,29 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
         }),
       })
     );
+  });
+
+  test("ensure sdk-token is passed when using the getRecommendedPaymentMethods", async () => {
+    getSDKToken.mockImplementationOnce(() => undefined);
+    // $FlowFixMe
+    const shopperInsightsComponent = getShopperInsightsComponent();
+    const error = new Error(
+      "script data attribute sdk-client-token is required but was not passed"
+    );
+    error.code = "validation_error";
+    error.name = "ValidationError";
+    await expect(
+      async () =>
+        await shopperInsightsComponent.getRecommendedPaymentMethods({
+          customer: {
+            email: "email@test.com",
+            phone: {
+              countryCode: "1",
+              nationalNumber: "2345678905",
+            },
+          },
+        })
+    ).rejects.toThrowError(error);
+    expect.assertions(1);
   });
 });

--- a/src/api/shopper-insights/component.test.js
+++ b/src/api/shopper-insights/component.test.js
@@ -4,6 +4,8 @@ import { getEnv, getBuyerCountry, getSDKToken } from "@paypal/sdk-client/src";
 import { vi, describe, expect } from "vitest";
 import { request } from "@krakenjs/belter/src";
 
+import { ValidationError } from "../../lib";
+
 import { getShopperInsightsComponent } from "./component";
 
 vi.mock("@paypal/sdk-client/src", () => {
@@ -350,14 +352,13 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
   });
 
   test("ensure sdk-token is passed when using the getRecommendedPaymentMethods", async () => {
+    // $FlowFixMe
     getSDKToken.mockImplementationOnce(() => undefined);
     // $FlowFixMe
     const shopperInsightsComponent = getShopperInsightsComponent();
-    const error = new Error(
-      "script data attribute sdk-client-token is required but was not passed"
+    const error = new ValidationError(
+      `script data attribute sdk-client-token is required but was not passed`
     );
-    error.code = "validation_error";
-    error.name = "ValidationError";
     await expect(
       async () =>
         await shopperInsightsComponent.getRecommendedPaymentMethods({


### PR DESCRIPTION
### Description

* Validate sdk-token is required only when calling  getRecommendedPaymentMethods() instead of when initialing the component. 

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
