### PR TITLE
feat: adds optional message prop to zoid interface

### DIFF
--- a/demo/dev/button-with-message.htm
+++ b/demo/dev/button-with-message.htm
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script src="https://localhost.paypal.com:9001/sdk.js?client-id=alc_client1&currency=USD"></script>
+  <script src="https://localhost.paypal.com:9001/sdk-constants.js"></script>
+  <style>
+    .paypal-button-container {
+      border: 2px solid black
+    }
+    hr {
+      margin: 5px 0 5px
+    }
+  </style>
+</head>
+
+<body>
+  <div class="buttons-1"></div>
+  <hr />
+  <div class="buttons-2"></div>
+  <hr />
+  <div class="buttons-3"></div>
+
+  <script>
+    const buttons1 = paypal.Buttons({
+      style: {
+        layout: "vertical",
+      },
+    });
+    const buttons2 = paypal.Buttons({
+      style: {
+        layout: "horizontal",
+        tagline: true,
+      },
+    });
+    const buttons3 = paypal.Buttons({
+      fundingSource: "paypal",
+      style: {
+        // layout: "horizontal",
+        // tagline: true,
+      },
+    });
+
+    buttons1.render(".buttons-1");
+    buttons2.render(".buttons-2");
+    buttons3.render(".buttons-3");
+  </script>
+</body>

--- a/src/constants/button.js
+++ b/src/constants/button.js
@@ -62,3 +62,24 @@ export const MENU_PLACEMENT = {
   ABOVE: ("above": "above"),
   BELOW: ("below": "below"),
 };
+
+export const MESSAGE_OFFER = {
+  PAY_LATER_LONG_TERM: ("pay_later_long_term": "pay_later_long_term"),
+  PAY_LATER_SHORT_TERM: ("pay_later_short_term": "pay_later_short_term"),
+};
+
+export const MESSAGE_COLOR = {
+  BLACK: ("black": "black"),
+  WHITE: ("white": "white"),
+};
+
+export const MESSAGE_POSITION = {
+  TOP: ("top": "top"),
+  BOTTOM: ("bottom": "bottom"),
+};
+
+export const MESSAGE_ALIGN = {
+  CENTER: ("center": "center"),
+  LEFT: ("left": "left"),
+  RIGHT: ("right": "right"),
+};

--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -36,6 +36,7 @@ import type {
   OnShippingChange,
   OnShippingAddressChange,
   OnShippingOptionsChange,
+  ButtonMessage,
 } from "./props";
 import { Spinner } from "./spinner";
 import { MenuButton } from "./menu-button";
@@ -65,6 +66,7 @@ type IndividualButtonProps = {|
   merchantFundingSource: ?$Values<typeof FUNDING>,
   instrument: ?WalletInstrument,
   showPayLabel: boolean,
+  message?: ButtonMessage,
 |};
 
 export function Button({
@@ -87,6 +89,8 @@ export function Button({
   experiment,
   instrument,
   showPayLabel,
+  // eslint-disable-next-line no-unused-vars
+  message,
 }: IndividualButtonProps): ElementNode {
   const { layout, shape } = style;
 

--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -36,7 +36,6 @@ import type {
   OnShippingChange,
   OnShippingAddressChange,
   OnShippingOptionsChange,
-  ButtonMessage,
 } from "./props";
 import { Spinner } from "./spinner";
 import { MenuButton } from "./menu-button";
@@ -66,7 +65,6 @@ type IndividualButtonProps = {|
   merchantFundingSource: ?$Values<typeof FUNDING>,
   instrument: ?WalletInstrument,
   showPayLabel: boolean,
-  message?: ButtonMessage,
 |};
 
 export function Button({
@@ -89,8 +87,6 @@ export function Button({
   experiment,
   instrument,
   showPayLabel,
-  // eslint-disable-next-line no-unused-vars
-  message,
 }: IndividualButtonProps): ElementNode {
   const { layout, shape } = style;
 

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -179,6 +179,7 @@ export function Buttons(props: ButtonsProps): ElementNode {
     supportedNativeBrowser,
     showPayLabel,
     displayOnly,
+    // eslint-disable-next-line no-unused-vars
     message,
   } = normalizeButtonProps(props);
   const { layout, shape, tagline } = style;
@@ -286,7 +287,6 @@ export function Buttons(props: ButtonsProps): ElementNode {
           vault={vault}
           instrument={instruments[source]}
           showPayLabel={showPayLabel}
-          message={message}
         />
       ))}
 

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -179,6 +179,7 @@ export function Buttons(props: ButtonsProps): ElementNode {
     supportedNativeBrowser,
     showPayLabel,
     displayOnly,
+    message,
   } = normalizeButtonProps(props);
   const { layout, shape, tagline } = style;
 
@@ -285,6 +286,7 @@ export function Buttons(props: ButtonsProps): ElementNode {
           vault={vault}
           instrument={instruments[source]}
           showPayLabel={showPayLabel}
+          message={message}
         />
       ))}
 

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -746,23 +746,23 @@ export function normalizeButtonMessage(
         )}`
       );
     }
-    const invalidOffers = offer.filter((o) =>
-      values(MESSAGE_OFFER).includes(o)
+    const invalidOffers = offer.filter(
+      (o) => !values(MESSAGE_OFFER).includes(o)
     );
     if (invalidOffers.length > 0) {
       throw new Error(`Invalid offer(s): ${invalidOffers.join(",")}`);
     }
   }
 
-  if (color && values(MESSAGE_COLOR).includes(color)) {
+  if (color && !values(MESSAGE_COLOR).includes(color)) {
     throw new Error(`Invalid color: ${color}`);
   }
 
-  if (position && values(MESSAGE_POSITION).includes(position)) {
+  if (position && !values(MESSAGE_POSITION).includes(position)) {
     throw new Error(`Invalid position: ${position}`);
   }
 
-  if (align && values(MESSAGE_ALIGN).includes(align)) {
+  if (align && !values(MESSAGE_ALIGN).includes(align)) {
     throw new Error(`Invalid align: ${align}`);
   }
 

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -435,7 +435,7 @@ export type ApplePaySessionConfigRequest = (
 
 export type ButtonMessage = {|
   amount?: number,
-  offer?: $ReadOnlyArray<?$Values<typeof MESSAGE_OFFER>>,
+  offer?: $ReadOnlyArray<$Values<typeof MESSAGE_OFFER>>,
   color?: $Values<typeof MESSAGE_COLOR>,
   position?: $Values<typeof MESSAGE_POSITION>,
   align?: $Values<typeof MESSAGE_ALIGN>,
@@ -443,7 +443,7 @@ export type ButtonMessage = {|
 
 export type ButtonMessageInputs = {|
   amount?: number | void,
-  offer?: $ReadOnlyArray<?$Values<typeof MESSAGE_OFFER>> | void,
+  offer?: $ReadOnlyArray<$Values<typeof MESSAGE_OFFER>> | void,
   color?: $Values<typeof MESSAGE_COLOR> | void,
   position?: $Values<typeof MESSAGE_POSITION> | void,
   align?: $Values<typeof MESSAGE_ALIGN> | void,
@@ -719,7 +719,7 @@ export function normalizeButtonStyle(
   };
 }
 
-export function validateButtonMessage(
+export function normalizeButtonMessage(
   props: ?ButtonPropsInputs,
   message: ButtonMessageInputs
 ): ButtonMessage {
@@ -727,19 +727,27 @@ export function validateButtonMessage(
     throw new Error(`Expected props.message to be set`);
   }
 
-  props = props || getDefaultButtonPropsInput();
-
   const { amount, offer, color, position, align } = message;
 
-  if (amount !== undefined) {
+  if (typeof amount !== "undefined") {
     if (typeof amount !== "number") {
       throw new TypeError(
-        `Expected style.height to be a number, got: ${amount}`
+        `Expected message.amount to be a number, got: ${amount}`
+      );
+    }
+    if (amount < 0) {
+      throw new TypeError(
+        `Expected message.amount to be a positive number, got: ${amount}`
       );
     }
   }
 
   if (offer) {
+    if (offer.constructor.name !== "Array") {
+      throw new TypeError(
+        `Expected message.offer to be an array of strings, got: ${offer}`
+      );
+    }
     const invalidOffers = offer.filter(
       (o) => values(MESSAGE_OFFER).indexOf(o) === -1
     );
@@ -882,7 +890,7 @@ export function normalizeButtonProps(
   }
 
   if (message) {
-    validateButtonMessage(props, message);
+    message = normalizeButtonMessage(props, message);
   }
 
   style = normalizeButtonStyle(props, style);

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -746,23 +746,23 @@ export function normalizeButtonMessage(
         )}`
       );
     }
-    const invalidOffers = offer.filter(
-      (o) => values(MESSAGE_OFFER).indexOf(o) === -1
+    const invalidOffers = offer.filter((o) =>
+      values(MESSAGE_OFFER).includes(o)
     );
     if (invalidOffers.length > 0) {
       throw new Error(`Invalid offer(s): ${invalidOffers.join(",")}`);
     }
   }
 
-  if (color && values(MESSAGE_COLOR).indexOf(color) === -1) {
+  if (color && values(MESSAGE_COLOR).includes(color)) {
     throw new Error(`Invalid color: ${color}`);
   }
 
-  if (position && values(MESSAGE_POSITION).indexOf(position) === -1) {
+  if (position && values(MESSAGE_POSITION).includes(position)) {
     throw new Error(`Invalid position: ${position}`);
   }
 
-  if (align && values(MESSAGE_ALIGN).indexOf(align) === -1) {
+  if (align && values(MESSAGE_ALIGN).includes(align)) {
     throw new Error(`Invalid align: ${align}`);
   }
 
@@ -887,10 +887,6 @@ export function normalizeButtonProps(
     }
   }
 
-  if (message) {
-    message = normalizeButtonMessage(props, message);
-  }
-
   style = normalizeButtonStyle(props, style);
 
   return {
@@ -925,6 +921,6 @@ export function normalizeButtonProps(
     supportedNativeBrowser,
     showPayLabel,
     displayOnly,
-    message,
+    message: message ? normalizeButtonMessage(props, message) : undefined,
   };
 }

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -745,7 +745,9 @@ export function normalizeButtonMessage(
   if (offer) {
     if (offer.constructor.name !== "Array") {
       throw new TypeError(
-        `Expected message.offer to be an array of strings, got: ${offer}`
+        `Expected message.offer to be an array of strings, got: ${String(
+          offer
+        )}`
       );
     }
     const invalidOffers = offer.filter(

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -543,7 +543,7 @@ export type ButtonProps = {|
   createVaultSetupToken: CreateVaultSetupToken,
   displayOnly?: $ReadOnlyArray<$Values<typeof DISPLAY_ONLY_VALUES>>,
   hostedButtonId?: string,
-  message: ButtonMessage,
+  message?: ButtonMessage,
 |};
 
 // eslint-disable-next-line flowtype/require-exact-type
@@ -723,10 +723,6 @@ export function normalizeButtonMessage(
   props: ?ButtonPropsInputs,
   message: ButtonMessageInputs
 ): ButtonMessage {
-  if (!message) {
-    throw new Error(`Expected props.message to be set`);
-  }
-
   const { amount, offer, color, position, align } = message;
 
   if (typeof amount !== "undefined") {
@@ -736,14 +732,14 @@ export function normalizeButtonMessage(
       );
     }
     if (amount < 0) {
-      throw new TypeError(
+      throw new Error(
         `Expected message.amount to be a positive number, got: ${amount}`
       );
     }
   }
 
   if (offer) {
-    if (offer.constructor.name !== "Array") {
+    if (!Array.isArray(offer)) {
       throw new TypeError(
         `Expected message.offer to be an array of strings, got: ${String(
           offer

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -890,10 +890,6 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
           // $FlowFixMe
           return normalizeButtonMessage(props, value);
         },
-        validate: ({ props, value }) => {
-          // $FlowFixMe
-          normalizeButtonMessage(props, value);
-        },
       },
     },
   });

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -72,7 +72,11 @@ import {
   logLatencyInstrumentationPhase,
   prepareInstrumentationPayload,
 } from "../../lib";
-import { normalizeButtonStyle, type ButtonProps } from "../../ui/buttons/props";
+import {
+  normalizeButtonStyle,
+  validateButtonMessage,
+  type ButtonProps,
+} from "../../ui/buttons/props";
 import { isFundingEligible } from "../../funding";
 
 import { containerTemplate } from "./container";
@@ -876,6 +880,17 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
         value: ({ props }) => {
           return props?.displayOnly || [];
         },
+      },
+
+      message: {
+        type: "object",
+        queryParam: true,
+        required: false,
+        validate: ({ props, value = {} }) => {
+          // $FlowFixMe
+          validateButtonMessage(props, value);
+        },
+        default: () => ({}),
       },
     },
   });

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -74,7 +74,7 @@ import {
 } from "../../lib";
 import {
   normalizeButtonStyle,
-  validateButtonMessage,
+  normalizeButtonMessage,
   type ButtonProps,
 } from "../../ui/buttons/props";
 import { isFundingEligible } from "../../funding";
@@ -886,11 +886,14 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
         type: "object",
         queryParam: true,
         required: false,
-        validate: ({ props, value = {} }) => {
+        decorate: ({ props, value }) => {
           // $FlowFixMe
-          validateButtonMessage(props, value);
+          return normalizeButtonMessage(props, value);
         },
-        default: () => ({}),
+        validate: ({ props, value }) => {
+          // $FlowFixMe
+          normalizeButtonMessage(props, value);
+        },
       },
     },
   });

--- a/test/integration/tests/button/validation.js
+++ b/test/integration/tests/button/validation.js
@@ -871,7 +871,7 @@ const buttonConfigs = [
       {
         message: {
           amount: 100,
-          offer: ["PAY_LATER_LONG_TERM"],
+          offer: ["pay_later_long_term"],
           color: "black",
           position: "top",
           align: "left",
@@ -882,7 +882,7 @@ const buttonConfigs = [
       {
         message: {
           amount: "100", // invalid: should be num
-          offer: ["PAY_LATER_LONG_TERM"],
+          offer: ["pay_later_long_term"],
           color: "black",
           position: "top",
           align: "left",
@@ -904,7 +904,7 @@ const buttonConfigs = [
       {
         message: {
           amount: 100,
-          offer: ["PAY_LATER_LONG_TERM"],
+          offer: ["pay_later_long_term"],
           color: "blue", // invalid: value not in enum
           position: "top",
           align: "left",
@@ -915,7 +915,7 @@ const buttonConfigs = [
       {
         message: {
           amount: 100,
-          offer: ["PAY_LATER_LONG_TERM"],
+          offer: ["pay_later_long_term"],
           color: "black",
           position: "right", // invalid: value not in enum
           align: "left",
@@ -926,7 +926,7 @@ const buttonConfigs = [
       {
         message: {
           amount: 100,
-          offer: ["PAY_LATER_LONG_TERM"],
+          offer: ["pay_later_long_term"],
           color: "black",
           position: "top",
           align: "middle", // invalid: value not in enum

--- a/test/integration/tests/button/validation.js
+++ b/test/integration/tests/button/validation.js
@@ -892,8 +892,19 @@ const buttonConfigs = [
 
       {
         message: {
+          amount: -100, // invalid: should be positive
+          offer: ["pay_later_long_term"],
+          color: "black",
+          position: "top",
+          align: "left",
+        },
+        valid: false,
+      },
+
+      {
+        message: {
           amount: 100,
-          offer: "PAY_LATER_LONG_TERM", // invalid: should be in an array
+          offer: "PAY_LATER_LONG_TERM", // invalid: should be in an array and lowercase
           color: "black",
           position: "top",
           align: "left",

--- a/test/integration/tests/button/validation.js
+++ b/test/integration/tests/button/validation.js
@@ -892,7 +892,7 @@ const buttonConfigs = [
 
       {
         message: {
-          amount: -100, // invalid: should be positive
+          amount: -100, //  invalid: should be positive
           offer: ["pay_later_long_term"],
           color: "black",
           position: "top",

--- a/test/integration/tests/button/validation.js
+++ b/test/integration/tests/button/validation.js
@@ -904,7 +904,18 @@ const buttonConfigs = [
       {
         message: {
           amount: 100,
-          offer: "PAY_LATER_LONG_TERM", // invalid: should be in an array and lowercase
+          offer: "pay_later_long_term", // invalid: should be in an array
+          color: "black",
+          position: "top",
+          align: "left",
+        },
+        valid: false,
+      },
+
+      {
+        message: {
+          amount: 100,
+          offer: ["PAY_LATER_LONG_TERM"], // invalid: should be lowercase to match enum values
           color: "black",
           position: "top",
           align: "left",

--- a/test/integration/tests/button/validation.js
+++ b/test/integration/tests/button/validation.js
@@ -863,6 +863,93 @@ const buttonConfigs = [
       },
     })),
   },
+
+  {
+    name: "message",
+
+    cases: [
+      {
+        message: {
+          amount: 100,
+          offer: ["PAY_LATER_LONG_TERM"],
+          color: "black",
+          position: "top",
+          align: "left",
+        },
+        valid: true,
+      },
+
+      {
+        message: {
+          amount: "100", // invalid: should be num
+          offer: ["PAY_LATER_LONG_TERM"],
+          color: "black",
+          position: "top",
+          align: "left",
+        },
+        valid: false,
+      },
+
+      {
+        message: {
+          amount: 100,
+          offer: "PAY_LATER_LONG_TERM", // invalid: should be in an array
+          color: "black",
+          position: "top",
+          align: "left",
+        },
+        valid: false,
+      },
+
+      {
+        message: {
+          amount: 100,
+          offer: ["PAY_LATER_LONG_TERM"],
+          color: "blue", // invalid: value not in enum
+          position: "top",
+          align: "left",
+        },
+        valid: false,
+      },
+
+      {
+        message: {
+          amount: 100,
+          offer: ["PAY_LATER_LONG_TERM"],
+          color: "black",
+          position: "right", // invalid: value not in enum
+          align: "left",
+        },
+        valid: false,
+      },
+
+      {
+        message: {
+          amount: 100,
+          offer: ["PAY_LATER_LONG_TERM"],
+          color: "black",
+          position: "top",
+          align: "middle", // invalid: value not in enum
+        },
+        valid: false,
+      },
+
+      {
+        message: {},
+        valid: true,
+      },
+    ].map(({ message, valid }) => ({
+      desc: `message ${JSON.stringify(message)}`,
+
+      valid,
+
+      conf: {
+        createOrder: noop,
+        onApprove: noop,
+        message,
+      },
+    })),
+  },
 ];
 
 for (const group of buttonConfigs) {


### PR DESCRIPTION
### Description

Adds an optional message prop to zoid interface in anticipation of adding adjacent message support to checkout buttons.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
"[buttons] Add message object option to zoid interface"

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->
@Seavenly 

❤️ Thank you!
