### PR TITLE
prevent popup bridge xss

### DIFF
--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -237,11 +237,14 @@ export function extendUrl(url : string, params : { [key : string] : string } = {
 }
 
 export function redirect(win : CrossDomainWindowType = window, url : string) : ZalgoPromise<void> {
-    return new ZalgoPromise(resolve => {
+    return new ZalgoPromise((resolve, reject) => {
 
         info(`redirect`, { url });
 
         setTimeout(() => {
+            if (url.toLowerCase().replace(/[^a-z:]+/g, '').match(/^javascript:/)) {
+                return reject(new Error('Invalid redirect URL'));
+            }
             win.location = url;
             if (!urlWillRedirectPage(url)) {
                 resolve();

--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -241,10 +241,11 @@ export function redirect(win : CrossDomainWindowType = window, url : string) : Z
 
         info(`redirect`, { url });
 
+        if (url.toLowerCase().replace(/[^a-z:]+/g, '').match(/^javascript:/)) {
+            return reject(new Error('Invalid redirect URL'));
+        }
+
         setTimeout(() => {
-            if (url.toLowerCase().replace(/[^a-z:]+/g, '').match(/^javascript:/)) {
-                return reject(new Error('Invalid redirect URL'));
-            }
             win.location = url;
             if (!urlWillRedirectPage(url)) {
                 resolve();


### PR DESCRIPTION
### Description

This PR will `reject` if `actions.redirect` attempts to redirect to a javascript URI.

### Why are we making these changes? 

LI-38558 - prevent xss

### Reproduction Steps (if applicable)

Specific details are in the ticket, but I was able to test this locally by using a redirect extension to redirect requests from https://www.paypalobjects.com/api/checkout.js to the local built js https://127.0.0.1:8080/dist/checkout.js


### Screenshots (if applicable)

<img width="636" alt="Screenshot 2024-04-05 at 07 08 45" src="https://github.com/paypal/paypal-checkout-components/assets/3824954/8d3ced61-fb81-4184-ba78-86b4a152c678">

❤️ Thank you!
