### PR TITLE
upgrade vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "puppeteer": "^1.20.0",
     "serve": "^14.0.0",
     "vite": "^3.2.4",
-    "vitest": "^0.25.3"
+    "vitest": "^1.3.1"
   },
   "dependencies": {
     "@krakenjs/beaver-logger": "^5.7.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -43,7 +43,11 @@ export default defineConfig({
     setupFiles: ["vitestSetup.js"],
     include: ["**/src/**/*.test.{js,jsx}"],
     deps: {
-      inline: ["@krakenjs/post-robot", "@krakenjs/zoid"],
+      optimizer: {
+        web: {
+          include: ["@krakenjs/post-robot", "@krakenjs/zoid"],
+        },
+      },
     },
     globals: true,
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -42,13 +42,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["vitestSetup.js"],
     include: ["**/src/**/*.test.{js,jsx}"],
-    deps: {
-      optimizer: {
-        web: {
-          include: ["@krakenjs/post-robot", "@krakenjs/zoid"],
-        },
-      },
-    },
     globals: true,
   },
   optimizeDeps: {


### PR DESCRIPTION
### Description

This PR upgrades `vitest` to the latest version in preparation for some incoming test-related changes

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

A follow-up PR will add test coverage for vitest tests, but depends on 1.0+ of vitest.

### Reproduction Steps (if applicable)

```
npm run test:unit
```

### Screenshots (if applicable)

The changes to `vite.config.js` were to address this warning:
<img width="1145" alt="Screenshot 2024-02-27 at 15 17 31" src="https://github.com/paypal/paypal-checkout-components/assets/3824954/685b0e9a-042e-489a-b0f7-55d0ec668a1a">

I first tried the suggested fix in https://github.com/paypal/paypal-checkout-components/pull/2343/commits/480cd67f78a8147da5663ab5876b674d3b2f5727 but realized it could be removed altogether :tada:

❤️ Thank you!
