### PR TITLE
Temporarily remove jest-screenshot command from main workflow 👾

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,9 @@ jobs:
       - name: ▶️ Run Jest SSR
         run: npm run jest-ssr
 
-      - name: ▶️ Run Jest Screenshot
-        run: npm run jest-screenshot
+      # Temporarily disable this until after button redesign project
+      # - name: ▶️ Run Jest Screenshot
+      #   run: npm run jest-screenshot
 
       - name: ▶️ Run Percy Screenshot
         if: ${{ github.actor != 'renovate[bot]' }}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "reinstall": "rimraf flow-typed && rimraf node_modules && npm install && flow-typed install",
     "release": "./scripts/publish.sh",
     "start": "npm run webpack -- --progress --watch",
-    "test": "npm run format:check && npm run test:unit && npm run jest-ssr && npm run karma && npm run jest-screenshot",
+    "test": "npm run format:check && npm run test:unit && npm run jest-ssr && npm run karma",
     "test:unit": "vitest run",
     "percy-screenshot": "npx playwright install && babel-node ./test/percy/server/createButtonConfigs.js && percy exec -- playwright test --config=./test/percy/playwright.config.js --reporter=dot --pass-with-no-tests",
     "typecheck": "npm run flow-typed && npm run flow",


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

This will help us be more efficient when making button design changes since the `jest-screenshot` command takes about 2.5 hours to run when changes are made to the designs.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
**JIRA:** [DTPPCPSDK-1783](https://paypal.atlassian.net/browse/DTPPCPSDK-1783)

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
