### PR TITLE
remove customer wrapper from getRecommendedPaymentMethods

### DIFF
--- a/src/api/shopper-insights/component.js
+++ b/src/api/shopper-insights/component.js
@@ -72,12 +72,12 @@ function createRecommendedPaymentMethodsRequestPayload(
       }),
       // $FlowIssue
       ...(hasEmail(merchantPayload) && {
-        email: merchantPayload?.customer?.email,
+        email: merchantPayload?.email,
       }),
       ...(hasPhoneNumber(merchantPayload) && {
         phone: {
-          country_code: merchantPayload?.customer?.phone?.countryCode,
-          national_number: merchantPayload?.customer?.phone?.nationalNumber,
+          country_code: merchantPayload?.phone?.countryCode,
+          national_number: merchantPayload?.phone?.nationalNumber,
         },
       }),
     },

--- a/src/api/shopper-insights/component.test.js
+++ b/src/api/shopper-insights/component.test.js
@@ -58,12 +58,10 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
     const shopperInsightsComponent = getShopperInsightsComponent();
     const recommendedPaymentMethods =
       await shopperInsightsComponent.getRecommendedPaymentMethods({
-        customer: {
-          email: "email@test.com",
-          phone: {
-            countryCode: "1",
-            nationalNumber: "2345678901",
-          },
+        email: "email@test.com",
+        phone: {
+          countryCode: "1",
+          nationalNumber: "2345678901",
         },
       });
 
@@ -78,12 +76,10 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
   test("should get recommended payment methods from memoized request for the exact same payload", async () => {
     const shopperInsightsComponent = getShopperInsightsComponent();
     const payload = {
-      customer: {
-        email: "email-1.0@test.com",
-        phone: {
-          countryCode: "1",
-          nationalNumber: "2345678901",
-        },
+      email: "email-1.0@test.com",
+      phone: {
+        countryCode: "1",
+        nationalNumber: "2345678901",
       },
     };
     const response1 =
@@ -111,17 +107,13 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
     const shopperInsightsComponent = getShopperInsightsComponent();
     const response1 =
       await shopperInsightsComponent.getRecommendedPaymentMethods({
-        customer: {
-          email: "email-1.1@test.com",
-        },
+        email: "email-1.1@test.com",
       });
     expect(request).toHaveBeenCalled();
     expect(request).toHaveBeenCalledTimes(1);
     const response2 =
       await shopperInsightsComponent.getRecommendedPaymentMethods({
-        customer: {
-          email: "email-1.2@test.com",
-        },
+        email: "email-1.2@test.com",
       });
 
     expect(request).toHaveBeenCalled();
@@ -155,12 +147,10 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
 
     await expect(() =>
       shopperInsightsComponent.getRecommendedPaymentMethods({
-        customer: {
-          email: "email@test.com",
-          phone: {
-            countryCode: "1",
-            nationalNumber: "2345678905",
-          },
+        email: "email@test.com",
+        phone: {
+          countryCode: "1",
+          nationalNumber: "2345678905",
         },
       })
     ).rejects.toThrow(
@@ -172,15 +162,13 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
     expect.assertions(2);
   });
 
-  test("create customer payload with email and phone number", async () => {
+  test("create payload with email and phone number", async () => {
     const shopperInsightsComponent = getShopperInsightsComponent();
     await shopperInsightsComponent.getRecommendedPaymentMethods({
-      customer: {
-        email: "email10@test.com",
-        phone: {
-          countryCode: "1",
-          nationalNumber: "2345678906",
-        },
+      email: "email10@test.com",
+      phone: {
+        countryCode: "1",
+        nationalNumber: "2345678906",
       },
     });
 
@@ -199,12 +187,10 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
     );
   });
 
-  test("create customer payload with email only", async () => {
+  test("create payload with email only", async () => {
     const shopperInsightsComponent = getShopperInsightsComponent();
     await shopperInsightsComponent.getRecommendedPaymentMethods({
-      customer: {
-        email: "email2@test.com",
-      },
+      email: "email2@test.com",
     });
 
     expect(request).toHaveBeenCalledWith(
@@ -218,15 +204,13 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
     );
   });
 
-  test("create customer payload with phone only", async () => {
+  test("create payload with phone only", async () => {
     const shopperInsightsComponent = getShopperInsightsComponent();
     await shopperInsightsComponent.getRecommendedPaymentMethods({
-      customer: {
-        email: "email5@test.com",
-        phone: {
-          countryCode: "1",
-          nationalNumber: "2345678901",
-        },
+      email: "email5@test.com",
+      phone: {
+        countryCode: "1",
+        nationalNumber: "2345678901",
       },
     });
 
@@ -244,12 +228,10 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
     );
   });
 
-  test("should default purchase units with currency code in the customer payload", async () => {
+  test("should default purchase units with currency code in the payload", async () => {
     const shopperInsightsComponent = getShopperInsightsComponent();
     await shopperInsightsComponent.getRecommendedPaymentMethods({
-      customer: {
-        email: "email6@test.com",
-      },
+      email: "email6@test.com",
     });
 
     expect(request).toHaveBeenCalledWith(
@@ -273,9 +255,7 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
 
     const shopperInsightsComponent = getShopperInsightsComponent();
     await shopperInsightsComponent.getRecommendedPaymentMethods({
-      customer: {
-        email: "email7@test.com",
-      },
+      email: "email7@test.com",
     });
 
     expect(request).toHaveBeenCalledWith(
@@ -297,9 +277,7 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
 
     const shopperInsightsComponent = getShopperInsightsComponent();
     await shopperInsightsComponent.getRecommendedPaymentMethods({
-      customer: {
-        email: "email9@test.com",
-      },
+      email: "email9@test.com",
     });
 
     expect(request).toHaveBeenCalledWith(
@@ -313,31 +291,22 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
     );
   });
 
-  test("should not set country code in prod env in the customer payload", async () => {
+  test("should not set country code in prod env in the payload", async () => {
     const shopperInsightsComponent = getShopperInsightsComponent();
     await shopperInsightsComponent.getRecommendedPaymentMethods({
-      customer: {
-        email: "email@test.com",
-      },
+      email: "email@test.com",
     });
 
-    expect(request).toHaveBeenCalledWith(
-      expect.objectContaining({
-        json: expect.objectContaining({
-          customer: expect.not.objectContaining({
-            country_code: expect.anything(),
-          }),
-        }),
-      })
+    // $FlowIssue
+    expect(request.mock.calls[0][0].json.customer.country_code).toEqual(
+      undefined
     );
   });
 
   test("should request recommended payment methods by setting account details in the payload", async () => {
     const shopperInsightsComponent = getShopperInsightsComponent();
     await shopperInsightsComponent.getRecommendedPaymentMethods({
-      customer: {
-        email: "email9@test.com",
-      },
+      email: "email9@test.com",
     });
 
     expect(request).toHaveBeenCalledWith(
@@ -362,12 +331,10 @@ describe("shopper insights component - getRecommendedPaymentMethods()", () => {
     await expect(
       async () =>
         await shopperInsightsComponent.getRecommendedPaymentMethods({
-          customer: {
-            email: "email@test.com",
-            phone: {
-              countryCode: "1",
-              nationalNumber: "2345678905",
-            },
+          email: "email@test.com",
+          phone: {
+            countryCode: "1",
+            nationalNumber: "2345678905",
           },
         })
     ).rejects.toThrowError(error);

--- a/src/api/shopper-insights/validation.js
+++ b/src/api/shopper-insights/validation.js
@@ -75,63 +75,45 @@ export function validateMerchantConfig({
   }
 }
 
-export const hasEmail = (merchantPayload: MerchantPayloadData): boolean => {
-  return Boolean(merchantPayload?.customer?.email);
-};
+export const hasEmail = (merchantPayload: MerchantPayloadData): boolean =>
+  Boolean(merchantPayload?.email);
 
-export const hasPhoneNumber = (
-  merchantPayload: MerchantPayloadData
-): boolean => {
-  return Boolean(
-    merchantPayload?.customer?.phone?.countryCode &&
-      merchantPayload?.customer?.phone?.nationalNumber
+export const hasPhoneNumber = (merchantPayload: MerchantPayloadData): boolean =>
+  Boolean(
+    merchantPayload?.phone?.countryCode &&
+      merchantPayload?.phone?.nationalNumber
   );
-};
 
-const isValidEmailFormat = (email: string): boolean => {
-  const emailRegex = /^.+@.+$/;
-  return email.length < 320 && emailRegex.test(email);
-};
+const isValidEmailFormat = (email: ?string): boolean =>
+  typeof email === "string" && email.length < 320 && /^.+@.+$/.test(email);
 
-const isValidPhoneNumberFormat = (phoneNumber: string): boolean => {
-  const phoneNumberRegex = /\d{5,}/;
-  return phoneNumberRegex.test(phoneNumber);
-};
+const isValidPhoneNumberFormat = (phoneNumber: ?string): boolean =>
+  typeof phoneNumber === "string" && /\d{5,}/.test(phoneNumber);
 
 export function validateMerchantPayload(merchantPayload: MerchantPayloadData) {
-  if (
-    typeof merchantPayload !== "object" ||
-    Object.keys(merchantPayload).length === 0 ||
-    !Object.keys(merchantPayload).includes("customer")
-  ) {
-    throw new ValidationError(
-      `Expected shopper information to be passed into customer object`
-    );
-  }
-
   const hasEmailOrPhoneNumber =
     hasEmail(merchantPayload) || hasPhoneNumber(merchantPayload);
-  if (!hasEmailOrPhoneNumber) {
+  if (typeof merchantPayload !== "object" || !hasEmailOrPhoneNumber) {
     throw new ValidationError(
-      `Expected shopper information to include an email or phone number`
+      `Expected either email or phone number for get recommended payment methods`
     );
   }
 
-  const merchantPayloadEmail = merchantPayload?.customer?.email || "";
-  if (hasEmail(merchantPayload) && !isValidEmailFormat(merchantPayloadEmail)) {
+  if (
+    hasEmail(merchantPayload) &&
+    !isValidEmailFormat(merchantPayload?.email)
+  ) {
     throw new ValidationError(
       `Expected shopper information to include a valid email format`
     );
   }
 
-  const merchantPhonePayload = merchantPayload?.customer?.phone || {};
-  const nationalNumber = merchantPhonePayload?.nationalNumber || "";
   if (
     hasPhoneNumber(merchantPayload) &&
-    !isValidPhoneNumberFormat(nationalNumber)
+    !isValidPhoneNumberFormat(merchantPayload?.phone?.nationalNumber)
   ) {
     throw new ValidationError(
-      `Expected shopper information to a valid phone number format`
+      `Expected shopper information to be a valid phone number format`
     );
   }
 }

--- a/src/api/shopper-insights/validation.test.js
+++ b/src/api/shopper-insights/validation.test.js
@@ -54,9 +54,7 @@ describe("shopper insights merchant payload validation", () => {
   test("should have successful validation if email is only passed", () => {
     expect(() =>
       validateMerchantPayload({
-        customer: {
-          email: "email@test.com",
-        },
+        email: "email@test.com",
       })
     ).not.toThrowError();
   });
@@ -64,11 +62,9 @@ describe("shopper insights merchant payload validation", () => {
   test("should have successful validation if phone is only passed", () => {
     expect(() =>
       validateMerchantPayload({
-        customer: {
-          phone: {
-            countryCode: "1",
-            nationalNumber: "2345678901",
-          },
+        phone: {
+          countryCode: "1",
+          nationalNumber: "2345678901",
         },
       })
     ).not.toThrowError();
@@ -77,66 +73,65 @@ describe("shopper insights merchant payload validation", () => {
   test("should have successful validation if email and phone is passed", () => {
     expect(() =>
       validateMerchantPayload({
-        customer: {
-          email: "email@test.com",
-          phone: {
-            countryCode: "1",
-            nationalNumber: "2345678901",
-          },
+        email: "email@test.com",
+        phone: {
+          countryCode: "1",
+          nationalNumber: "2345678901",
         },
       })
     ).not.toThrowError();
   });
 
   test("should throw if email or phone is not passed", () => {
+    expect(() => validateMerchantPayload({})).toThrowError(
+      "Expected either email or phone number for get recommended payment methods"
+    );
+
     expect(() =>
-      validateMerchantPayload({
-        customer: {},
-      })
+      // $FlowIssue
+      validateMerchantPayload()
     ).toThrowError(
-      "Expected shopper information to include an email or phone number"
+      "Expected either email or phone number for get recommended payment methods"
     );
   });
 
   test("should throw if countryCode or nationalNumber in phone is not passed or is empty", () => {
+    expect.assertions(2);
     expect(() =>
       validateMerchantPayload({
-        customer: {
-          phone: {
-            nationalNumber: "",
-            countryCode: "",
-          },
+        phone: {
+          nationalNumber: "",
+          countryCode: "",
         },
       })
     ).toThrowError(
-      "Expected shopper information to include an email or phone number"
+      "Expected either email or phone number for get recommended payment methods"
     );
 
     expect(() =>
       validateMerchantPayload(
         // $FlowFixMe
-        { customer: { phone: {} } }
+        { phone: {} }
       )
     ).toThrowError(
-      "Expected shopper information to include an email or phone number"
+      "Expected either email or phone number for get recommended payment methods"
     );
-    expect.assertions(2);
   });
 
   test("should throw if phone is in an invalid format", () => {
     expect(() =>
       validateMerchantPayload({
-        customer: { phone: { countryCode: "1", nationalNumber: "2.354" } },
+        phone: { countryCode: "1", nationalNumber: "2.354" },
       })
     ).toThrowError(
-      "Expected shopper information to a valid phone number format"
+      "Expected shopper information to be a valid phone number format"
     );
     expect(() =>
       validateMerchantPayload({
-        customer: { phone: { countryCode: "1", nationalNumber: "2-354" } },
+        phone: { countryCode: "1", nationalNumber: "2-354" },
       })
     ).toThrowError(
-      "Expected shopper information to a valid phone number format"
+      "Expected shopper information to be a valid phone number format"
     );
     expect.assertions(2);
   });
@@ -144,9 +139,7 @@ describe("shopper insights merchant payload validation", () => {
   test("should throw if email is in an invalid format", () => {
     expect(() =>
       validateMerchantPayload({
-        customer: {
-          email: "123",
-        },
+        email: "123",
       })
     ).toThrowError(
       "Expected shopper information to include a valid email format"

--- a/src/connect/component.test.js
+++ b/src/connect/component.test.js
@@ -72,7 +72,7 @@ describe("getConnectComponent: returns ConnectComponent", () => {
       ...mockProps,
       platformOptions: {
         platform: "PPCP",
-        clientID: "mock-client-id",
+        clientId: "mock-client-id",
         clientMetadataId: "mock-cmid",
         userIdToken: "mock-uid",
         fraudnet: expect.any(Function),

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -19,11 +19,9 @@ export const SHOPPER_INSIGHTS_METRIC_NAME =
   "pp.app.paypal_sdk.api.shopper_insights.count";
 
 export type MerchantPayloadData = {|
-  customer: {|
-    email?: string,
-    phone?: {|
-      countryCode?: string,
-      nationalNumber?: string,
-    |},
+  email?: string,
+  phone?: {|
+    countryCode?: string,
+    nationalNumber?: string,
   |},
 |};


### PR DESCRIPTION
In an effort to make sure implementations between BT Web and the PayPal web SDK remain the same, we are removing the `customer` wrapper from the params for `getRecommendedPaymentMethods`