### PR TITLE
hosted buttons: use Promise instead of ZalgoPromise

### DIFF
--- a/src/hosted-buttons/index.js
+++ b/src/hosted-buttons/index.js
@@ -20,35 +20,34 @@ export const getHostedButtonsComponent = (): HostedButtonsComponent => {
     hostedButtonId,
   }: HostedButtonsComponentProps): HostedButtonsInstance {
     const Buttons = getButtonsComponent();
-    const render = (selector) => {
+    const render = async (selector) => {
       const merchantId = getMerchantID();
+      const { html, htmlScript, style } = await getHostedButtonDetails({
+        hostedButtonId,
+      });
 
-      getHostedButtonDetails({ hostedButtonId }).then(
-        ({ html, htmlScript, style }) => {
-          const { onInit, onClick } = renderForm({
-            hostedButtonId,
-            html,
-            htmlScript,
-            selector,
-          });
+      const { onInit, onClick } = renderForm({
+        hostedButtonId,
+        html,
+        htmlScript,
+        selector,
+      });
 
-          // $FlowFixMe
-          Buttons({
-            hostedButtonId,
-            style,
-            onInit,
-            onClick,
-            createOrder: buildHostedButtonCreateOrder({
-              hostedButtonId,
-              merchantId,
-            }),
-            onApprove: buildHostedButtonOnApprove({
-              hostedButtonId,
-              merchantId,
-            }),
-          }).render(selector);
-        }
-      );
+      // $FlowFixMe
+      Buttons({
+        hostedButtonId,
+        style,
+        onInit,
+        onClick,
+        createOrder: buildHostedButtonCreateOrder({
+          hostedButtonId,
+          merchantId,
+        }),
+        onApprove: buildHostedButtonOnApprove({
+          hostedButtonId,
+          merchantId,
+        }),
+      }).render(selector);
     };
     return {
       render,

--- a/src/hosted-buttons/index.test.js
+++ b/src/hosted-buttons/index.test.js
@@ -1,8 +1,8 @@
 /* @flow */
+/* eslint-disable no-restricted-globals, promise/no-native */
 
 import { describe, test, expect, vi } from "vitest";
 import { request } from "@krakenjs/belter/src";
-import { ZalgoPromise } from "@krakenjs/zalgo-promise";
 
 import { getButtonsComponent } from "../zoid/buttons";
 
@@ -61,16 +61,17 @@ const getHostedButtonDetailsResponse = {
 };
 
 describe("HostedButtons", () => {
-  test("paypal.Buttons calls getHostedButtonDetails and invokes v5 of the SDK", () => {
+  test("paypal.Buttons calls getHostedButtonDetails and invokes v5 of the SDK", async () => {
     const Buttons = vi.fn(() => ({ render: vi.fn() }));
     // $FlowIssue
     getButtonsComponent.mockImplementationOnce(() => Buttons);
     const HostedButtons = getHostedButtonsComponent();
     // $FlowIssue
     request.mockImplementationOnce(() =>
-      ZalgoPromise.resolve(getHostedButtonDetailsResponse)
+      // eslint-disable-next-line compat/compat
+      Promise.resolve(getHostedButtonDetailsResponse)
     );
-    HostedButtons({
+    await HostedButtons({
       hostedButtonId: "B1234567890",
     }).render("#example");
     expect(Buttons).toHaveBeenCalledWith(
@@ -81,3 +82,5 @@ describe("HostedButtons", () => {
     expect.assertions(1);
   });
 });
+
+/* eslint-enable no-restricted-globals, promise/no-native */

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -1,6 +1,5 @@
 /* @flow */
-
-import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
+/* eslint-disable no-restricted-globals, promise/no-native */
 
 export type HostedButtonsComponentProps = {|
   hostedButtonId: string,
@@ -12,11 +11,11 @@ export type GetCallbackProps = {|
 |};
 
 export type HostedButtonsInstance = {|
-  render: (string | HTMLElement) => void,
+  render: (string | HTMLElement) => Promise<void>,
 |};
 
 export type HostedButtonDetailsParams =
-  (HostedButtonsComponentProps) => ZalgoPromise<{|
+  (HostedButtonsComponentProps) => Promise<{|
     html: string,
     htmlScript: string,
     style: {|
@@ -34,14 +33,14 @@ export type ButtonVariables = $ReadOnlyArray<{|
 
 export type CreateOrder = (data: {|
   paymentSource: string,
-|}) => ZalgoPromise<string | void>;
+|}) => Promise<string | void>;
 
 export type OnApprove = (data: {|
   orderID: string,
   paymentSource: string,
-|}) => ZalgoPromise<mixed>;
+|}) => Promise<mixed>;
 
-export type CreateAccessToken = (clientID: string) => ZalgoPromise<string>;
+export type CreateAccessToken = (clientID: string) => Promise<string>;
 
 export type HostedButtonsComponent =
   (HostedButtonsComponentProps) => HostedButtonsInstance;
@@ -55,3 +54,5 @@ export type RenderForm = ({|
   onInit: (data: mixed, actions: mixed) => void,
   onClick: (data: mixed, actions: mixed) => void,
 |};
+
+/* eslint-enable no-restricted-globals, promise/no-native */

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -1,8 +1,7 @@
 /* @flow */
-
+/* eslint-disable no-restricted-globals, promise/no-native */
 import { test, expect, vi } from "vitest";
 import { request } from "@krakenjs/belter/src";
-import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 
 import {
   buildHostedButtonCreateOrder,
@@ -62,7 +61,8 @@ const getHostedButtonDetailsResponse = {
 test("getHostedButtonDetails", async () => {
   // $FlowIssue
   request.mockImplementationOnce(() =>
-    ZalgoPromise.resolve(getHostedButtonDetailsResponse)
+    // eslint-disable-next-line compat/compat
+    Promise.resolve(getHostedButtonDetailsResponse)
   );
   await getHostedButtonDetails({
     hostedButtonId,
@@ -85,7 +85,8 @@ test("buildHostedButtonCreateOrder", async () => {
 
   // $FlowIssue
   request.mockImplementation(() =>
-    ZalgoPromise.resolve({
+    // eslint-disable-next-line compat/compat
+    Promise.resolve({
       body: {
         link_id: hostedButtonId,
         merchant_id: merchantId,
@@ -107,7 +108,8 @@ test("buildHostedButtonCreateOrder error handling", async () => {
 
   // $FlowIssue
   request.mockImplementation(() =>
-    ZalgoPromise.resolve({
+    // eslint-disable-next-line compat/compat
+    Promise.resolve({
       body: {
         name: "RESOURCE_NOT_FOUND",
       },
@@ -133,7 +135,8 @@ describe("buildHostedButtonOnApprove", () => {
 
     // $FlowIssue
     request.mockImplementation(() =>
-      ZalgoPromise.resolve({
+      // eslint-disable-next-line compat/compat
+      Promise.resolve({
         body: {},
       })
     );
@@ -150,3 +153,5 @@ describe("buildHostedButtonOnApprove", () => {
     expect.assertions(1);
   });
 });
+
+/* eslint-enable no-restricted-globals, promise/no-native */


### PR DESCRIPTION
### Description

This PR is a light refactor to use `Promise` instead of `ZalgoPromise` in preparation for some [incoming changes](https://github.com/paypal/paypal-sdk-client/pull/184) from `@paypal/sdk-client`.

### Why are we making these changes?

I started working on consuming [some](https://github.com/paypal/paypal-sdk-client/pull/186) [changes](https://github.com/paypal/paypal-sdk-client/pull/187) from `@paypal/sdk-client` but realized the diff was quite large. I wanted to separate out the refactor from the new functionality to make the diffs easier to read.

because of the change from `.then(() => {...` to `await` I recommend reviewing this PR with the [whitespace ignored](https://github.com/paypal/paypal-checkout-components/pull/2337/files?diff=unified&w=1)

❤️ Thank you!
