### PR TITLE
Fix for NCP height string to number conversion 👾

### DIFF
--- a/src/hosted-buttons/index.test.js
+++ b/src/hosted-buttons/index.test.js
@@ -55,6 +55,10 @@ const getHostedButtonDetailsResponse = {
           name: "button_type",
           value: "FIXED_PRICE",
         },
+        {
+          name: "height",
+          value: "40",
+        },
       ],
     },
   },

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -50,7 +50,7 @@ export type HostedButtonDetailsParams =
       shape: string,
       color: string,
       label: string,
-      height: string,
+      height: ?number,
     |},
     version: ?string,
     buttonContainerId: ?string,

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -98,7 +98,7 @@ export const getHostedButtonDetails: HostedButtonDetailsParams = async ({
       shape: getButtonVariable(variables, "shape"),
       color: getButtonVariable(variables, "color"),
       label: getButtonVariable(variables, "button_text"),
-      height: parseInt(getButtonVariable(variables, "height")) || undefined,
+      height: parseInt(getButtonVariable(variables, "height"), 10) || undefined,
     },
     version: body.version,
     buttonContainerId: body.button_container_id,

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -98,7 +98,7 @@ export const getHostedButtonDetails: HostedButtonDetailsParams = async ({
       shape: getButtonVariable(variables, "shape"),
       color: getButtonVariable(variables, "color"),
       label: getButtonVariable(variables, "button_text"),
-      height: getButtonVariable(variables, "height"),
+      height: parseInt(getButtonVariable(variables, "height")) || undefined,
     },
     version: body.version,
     buttonContainerId: body.button_container_id,

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -82,7 +82,7 @@ describe("getHostedButtonDetails", () => {
           link_variables: [
             {
               name: "height",
-              value: 50,
+              value: "50",
             },
           ],
           preferences: {
@@ -110,7 +110,6 @@ describe("getHostedButtonDetails", () => {
         shape: "rect",
         color: "gold",
         label: "paypal",
-        height: "",
       });
     });
     expect.assertions(1);


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

JIRA: [DTPPCPSDK-2227](https://paypal.atlassian.net/browse/DTPPCPSDK-2227)

- 🔨 _**Height should be a number, not a string**_ - This fixes the error that yells at you in your dreams as you try to sleep but you open your eyes and height is in front of your face punishing you for attempting to make him a string, when he is in fact, a number.  He then threatens you but you cannot move.  He repeats himself, "height should be a number. height should be a number."  You wake up from the nightmare just for it to all be true. This actually happened.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
