### PR TITLE
Use node 14 for publishing v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         # sets up the .npmrc file to publish to npm
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NVMRC }}
+          node-version: '14.x'
           registry-url: "https://registry.npmjs.org"
 
       - name: 📥 Download deps


### PR DESCRIPTION
### Description

Using the `publish` GitHub Actions workflow with `v4` fails due to Node 18 being used ([example](https://github.com/paypal/paypal-checkout-components/actions/runs/8067044615/job/22036540626)). This PR pins Node `v14.x`.
