### PR TITLE
Add `enableDPoP` flag for Hosted Buttons

### DIFF
--- a/src/hosted-buttons/index.js
+++ b/src/hosted-buttons/index.js
@@ -17,6 +17,7 @@ import type {
 
 export const getHostedButtonsComponent = (): HostedButtonsComponent => {
   function HostedButtons({
+    enableDPoP = false,
     hostedButtonId,
   }: HostedButtonsComponentProps): HostedButtonsInstance {
     const Buttons = getButtonsComponent();
@@ -40,10 +41,12 @@ export const getHostedButtonsComponent = (): HostedButtonsComponent => {
         onInit,
         onClick,
         createOrder: buildHostedButtonCreateOrder({
+          enableDPoP,
           hostedButtonId,
           merchantId,
         }),
         onApprove: buildHostedButtonOnApprove({
+          enableDPoP,
           hostedButtonId,
           merchantId,
         }),

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -59,21 +59,4 @@ export type RenderForm = ({|
   onClick: (data: mixed, actions: mixed) => void,
 |};
 
-type Request = {|
-  url: string,
-  headers: {|
-    [key: string]: string,
-    Authorization?: string,
-  |},
-  method: string,
-  body: string,
-|};
-
-type Response = {|
-  status: number,
-  headers: { [string]: string },
-  body: Object,
-|};
-
-export type RequestWithDPoP = (Request) => Response;
 /* eslint-enable no-restricted-globals, promise/no-native */

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -6,6 +6,7 @@ export type HostedButtonsComponentProps = {|
 |};
 
 export type GetCallbackProps = {|
+  enableDPoP?: boolean,
   hostedButtonId: string,
   merchantId?: string,
 |};
@@ -40,7 +41,10 @@ export type OnApprove = (data: {|
   paymentSource: string,
 |}) => Promise<mixed>;
 
-export type CreateAccessToken = (clientID: string) => Promise<string>;
+export type CreateAccessToken = ({|
+  clientId: string,
+  enableDPoP?: boolean,
+|}) => Promise<{| accessToken: string, nonce: string |}>;
 
 export type HostedButtonsComponent =
   (HostedButtonsComponentProps) => HostedButtonsInstance;
@@ -55,4 +59,21 @@ export type RenderForm = ({|
   onClick: (data: mixed, actions: mixed) => void,
 |};
 
+type Request = {|
+  url: string,
+  headers: {|
+    [key: string]: string,
+    Authorization?: string,
+  |},
+  method: string,
+  body: string,
+|};
+
+type Response = {|
+  status: number,
+  headers: { [string]: string },
+  body: Object,
+|};
+
+export type RequestWithDPoP = (Request) => Response;
 /* eslint-enable no-restricted-globals, promise/no-native */

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -43,18 +43,22 @@ export const createAccessToken: CreateAccessToken = memoize<CreateAccessToken>(
   async ({ clientId, enableDPoP }) => {
     const url = `${apiUrl}/v1/oauth2/token`;
     const method = "POST";
+    const DPoPHeaders = enableDPoP
+      ? await buildDPoPHeaders({
+          uri: url,
+          method,
+        })
+      : {};
     const response = await request({
       url,
       method,
       body: "grant_type=client_credentials",
+      // $FlowIssue optional properties are not compatible with [key: string]: string
       headers: {
         Authorization: `Basic ${btoa(clientId)}`,
         "Content-Type": "application/json",
-        ...(enableDPoP &&
-          (await buildDPoPHeaders({
-            uri: url,
-            method,
-          }))),
+        // $FlowIssue exponential-spread
+        ...DPoPHeaders,
       },
     });
     // $FlowIssue request returns ZalgoPromise
@@ -137,18 +141,21 @@ export const buildHostedButtonCreateOrder = ({
     try {
       const url = `${apiUrl}/v1/checkout/links/${hostedButtonId}/create-context`;
       const method = "POST";
+      const DPoPHeaders = enableDPoP
+        ? await buildDPoPHeaders({
+            uri: url,
+            method,
+            accessToken,
+            nonce,
+          })
+        : {};
       const response = await request({
         url,
+        // $FlowIssue optional properties are not compatible with [key: string]: string
         headers: {
           ...getHeaders(accessToken),
-          ...(enableDPoP &&
-            // $FlowIssue exponential-spread
-            (await buildDPoPHeaders({
-              uri: url,
-              method,
-              accessToken,
-              nonce,
-            }))),
+          // $FlowIssue exponential-spread
+          ...DPoPHeaders,
         },
         method,
         body: JSON.stringify({
@@ -179,18 +186,21 @@ export const buildHostedButtonOnApprove = ({
     });
     const url = `${apiUrl}/v1/checkout/links/${hostedButtonId}/pay`;
     const method = "POST";
+    const DPoPHeaders = enableDPoP
+      ? await buildDPoPHeaders({
+          uri: url,
+          method,
+          accessToken,
+          nonce,
+        })
+      : {};
     return request({
       url,
+      // $FlowIssue optional properties are not compatible with [key: string]: string
       headers: {
         ...getHeaders(accessToken),
-        ...(enableDPoP &&
-          // $FlowIssue exponential-spread
-          (await buildDPoPHeaders({
-            uri: url,
-            method,
-            accessToken,
-            nonce,
-          }))),
+        // $FlowIssue exponential-spread
+        ...DPoPHeaders,
       },
       method,
       body: JSON.stringify({

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -175,6 +175,7 @@ export const buildHostedButtonOnApprove = ({
   return async (data) => {
     const { accessToken, nonce } = await createAccessToken({
       clientId: getClientID(),
+      enableDPoP,
     });
     const url = `${apiUrl}/v1/checkout/links/${hostedButtonId}/pay`;
     const method = "POST";

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -80,6 +80,7 @@ test("getHostedButtonDetails", async () => {
 
 test("requestWithDPoP", async () => {
   const accessToken = window.crypto.randomUUID();
+  // $FlowIssue
   request.mockImplementation(() =>
     // eslint-disable-next-line compat/compat
     Promise.resolve({

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -6,8 +6,8 @@ import { request } from "@krakenjs/belter/src";
 import {
   buildHostedButtonCreateOrder,
   buildHostedButtonOnApprove,
+  createAccessToken,
   getHostedButtonDetails,
-  requestWithDPoP,
 } from "./utils";
 
 vi.mock("@krakenjs/belter/src", async () => {
@@ -26,9 +26,11 @@ vi.mock("@paypal/sdk-client/src", async () => {
   };
 });
 
+const accessToken = "AT1234567890";
 const hostedButtonId = "B1234567890";
 const merchantId = "M1234567890";
 const orderID = "EC-1234567890";
+const clientId = "C1234567890";
 
 const getHostedButtonDetailsResponse = {
   body: {
@@ -59,6 +61,14 @@ const getHostedButtonDetailsResponse = {
   },
 };
 
+const mockCreateAccessTokenRequest = () =>
+  // eslint-disable-next-line compat/compat
+  Promise.resolve({
+    body: {
+      access_token: accessToken,
+    },
+  });
+
 test("getHostedButtonDetails", async () => {
   // $FlowIssue
   request.mockImplementationOnce(() =>
@@ -78,50 +88,36 @@ test("getHostedButtonDetails", async () => {
   expect.assertions(1);
 });
 
-test("requestWithDPoP", async () => {
-  const accessToken = window.crypto.randomUUID();
-  // $FlowIssue
-  request.mockImplementation(() =>
-    // eslint-disable-next-line compat/compat
-    Promise.resolve({
-      body: {
-        access_token: accessToken,
-        nonce: "123abc",
-      },
-    })
-  );
-  const options = {
-    method: "POST",
-    url: "https://example.com/",
-    headers: {
-      Authorization: `Basic ${accessToken}`,
-    },
-    body: "",
-  };
-  await requestWithDPoP(options);
-  expect(request).toHaveBeenCalledWith(
-    expect.objectContaining({
-      headers: expect.objectContaining({
-        // does not override the basic auth scheme
-        Authorization: expect.stringContaining(`Basic ${accessToken}`),
-        // but includes a DPoP jwt
-        DPoP: expect.any(String),
-      }),
-    })
-  );
-
-  options.headers.Authorization = `Bearer ${accessToken}`;
-  await requestWithDPoP(options);
-  expect(request).toHaveBeenCalledWith(
-    expect.objectContaining({
-      headers: expect.objectContaining({
-        // overrides the Bearer auth scheme
-        Authorization: expect.stringContaining(`DPoP ${accessToken}`),
-        // and includes a DPoP jwt
-        DPoP: expect.any(String),
-      }),
-    })
-  );
+describe("createAccessToken", () => {
+  test("basic functionality", async () => {
+    request
+      // $FlowIssue
+      .mockImplementationOnce(mockCreateAccessTokenRequest);
+    await createAccessToken({ clientId });
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: expect.stringContaining("Basic "),
+        }),
+      })
+    );
+    expect.assertions(1);
+  });
+  test("with DPoP enabled", async () => {
+    request
+      // $FlowIssue
+      .mockImplementationOnce(mockCreateAccessTokenRequest);
+    await createAccessToken({ clientId, enableDPoP: true });
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: expect.stringContaining("Basic "),
+          DPoP: expect.any(String),
+        }),
+      })
+    );
+    expect.assertions(1);
+  });
 });
 
 test("buildHostedButtonCreateOrder", async () => {
@@ -130,20 +126,62 @@ test("buildHostedButtonCreateOrder", async () => {
     merchantId,
   });
 
-  // $FlowIssue
-  request.mockImplementation(() =>
-    // eslint-disable-next-line compat/compat
-    Promise.resolve({
-      body: {
-        link_id: hostedButtonId,
-        merchant_id: merchantId,
-        context_id: orderID,
-        status: "CREATED",
-      },
+  request
+    // $FlowIssue
+    .mockImplementationOnce(mockCreateAccessTokenRequest)
+    .mockImplementation(() =>
+      // eslint-disable-next-line compat/compat
+      Promise.resolve({
+        body: {
+          link_id: hostedButtonId,
+          merchant_id: merchantId,
+          context_id: orderID,
+          status: "CREATED",
+        },
+      })
+    );
+  const createdOrderID = await createOrder({ paymentSource: "paypal" });
+  expect(request).toHaveBeenCalledWith(
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: `Bearer ${accessToken}`,
+      }),
     })
   );
-  const createdOrderID = await createOrder({ paymentSource: "paypal" });
   expect(createdOrderID).toBe(orderID);
+  expect.assertions(2);
+});
+
+test("buildHostedButtonCreateOrder with DPoP enabled", async () => {
+  const createOrder = buildHostedButtonCreateOrder({
+    enableDPoP: true,
+    hostedButtonId,
+    merchantId,
+  });
+
+  request
+    // $FlowIssue
+    .mockImplementationOnce(mockCreateAccessTokenRequest)
+    .mockImplementation(() =>
+      // eslint-disable-next-line compat/compat
+      Promise.resolve({
+        body: {
+          link_id: hostedButtonId,
+          merchant_id: merchantId,
+          context_id: orderID,
+          status: "CREATED",
+        },
+      })
+    );
+  await createOrder({ paymentSource: "paypal" });
+  expect(request).toHaveBeenCalledWith(
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: `DPoP ${accessToken}`,
+        DPoP: expect.any(String),
+      }),
+    })
+  );
   expect.assertions(1);
 });
 
@@ -194,6 +232,33 @@ describe("buildHostedButtonOnApprove", () => {
           entry_point: "SDK",
           merchant_id: merchantId,
           context_id: orderID,
+        }),
+      })
+    );
+    expect.assertions(1);
+  });
+
+  test("with DPoP enabled", async () => {
+    const onApprove = buildHostedButtonOnApprove({
+      enableDPoP: true,
+      hostedButtonId,
+      merchantId,
+    });
+    request
+      // $FlowIssue
+      .mockImplementationOnce(mockCreateAccessTokenRequest)
+      .mockImplementation(() =>
+        // eslint-disable-next-line compat/compat
+        Promise.resolve({
+          body: {},
+        })
+      );
+    await onApprove({ orderID, paymentSource: "paypal" });
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `DPoP ${accessToken}`,
+          DPoP: expect.any(String),
         }),
       })
     );

--- a/vitestSetup.js
+++ b/vitestSetup.js
@@ -1,4 +1,7 @@
 /* @flow */
+// eslint-disable-next-line import/no-nodejs-modules
+import crypto from "crypto";
+
 import { vi } from "vitest";
 
 Object.defineProperty(window, "matchMedia", {
@@ -14,3 +17,6 @@ Object.defineProperty(window, "matchMedia", {
     dispatchEvent: vi.fn(),
   })),
 });
+
+// $FlowIssue missing browser crypto typedefs
+window.crypto = crypto.webcrypto;


### PR DESCRIPTION
### Description

This PR adds a new prop `enableDPoP` to the hosted buttons component to feature-flag adding DPoP headers to `/v1/oauth2/token` and protected resource requests.

```js
paypal.HostedButtons({
  hostedButtonId: "H1234567890",
  enableDPoP: true // 🆕
})
```

When `enableDPoP` is `true`, requests to create an access token will include a `DPoP` header (see https://datatracker.ietf.org/doc/html/rfc9449#name-dpop-access-token-request) that includes information about the request (request method and uri) and information about the device (the in-memory public key generated from the buyer's browser) and signed with an in-memory and non-extractable private key.

When `enableDPoP` is `true`, requests to protected resources will replace the existing `Authorization: Bearer <token>` with the new authentication scheme: `Authorization: DPoP <token>` and also include a `DPoP` header. (see https://datatracker.ietf.org/doc/html/rfc9449#name-protected-resource-access).

When `enableDPoP` is `false` (or `undefined`), no existing functionality is changed. This property is used as a feature flag only before general availability.

### Why are we making these changes? 

The hosted buttons component creates access tokens cross-origin from the merchant's site. DPoP enforces a policy where access tokens can only be used from the device that requested the access token. 

From https://datatracker.ietf.org/doc/html/rfc9449#name-objectives:
>The primary aim of DPoP is to prevent unauthorized or illegitimate parties from using leaked or stolen access tokens, by binding a token to a public key upon issuance and requiring that the client proves possession of the corresponding private key when using the token.

### Reproduction Steps

add `enableDPoP: true` to `paypal.HostedButtons({})`

### Screenshots

See an example DPoP proof (and its contents) validated in the [jwt.io debugger](https://jwt.io/#debugger-io?token=eyJhbGciOiJFUzI1NiIsInR5cCI6ImRwb3Arand0IiwiandrIjp7ImNydiI6IlAtMjU2IiwiZXh0Ijp0cnVlLCJrZXlfb3BzIjpbInZlcmlmeSJdLCJrdHkiOiJFQyIsIngiOiIwazNxYWVKTnhMc1lHeFE5Y2NaeFpSa015VEI0VzhZclVPWk5sQlFvbWFrIiwieSI6IlRJVVQwZ2xqb2ZVcFl2ajh0NGtOeV9sWmJzc3ExREJ2cXZOa3lZeGtIajgifX0.eyJjbmYiOnsiamt0IjoicDJfLTNXOHpQZjZxUi1mYXl3bjA1M3U3ajdTM3JTTkJIeU9Jd2VhWWZPUSJ9LCJodG0iOiJQT1NUIiwiaHR1IjoiaHR0cHM6Ly9sb2NhbGhvc3QucGF5cGFsLmNvbTo4NDQzL3YxL29hdXRoMi90b2tlbiIsImlhdCI6MTcwODYwMzY0MSwianRpIjoiZjRmNWNiMjEtMWJlMy00OTcyLTlmMWUtNDA2NTdlMGVkYzYyIn0.PT_pwpe20pj71hH66KSSGcprpxXmzAnIHO8J1jCBis9X76Bi5N-J_KGc62wQ4j6VecD_cLwBvyTzDtRB_-0gnw&publicKey=%7B%0A%20%20%22crv%22%3A%20%22P-256%22%2C%0A%20%20%22ext%22%3A%20true%2C%0A%20%20%22key_ops%22%3A%20%5B%0A%20%20%20%20%22verify%22%0A%20%20%5D%2C%0A%20%20%22kty%22%3A%20%22EC%22%2C%0A%20%20%22x%22%3A%20%220k3qaeJNxLsYGxQ9ccZxZRkMyTB4W8YrUOZNlBQomak%22%2C%0A%20%20%22y%22%3A%20%22TIUT0gljofUpYvj8t4kNy_lZbssq1DBvqvNkyYxkHj8%22%0A%7D) .

I also wanted to include the above link to show that no sensitive information is included in the `DPoP` proof. Even when an access token is passed to `buildDPoPHeaders`, it is hashed ([ath](https://datatracker.ietf.org/doc/html/rfc9449#section-4.2-6.2)).

### Dependent Changes

Everything related to JWT creation, key pair generation, and signatures is implemented in `@paypal/sdk-client`:

- https://github.com/paypal/paypal-sdk-client/pull/184
- https://github.com/paypal/paypal-sdk-client/pull/186
- https://github.com/paypal/paypal-sdk-client/pull/187

Future PRs:

- this feature flag can be removed (and default to DPoP requests) when e2e testing has been completed.

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
