### PR TITLE
run vitest in ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,9 @@ jobs:
       - name: ▶️ Run Typecheck
         run: npm run typecheck
 
+      - name: ▶️ Run Vitest
+        run: npm run test:unit
+
       - name: ▶️ Run Karma
         run: npm run karma
 


### PR DESCRIPTION
### Description

This PR adds a step to our main CI pipeline to run the vitest unit tests.

### Why are we making these changes? 

While working on a related change, I noticed vitest was not running in CI.

### Reproduction Steps (if applicable)

See a [previous build](https://github.com/paypal/paypal-checkout-components/actions/runs/8071840002/job/22052337072) and observe that there is no mention of vitest.

### Screenshots (if applicable)

Before:

<img width="454" alt="Screenshot 2024-02-27 at 16 03 26" src="https://github.com/paypal/paypal-checkout-components/assets/3824954/8d879800-8215-405a-994c-a2a1f6c69f06">

After:

<img width="987" alt="Screenshot 2024-02-27 at 16 07 02" src="https://github.com/paypal/paypal-checkout-components/assets/3824954/a5bc7b97-b209-4574-99bb-6ec3445aa987">



❤️ Thank you!
