### PR TITLE
DTPPCPSDK-2227: Return V2 Variables from getHostedButtonDetails 👾

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,6 @@
     "@paypal/sdk-logos": "^2.2.6"
   },
   "lint-staged": {
-    "**/{src,test,scripts}/**/*.{js,jsx,json,sh}": "prettier --write"
+    "**/*": "prettier --write --ignore-unknown"
   }
 }

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -34,10 +34,10 @@ export type HostedButtonsInstance = {|
   render: (string | HTMLElement) => Promise<void>,
 |};
 
-export type HostedButtonPreferences = {
+export type HostedButtonPreferences = {|
   buttonPreferences: $ReadOnlyArray<string>,
   eligibleFundingMethods: $ReadOnlyArray<string>,
-};
+|};
 
 export type HostedButtonDetailsParams =
   (HostedButtonsComponentProps) => Promise<{|

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -34,16 +34,24 @@ export type HostedButtonsInstance = {|
   render: (string | HTMLElement) => Promise<void>,
 |};
 
+export type HostedButtonPreferences = {
+  buttonPreferences: $ReadOnlyArray<string>,
+  eligibleFundingMethods: $ReadOnlyArray<string>,
+};
+
 export type HostedButtonDetailsParams =
   (HostedButtonsComponentProps) => Promise<{|
     html: string,
     htmlScript: string,
     style: {|
       layout: string,
-      shape: string,
-      color: string,
-      label: string,
+      shape: ?string,
+      label: ?string,
+      height: ?string,
     |},
+    version: string,
+    preferences: HostedButtonPreferences,
+    buttonContainerId: string,
   |}>;
 
 export type ButtonVariables = $ReadOnlyArray<{|

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -45,13 +45,14 @@ export type HostedButtonDetailsParams =
     htmlScript: string,
     style: {|
       layout: string,
-      shape: ?string,
-      label: ?string,
-      height: ?string,
+      shape: string,
+      color: string,
+      label: string,
+      height: string,
     |},
-    version: string,
-    preferences: HostedButtonPreferences,
-    buttonContainerId: string,
+    version: ?string,
+    buttonContainerId: ?string,
+    preferences?: HostedButtonPreferences,
   |}>;
 
 export type ButtonVariables = $ReadOnlyArray<{|

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -34,9 +34,11 @@ export type HostedButtonsInstance = {|
   render: (string | HTMLElement) => Promise<void>,
 |};
 
+export type EligibleHostedButtons = "paypal" | "venmo" | "paylater";
+
 export type HostedButtonPreferences = {|
-  buttonPreferences: $ReadOnlyArray<string>,
-  eligibleFundingMethods: $ReadOnlyArray<string>,
+  buttonPreferences: $ReadOnlyArray<EligibleHostedButtons & "default">,
+  eligibleFundingMethods: $ReadOnlyArray<EligibleHostedButtons>,
 |};
 
 export type HostedButtonDetailsParams =

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -90,16 +90,26 @@ export const getHostedButtonDetails: HostedButtonDetailsParams = async ({
 
   // $FlowIssue request returns ZalgoPromise
   const { body } = response;
-  const variables = body.button_details.link_variables;
+  const { link_variables: variables, preferences } = body.button_details;
+
   return {
     style: {
       layout: getButtonVariable(variables, "layout"),
       shape: getButtonVariable(variables, "shape"),
       color: getButtonVariable(variables, "color"),
       label: getButtonVariable(variables, "button_text"),
+      height: getButtonVariable(variables, "height"),
     },
+    version: body.version,
+    buttonContainerId: body.button_container_id,
     html: body.html,
     htmlScript: body.html_script,
+    ...(preferences && {
+      preferences: {
+        buttonPreferences: preferences.button_preferences,
+        eligibleFundingMethods: preferences.eligible_funding_methods,
+      },
+    }),
   };
 };
 


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

- 🥖 **Prepares us for the NCPS 2.0 changes** - All we need to do for this PR is extract those variables from the response to prepare for future changes.
- 📝  **Added tests for v2 response** -  Since we need to support both V1 & V2 responses from `/ncp/api/form-fields/`, I added some quick unit tests to make sure `getHostedButtonDetails` can handle either response appropriately.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
**JIRA:** [DTPPCPSDK-2227](https://paypal.atlassian.net/browse/DTPPCPSDK-2227)

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
