### PR TITLE
redirect ncps inline guest with errors

### DIFF
--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -214,7 +214,12 @@ export const buildHostedButtonOnApprove = ({
       // so we need to redirect to the thank you page for buyers who complete
       // a checkout via "Debit or Credit Card".
       if (data.paymentSource === FUNDING.CARD) {
-        window.location = `${baseUrl}/ncp/payment/${hostedButtonId}/${data.orderID}`;
+        let redirectUrl = `${baseUrl}/ncp/payment/${hostedButtonId}/${data.orderID}`;
+        // add error messages to the payment confirmation page url
+        if (response.body?.details?.[0]?.issue) {
+          redirectUrl += `?status=${response.body.details[0].issue}`;
+        }
+        window.location = redirectUrl;
       }
       return response;
     });

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -287,6 +287,7 @@ describe("buildHostedButtonOnApprove", () => {
     });
 
     test("redirects with an error message in the status query parameter", async () => {
+      // $FlowIssue
       request.mockImplementation(() =>
         // eslint-disable-next-line compat/compat
         Promise.resolve({

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -285,6 +285,26 @@ describe("buildHostedButtonOnApprove", () => {
         "https://example.com/ncp/payment/B1234567890/EC-1234567890"
       );
     });
+
+    test("redirects with an error message in the status query parameter", async () => {
+      request.mockImplementation(() =>
+        // eslint-disable-next-line compat/compat
+        Promise.resolve({
+          body: {
+            details: [
+              {
+                issue: "DUPLICATE_INVOICE_ID",
+              },
+            ],
+          },
+        })
+      );
+
+      await onApprove({ orderID, paymentSource: "card" });
+      expect(window.location).toBe(
+        "https://example.com/ncp/payment/B1234567890/EC-1234567890?status=DUPLICATE_INVOICE_ID"
+      );
+    });
   });
 });
 


### PR DESCRIPTION
### Description

This PR fixes an issue where errors during order capture are not included in the redirect URL, resulting in a thank you confirmation page, despite the order not being captured successfully.

### Why are we making these changes?

LI-38989 (the thank you page should include a `status` query parameter to indicate any issues with order capture).

### Reproduction Steps

I created this sandbox hosted button:

```html
<script src="https://www.paypal.com/sdk/js?client-id=BAA9VRd1Ml8qgmlZsS4yN0eQYNtem7WE5a5IKzp3lsS6RESfg8ZOiKaUAaJsJl_dxgiRpLJd1Vka3F4a-M&components=hosted-buttons&enable-funding=venmo&currency=USD"></script>
<div id="paypal-container-M4YT4Q7TJBGEL"></div>
<script>
  paypal.HostedButtons({
    hostedButtonId: "M4YT4Q7TJBGEL",
  }).render("#paypal-container-M4YT4Q7TJBGEL")
</script>
```

if you type in `1234` for the invoice id and complete the checkout with inline guest (credit or debit card), the order capture will fail (422 `POST` https://api.sandbox.paypal.com/v1/checkout/links/M4YT4Q7TJBGEL/pay), but the page will redirect to a thank you page.

### Screenshots

<img width="916" alt="Screenshot 2024-04-08 at 14 26 31" src="https://github.com/paypal/paypal-checkout-components/assets/3824954/9cb2080d-217e-4515-897a-85bcaf7f8e38">

❤️ Thank you!
