### PR TITLE
Add Liberation Sans as fallback font

### DIFF
--- a/src/marks/template.jsx
+++ b/src/marks/template.jsx
@@ -78,7 +78,7 @@ export function MarksElement({
       <style>
         {`
                     .${CLASS.TEXT} {
-                        font-family: PayPalOpen-Regular, "Helvetica Neue", Helvetica, Arial, sans-serif;
+                        font-family: PayPalOpen-Regular, Helvetica, Arial, "Liberation Sans", sans-serif;
                         font-size: 12px;
                         vertical-align: middle;
                     }

--- a/src/ui/buttons/buttonDesigns/divideLogoAnimation.jsx
+++ b/src/ui/buttons/buttonDesigns/divideLogoAnimation.jsx
@@ -192,7 +192,7 @@ export function DivideLogoTextComponent({
                   position: absolute;
                   opacity: 0; 
                   color: #142C8E;
-                  font-family: PayPalOpen-Regular, "Helvetica Neue", Helvetica, Arial, sans-serif;
+                  font-family: PayPalOpen-Regular, Helvetica, Arial, "Liberation Sans", sans-serif;
                   font-size: 14px;
               }
 

--- a/src/ui/buttons/buttonDesigns/inlineLogoTextDesign.jsx
+++ b/src/ui/buttons/buttonDesigns/inlineLogoTextDesign.jsx
@@ -131,7 +131,7 @@ export function InlineLogoTextComponent({
                   position: absolute;
                   opacity: 0; 
                   color: #142C8E;
-                  font-family: PayPalOpen-Regular, "Helvetica Neue", Helvetica, Arial, sans-serif;
+                  font-family: PayPalOpen-Regular, Helvetica, Arial, "Liberation Sans", sans-serif;
                   font-size: 14px;
               }
 

--- a/src/ui/buttons/poweredBy.jsx
+++ b/src/ui/buttons/poweredBy.jsx
@@ -15,7 +15,7 @@ const POWERED_BY_PAYPAL_STYLE = `
         text-align: center;
         margin: 10px auto;
         height: 14px;
-        font-family: PayPalOpen-Regular, "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-family: PayPalOpen-Regular, Helvetica, Arial, "Liberation Sans", sans-serif;
         font-size: 11px;
         font-weight: normal;
         font-style: italic;

--- a/src/ui/buttons/styles/button.js
+++ b/src/ui/buttons/styles/button.js
@@ -15,7 +15,7 @@ export const buttonStyle = `
         margin: 0;
         background: 0;
         border: 0;
-        font-family: PayPalOpen-Regular, "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-family: PayPalOpen-Regular, Helvetica, Arial, "Liberation Sans", sans-serif;
         text-transform: none;
         font-weight: 500;
         font-smoothing: antialiased;

--- a/src/ui/buttons/styles/page.js
+++ b/src/ui/buttons/styles/page.js
@@ -4,7 +4,7 @@ import { CLASS } from "../../../constants";
 
 export const pageStyle = `
     html, body {
-        font-family: PayPalOpen-Regular, "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-family: PayPalOpen-Regular, Helvetica, Arial, "Liberation Sans", sans-serif;
         padding: 0;
         margin: 0;
         width: 100%;


### PR DESCRIPTION
### Why is this change required?
<!--
- Motivation and Summary
- JIRA Ticket, Rally Story, etc
- Links to Product Requirements and/or Design Documents
- Links to approved specification
-->
We are redesigning the PayPal button and updating the font as a part of this redesign.
https://paypal.atlassian.net/browse/DTPPCPSDK-1682

### Additional PRs with CSS Changes
[smartcomponentnodeweb](https://github.paypal.com/Checkout-R/smartcomponentnodeweb/pull/553)


### View Visual Changes
1. Clone [button-redesign-storybook](https://github.paypal.com/Core-SDK/button-redesign-storybook)
2. Follow Quick Setup instructions for button-redesign-repo
3. Run Storybook: `npm run storybook`
4. Checkout `feature/redesign-fronts` branch for `smartcomponentnodeweb`
5. Checkout `feature/redesign-fronts` branch for `paypal-checkout-components`
6. Checkout `feature/redesign-fronts` branch for `paypal-common-components`
7. Run JS SDK locally
8. View changes in Storybook!

### Type of change
<!--
Check all that best describes your change.
-->
- [ ] Breaking change (backward incompatible change). **Provide references to customer impact and communication.**
- [x] New feature (backward compatible change that adds new capability).
- [ ] Bug fix.
- [ ] Refactor (no functional change)

### Impact of change
<!--
Describe the change **before** and **after** your change. e.g. API samples, error samples, performance numbers, etc
-->
PayPal Open font should be used everywhere in the SDK

### Checklist
- [x] I have authored code based on the an `approved` and `merged` specification change.
- [x] I have authored sufficient (line and branch coverage) unit tests including negative use-cases. My tests [do not rely on the internal implementation](https://martinfowler.com/articles/practical-test-pyramid.html#WhatToTest).
- [x] I have authored sufficient functional tests including error conditions.
- [x] Each commit in my code addresses a [single concern](https://blog.ploeh.dk/2015/01/15/10-tips-for-better-pull-requests/#9456245213574e5b879092ad3f658fc0).
- [x] I have used [meaningful names](https://hackernoon.com/the-art-of-naming-variables-52f44de00aad) for classes/methods/variables and made sure my code is readable.
- [x] My commits have [meaningful commit message](https://blog.ploeh.dk/2015/01/15/10-tips-for-better-pull-requests/#698cd08fcaa04ef0bed29be8a2e2634d).
- [x] I have added sufficient logging, e.g. CAL.
- [x] I have added sufficient instrumentation, e.g. FPTI.