### PR TITLE
use current sha in prerelease tags

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,15 +1,19 @@
 #!/bin/sh
 
-# This script will determine the type of release based on the git branch. When the default branch is used, it will be a `patch` that's published to npm under the `latest` dist-tag. Any other branch will be a `prelease` that's published to npm under the `alpha` dist-tag.
+# This script will determine the type of release based on the git branch.
+# When the default branch is used, it will be a `patch` that's published to npm
+# under the `latest` dist-tag. Any other branch will be a `prelease` that's
+# published to npm under the `alpha-$SHA` dist-tag.
 bump='patch'
 tag='latest'
 
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 default_branch=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+current_sha=$(git rev-parse --short HEAD)
 
 if [ "$current_branch" != "$default_branch" ]; then
   bump='prerelease'
-  tag='alpha'
+  tag="alpha-$current_sha"
   export tag
   npm --no-git-tag-version version $bump --preid=$tag
 else


### PR DESCRIPTION
### Description

This PR uses the current git sha in the prerelease tag when publishing to npm:

<img width="539" alt="Screenshot 2024-03-22 at 09 15 58" src="https://github.com/paypal/paypal-checkout-components/assets/3824954/ebf7ce87-19b6-48b4-965d-79c5b57d2456">

### Why are we making these changes? 

Only one alpha release can be published per `main` package version:

e.g. package version is `1.2.3`. If i run `npm publish` on a non-`main` branch, the release version will be `1.2.3-alpha.0`

and subsequent `npm publish` runs on _any_ branch will error:

<img width="822" alt="Screenshot 2024-03-22 at 09 02 26" src="https://github.com/paypal/paypal-checkout-components/assets/3824954/e728ef77-258f-4af0-aa52-71680ecc2b63">

To get around this error, contributors must manually update the package version on their feature branch:

<img width="504" alt="Screenshot 2024-03-22 at 09 40 44" src="https://github.com/paypal/paypal-checkout-components/assets/3824954/617e4587-5f45-491f-9dfb-17b503f6069a">

After updating the package version on a feature branch, rerunning `npm publish` increments the build number, so the published version _never_ matches the version specified in `package.json`, which is confusing.

After testing out their changes, developers have to revert the `package.json` version. This effectively means that what gets tested in an alpha release will never correspond 1:1 w/ code that gets merged. 

### Reproduction Steps 

1. create and push a feature branch
2. run the `npm publish` action (specifying the name of the feature branch)
3. push an empty commit to the feature branch
4. rerun the `npm publish` action (specifying the name of the feature branch)
5. observe npm publish 403.

### Known Limitations

Users will still receive a 403 error if they rerun the `npm publish` workflow without pushing a new commit. I thought about adding support for this use case, but decided against it because:
1. the implementation would need to be github-actions aware (lack of portability) to use a build number and/or
2. the build number would be a timestamp (longer tag name) (didn't love this idea)
3. I think the error is the correct behavior here - if someone forgot to push up their changes before rerunning the `npm publish` workflow, this error would tell the user that information.

❤️ Thank you!
