### PR TITLE
add QRCode component to hosted buttons

### DIFF
--- a/src/interface/hosted-buttons.js
+++ b/src/interface/hosted-buttons.js
@@ -7,6 +7,7 @@ import {
   getCardFormComponent,
   type CardFormComponent,
 } from "../zoid/card-form";
+import { getQRCodeComponent, type QRCodeComponent } from "../zoid/qr-code";
 import { getCheckoutComponent, type CheckoutComponent } from "../zoid/checkout";
 import type { LazyExport, LazyProtectedExport } from "../types";
 import { protectedExport } from "../lib";
@@ -21,6 +22,10 @@ export const Checkout: LazyProtectedExport<CheckoutComponent> = {
 
 export const CardForm: LazyProtectedExport<CardFormComponent> = {
   __get__: () => protectedExport(getCardFormComponent()),
+};
+
+export const QRCode: LazyProtectedExport<QRCodeComponent> = {
+  __get__: () => protectedExport(getQRCodeComponent()),
 };
 
 export function setup() {


### PR DESCRIPTION
### Description

This PR fixes an issue where buyers checking out with Venmo on Desktop receive a `native_error`. 

### Why are we making these changes? 

Desktop buyers are unable to complete a checkout using the Venmo button for hosted button experiences.

### Reproduction Steps (if applicable)

Load this hosted button example in a browser and click on the venmo button.

```
<script src=[https://www.paypal.com/sdk/js?client-id=BAASQz64f1YcDfoz5jgt15dL2BGNcDZ5Mb_pAFQ6TgEk7fB3eE7WHpPU8v1cySkLIc6YaJ7ajwbdhiICCM&components=buttons,hosted-buttons&enable-funding=venmo&currency=USD](view-source:https://www.paypal.com/sdk/js?client-id=BAASQz64f1YcDfoz5jgt15dL2BGNcDZ5Mb_pAFQ6TgEk7fB3eE7WHpPU8v1cySkLIc6YaJ7ajwbdhiICCM&components=buttons,hosted-buttons&enable-funding=venmo&currency=USD)></script>
<div id="paypal-container-CQ2ZWHMMN7UD2"></div>
<script>
  paypal.HostedButtons({
    hostedButtonId: "CQ2ZWHMMN7UD2",
  }).render("#paypal-container-CQ2ZWHMMN7UD2")
</script>
```

### Screenshots (if applicable)

<img width="434" alt="Screenshot 2024-03-04 at 15 41 44" src="https://github.com/paypal/paypal-checkout-components/assets/3824954/e59ba744-db94-4f3f-ab8f-9d4f572acf88">

### Follow-Up Work

- Investigate aliasing `hosted-buttons` to the `buttons` component so that new components (e.g. venmo web) will automatically be picked up without editing this file
- Investigate supporting the QRcode checkout experience in sandbox (today it is the popup window)

❤️ Thank you!
