### PR TITLE
fix: add eslint-config-grumbler as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "devDependencies": {
     "@bunchtogether/vite-plugin-flow": "^1.0.2",
     "@krakenjs/grumbler-scripts": "^8.1.5",
+    "@krakenjs/eslint-config-grumbler": "8.1.3",
     "@krakenjs/sync-browser-mocks": "^3.0.0",
     "@percy/cli": "1.28.5",
     "@percy/playwright": "^1.0.4",


### PR DESCRIPTION
### Description

Fixes issue with `eslint-plugin-*` packages specified by `@krakenjs/eslint-config-grumbler` (via `@krakenjs/grumbler-scripts`) no longer installing as expected. This changes adds `@krakenjs/eslint-config-grumbler` as a dev dependency directly, which is producing the correct graph. See https://github.com/paypal/paypal-common-components/pull/99 for discussion.
