### PR TITLE
Update hosted buttons funding source mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/checkout-components",
-  "version": "5.0.295",
+  "version": "5.0.294",
   "description": "PayPal Checkout components, for integrating checkout products.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/checkout-components",
-  "version": "5.0.295-alpha.10",
+  "version": "5.0.295",
   "description": "PayPal Checkout components, for integrating checkout products.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/checkout-components",
-  "version": "5.0.294",
+  "version": "5.0.295-alpha.10",
   "description": "PayPal Checkout components, for integrating checkout products.",
   "main": "index.js",
   "scripts": {

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -58,17 +58,6 @@ export const createAccessToken: CreateAccessToken = memoize<CreateAccessToken>(
 const getButtonVariable = (variables: ButtonVariables, key: string): string =>
   variables?.find((variable) => variable.name === key)?.value ?? "";
 
-export const getFundingSource = (paymentSource: string): string => {
-  let fundingSource = paymentSource;
-  // The SDK uses "credit" for the "Debit or Credit Card" button, but the
-  // Hosted Buttons API expects "CARD" for the "Debit or Credit Card" button
-  // as the `funding_source` property.
-  if (paymentSource === FUNDING.CREDIT) {
-    fundingSource = FUNDING.CARD;
-  }
-  return fundingSource.toUpperCase();
-};
-
 export const getHostedButtonDetails: HostedButtonDetailsParams = ({
   hostedButtonId,
 }) => {
@@ -133,7 +122,7 @@ export const buildHostedButtonCreateOrder = ({
         method: "POST",
         body: JSON.stringify({
           entry_point: entryPoint,
-          funding_source: getFundingSource(data.paymentSource),
+          funding_source: data.paymentSource.toUpperCase(),
           merchant_id: merchantId,
           ...userInputs,
         }),
@@ -163,7 +152,7 @@ export const buildHostedButtonOnApprove = ({
         // The "Debit or Credit Card" button does not open a popup
         // so we need to open a new popup for buyers who complete
         // a checkout via "Debit or Credit Card".
-        if (data.paymentSource === FUNDING.CREDIT) {
+        if (data.paymentSource === FUNDING.CARD) {
           const url = `${baseUrl}/ncp/payment/${hostedButtonId}/${data.orderID}`;
           if (supportsPopups()) {
             popup(url, {

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -7,7 +7,6 @@ import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 import {
   buildHostedButtonCreateOrder,
   buildHostedButtonOnApprove,
-  getFundingSource,
   getHostedButtonDetails,
 } from "./utils";
 
@@ -142,22 +141,17 @@ describe("buildHostedButtonOnApprove", () => {
 
     // $FlowIssue
     supportsPopups.mockImplementation(() => true);
-    await onApprove({ orderID, paymentSource: "credit" });
+    await onApprove({ orderID, paymentSource: "card" });
     expect(popup).toHaveBeenCalled();
 
     // but redirects if popups are not supported
     // $FlowIssue
     supportsPopups.mockImplementation(() => false);
-    await onApprove({ orderID, paymentSource: "credit" });
+    await onApprove({ orderID, paymentSource: "card" });
     expect(window.location).toMatch(
       `/ncp/payment/${hostedButtonId}/${orderID}`
     );
 
     expect.assertions(2);
   });
-});
-
-test("getFundingSource", () => {
-  expect(getFundingSource("paypal")).toEqual("PAYPAL");
-  expect(getFundingSource("credit")).toEqual("CARD");
 });


### PR DESCRIPTION
### Description

This PR fixes two issues:

1. The hosted buttons API is no longer expecting a custom funding source (it is now just uppercased)
2. The funding source used to detect inline guest was incorrectly mapped to `credit` when it should have been `card` - which prevented the payment done popup from displaying after the order was captured.

### Why are we making these changes?

Completing a checkout via inline guest results in no popup window at the moment, which might be confusing for a buyer - not seeing any confirmation of the purchase.

### Reproduction Steps (if applicable)

This functionality is only available in a test environment - let me know if you'd like to try it out and I can send the proper credentials.

❤️ Thank you!
