### PR TITLE
NCPS v2 👾

### DIFF
--- a/src/hosted-buttons/index.js
+++ b/src/hosted-buttons/index.js
@@ -66,7 +66,7 @@ export const getHostedButtonsComponent = (): HostedButtonsComponent => {
         style,
       };
 
-      if (version && version === "2") {
+      if (version === "2") {
         const { flexDirection } = getFlexDirection({ ...style });
 
         applyContainerStyles({ flexDirection, buttonContainerId });

--- a/src/hosted-buttons/index.js
+++ b/src/hosted-buttons/index.js
@@ -76,7 +76,6 @@ export const getHostedButtonsComponent = (): HostedButtonsComponent => {
             preferences,
             buttonContainerId,
             buttonOptions,
-            style,
           });
         });
       } else {

--- a/src/hosted-buttons/index.js
+++ b/src/hosted-buttons/index.js
@@ -10,6 +10,8 @@ import {
   getFlexDirection,
   applyContainerStyles,
   renderStandaloneButton,
+  renderDefaultButton,
+  getDefaultButtonOptions,
 } from "./utils";
 import type {
   HostedButtonsComponent,
@@ -72,12 +74,20 @@ export const getHostedButtonsComponent = (): HostedButtonsComponent => {
         applyContainerStyles({ flexDirection, buttonContainerId });
 
         preferences?.buttonPreferences.forEach((fundingSource) => {
-          renderStandaloneButton({
-            fundingSource,
-            preferences,
-            buttonContainerId,
-            buttonOptions,
-          });
+          if (fundingSource === "default") {
+            const eligibleDefaultButtons = getDefaultButtonOptions(preferences);
+            renderDefaultButton({
+              eligibleDefaultButtons,
+              buttonContainerId,
+              buttonOptions,
+            });
+          } else {
+            renderStandaloneButton({
+              fundingSource,
+              buttonContainerId,
+              buttonOptions,
+            });
+          }
         });
       } else {
         // V1 Experience

--- a/src/hosted-buttons/index.js
+++ b/src/hosted-buttons/index.js
@@ -1,7 +1,4 @@
 /* @flow */
-
-import { getLogger } from "@paypal/sdk-client/src";
-
 import { getButtonsComponent } from "../zoid/buttons";
 
 import {
@@ -11,7 +8,6 @@ import {
   renderForm,
   getMerchantID,
   getFlexDirection,
-  getButtonColor,
   applyContainerStyles,
   renderStandaloneButton,
 } from "./utils";

--- a/src/hosted-buttons/index.js
+++ b/src/hosted-buttons/index.js
@@ -49,6 +49,7 @@ export const getHostedButtonsComponent = (): HostedButtonsComponent => {
         hostedButtonId,
         merchantId,
       });
+
       const onApprove = buildHostedButtonOnApprove({
         enableDPoP,
         hostedButtonId,

--- a/src/hosted-buttons/index.test.js
+++ b/src/hosted-buttons/index.test.js
@@ -222,7 +222,7 @@ describe("HostedButtons v2", () => {
     vi.spyOn(document, "querySelector").mockReturnValue(selector);
   });
 
-  test("paypal.HostedButtons calls renderStandaloneButton for each eligible button preference", async () => {
+  test("paypal.HostedButtons calls renderStandaloneButton & renderDefaultButton accordingly", async () => {
     const renderMock = vi.fn();
 
     const Buttons = vi.fn(() => ({
@@ -232,8 +232,6 @@ describe("HostedButtons v2", () => {
     // $FlowIssue
     getButtonsComponent.mockImplementation(() => Buttons);
 
-    const { button_preferences: buttonPreferences } =
-      hostedButtonDetailsResponse.body.button_details.preferences;
     const HostedButtons = getHostedButtonsComponent();
 
     // $FlowIssue

--- a/src/hosted-buttons/index.test.js
+++ b/src/hosted-buttons/index.test.js
@@ -6,8 +6,9 @@ import { request } from "@krakenjs/belter/src";
 
 import { getButtonsComponent } from "../zoid/buttons";
 
-import { getHostedButtonsComponent } from ".";
 import { renderStandaloneButton } from "./utils";
+
+import { getHostedButtonsComponent } from ".";
 
 vi.mock("@krakenjs/belter/src", async () => {
   return {
@@ -200,9 +201,9 @@ describe("HostedButtons v2", () => {
   const hostedButtonDetailsResponse = {
     body: {
       version: "2",
-      button_container_id: "spb-container",
       button_details: {
         link_variables: baseLinkVariables,
+        js_sdk_container_id: "spb-container",
         preferences: {
           button_preferences: ["paypal", "default"],
           eligible_funding_methods: ["paypal", "venmo", "paylater"],
@@ -215,7 +216,8 @@ describe("HostedButtons v2", () => {
     vi.restoreAllMocks();
 
     const selector = document.createElement("div");
-    selector.id = hostedButtonDetailsResponse.button_container_id;
+    selector.id =
+      hostedButtonDetailsResponse.body.button_details.js_sdk_container_id;
     vi.spyOn(document, "querySelector").mockReturnValue(selector);
   });
 

--- a/src/hosted-buttons/index.test.js
+++ b/src/hosted-buttons/index.test.js
@@ -68,7 +68,7 @@ const getHostedButtonDetailsResponse = {
   },
 };
 
-describe("HostedButtons", () => {
+describe("HostedButtons v1", () => {
   test("paypal.Buttons calls getHostedButtonDetails and invokes v5 of the SDK", async () => {
     const Buttons = vi.fn(() => ({ render: vi.fn() }));
     // $FlowIssue
@@ -125,8 +125,8 @@ describe("HostedButtons", () => {
           hostedButtonId: "B1234567890",
         })
       );
-      expect(Buttons).toHaveBeenCalledTimes(2);
-      expect(renderMock).toHaveBeenCalledTimes(2);
+      expect(Buttons).toHaveBeenCalledTimes(1);
+      expect(renderMock).toHaveBeenCalledTimes(1);
       expect.assertions(3);
     });
   });
@@ -148,15 +148,14 @@ describe("HostedButtons", () => {
     );
     await HostedButtons({
       hostedButtonId: "B1234567890",
-      fundingSources: ["paypal", "venmo"],
     }).render("#example");
     expect(Buttons).toHaveBeenCalledWith(
       expect.objectContaining({
         hostedButtonId: "B1234567890",
       })
     );
-    expect(Buttons).toHaveBeenCalledTimes(2);
-    expect(renderMock).toHaveBeenCalledTimes(0);
+    expect(Buttons).toHaveBeenCalledTimes(1);
+    expect(renderMock).toHaveBeenCalledTimes(1);
     expect.assertions(3);
   });
 

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -6,6 +6,18 @@ export type Color = string;
 export type FlexDirection = string;
 export type Layout = string;
 
+export type CreateOrder = (data: {|
+  paymentSource: string,
+|}) => Promise<string | void>;
+
+export type OnApprove = (data: {|
+  orderID: string,
+  paymentSource: string,
+|}) => Promise<mixed>;
+
+type OnInit = (data: mixed, actions: mixed) => void;
+type OnClick = (data: mixed, actions: mixed) => void;
+
 export type FundingSources = string;
 export interface GetFlexDirection {
   flexDirection: FlexDirection;
@@ -20,10 +32,10 @@ export interface BuildButtonContainerArgs {
   selector: string | HTMLElement;
 }
 
-export type ApplyButtonStylesProps = {
+export type ApplyButtonStylesProps = {|
   flexDirection: FlexDirection,
   buttonContainerId: string,
-};
+|};
 
 export type HostedButtonStyles = {|
   layout: string,
@@ -34,7 +46,7 @@ export type HostedButtonStyles = {|
   tagline: boolean,
 |};
 
-export type HostedButtonOptions = {
+export type HostedButtonOptions = {|
   createOrder: CreateOrder,
   onApprove: OnApprove,
   onClick: OnClick,
@@ -42,7 +54,12 @@ export type HostedButtonOptions = {
   style: HostedButtonStyles,
   hostedButtonId: string,
   merchantId?: string,
-};
+|};
+
+export type HostedButtonPreferences = {|
+  buttonPreferences: $ReadOnlyArray<$Values<typeof FUNDING> | "default">,
+  eligibleFundingMethods: $ReadOnlyArray<$Values<typeof FUNDING>>,
+|};
 
 export type RenderStandaloneButtonProps = {|
   fundingSource: FundingSources,
@@ -67,11 +84,6 @@ export type HostedButtonsInstance = {|
   render: (string | HTMLElement) => Promise<void>,
 |};
 
-export type HostedButtonPreferences = {|
-  buttonPreferences: $ReadOnlyArray<$Values<typeof FUNDING> | "default">,
-  eligibleFundingMethods: $ReadOnlyArray<$Values<typeof FUNDING>>,
-|};
-
 export type HostedButtonDetailsParams =
   (HostedButtonsComponentProps) => Promise<{|
     html: string,
@@ -86,18 +98,6 @@ export type ButtonVariables = $ReadOnlyArray<{|
   name: string,
   value: string,
 |}>;
-
-export type CreateOrder = (data: {|
-  paymentSource: string,
-|}) => Promise<string | void>;
-
-export type OnApprove = (data: {|
-  orderID: string,
-  paymentSource: string,
-|}) => Promise<mixed>;
-
-type OnInit = (data: mixed, actions: mixed) => void;
-type OnClick = (data: mixed, actions: mixed) => void;
 
 export type CreateAccessToken = ({|
   clientId: string,

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -56,19 +56,33 @@ export type HostedButtonOptions = {|
   merchantId?: string,
 |};
 
+export type ButtonPreferences = $ReadOnlyArray<
+  $Values<typeof FUNDING> | "default"
+>;
+
 export type HostedButtonPreferences = {|
-  buttonPreferences: $ReadOnlyArray<$Values<typeof FUNDING> | "default">,
+  buttonPreferences: ButtonPreferences,
   eligibleFundingMethods: $ReadOnlyArray<$Values<typeof FUNDING>>,
 |};
 
 export type NcpResponsePreferences = {|
-  button_preferences: $ReadOnlyArray<$Values<typeof FUNDING> | "default">,
+  button_preferences: ButtonPreferences,
   eligible_funding_methods: $ReadOnlyArray<$Values<typeof FUNDING>>,
+|};
+
+export type GetButtonsProps = {|
+  fundingSource: FundingSources,
+  buttonOptions: HostedButtonOptions,
 |};
 
 export type RenderStandaloneButtonProps = {|
   fundingSource: FundingSources,
-  preferences: HostedButtonPreferences,
+  buttonContainerId: string,
+  buttonOptions: HostedButtonOptions,
+|};
+
+export type RenderDefaultButtonProps = {|
+  eligibleDefaultButtons: $ReadOnlyArray<FundingSources>,
   buttonContainerId: string,
   buttonOptions: HostedButtonOptions,
 |};

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -1,5 +1,6 @@
 /* @flow */
 /* eslint-disable no-restricted-globals, promise/no-native */
+import { FUNDING } from "@paypal/sdk-constants/src";
 
 export type Color = string;
 export type FlexDirection = string;
@@ -19,6 +20,38 @@ export interface BuildButtonContainerArgs {
   selector: string | HTMLElement;
 }
 
+export type ApplyButtonStylesProps = {
+  flexDirection: FlexDirection,
+  buttonContainerId: string,
+};
+
+export type HostedButtonStyles = {|
+  layout: string,
+  shape: string,
+  color: string,
+  label: string,
+  height: ?number,
+  tagline: boolean,
+|};
+
+export type HostedButtonOptions = {
+  createOrder: CreateOrder,
+  onApprove: OnApprove,
+  onClick: OnClick,
+  onInit: OnInit,
+  style: HostedButtonStyles,
+  hostedButtonId: string,
+  merchantId?: string,
+};
+
+export type RenderStandaloneButtonProps = {|
+  fundingSource: FundingSources,
+  preferences: HostedButtonPreferences,
+  buttonContainerId: string,
+  buttonOptions: HostedButtonOptions,
+  style: HostedButtonStyles,
+|};
+
 export type HostedButtonsComponentProps = {|
   hostedButtonId: string,
   fundingSources?: $ReadOnlyArray<FundingSources>,
@@ -34,27 +67,18 @@ export type HostedButtonsInstance = {|
   render: (string | HTMLElement) => Promise<void>,
 |};
 
-export type EligibleHostedButtons = "paypal" | "venmo" | "paylater";
-
 export type HostedButtonPreferences = {|
-  buttonPreferences: $ReadOnlyArray<EligibleHostedButtons & "default">,
-  eligibleFundingMethods: $ReadOnlyArray<EligibleHostedButtons>,
+  buttonPreferences: $ReadOnlyArray<$Values<typeof FUNDING> | "default">,
+  eligibleFundingMethods: $ReadOnlyArray<$Values<typeof FUNDING>>,
 |};
 
 export type HostedButtonDetailsParams =
   (HostedButtonsComponentProps) => Promise<{|
     html: string,
     htmlScript: string,
-    style: {|
-      layout: string,
-      shape: string,
-      color: string,
-      label: string,
-      height: ?number,
-      tagline: boolean,
-    |},
+    style: HostedButtonStyles,
     version: ?string,
-    buttonContainerId: ?string,
+    buttonContainerId: string,
     preferences?: HostedButtonPreferences,
   |}>;
 
@@ -72,6 +96,9 @@ export type OnApprove = (data: {|
   paymentSource: string,
 |}) => Promise<mixed>;
 
+type OnInit = (data: mixed, actions: mixed) => void;
+type OnClick = (data: mixed, actions: mixed) => void;
+
 export type CreateAccessToken = ({|
   clientId: string,
   enableDPoP?: boolean,
@@ -86,8 +113,8 @@ export type RenderForm = ({|
   htmlScript: string,
   selector: string | HTMLElement,
 |}) => {|
-  onInit: (data: mixed, actions: mixed) => void,
-  onClick: (data: mixed, actions: mixed) => void,
+  onInit: OnInit,
+  onClick: OnClick,
 |};
 
 /* eslint-enable no-restricted-globals, promise/no-native */

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -61,12 +61,16 @@ export type HostedButtonPreferences = {|
   eligibleFundingMethods: $ReadOnlyArray<$Values<typeof FUNDING>>,
 |};
 
+export type NcpResponsePreferences = {|
+  button_preferences: $ReadOnlyArray<$Values<typeof FUNDING> | "default">,
+  eligible_funding_methods: $ReadOnlyArray<$Values<typeof FUNDING>>,
+|};
+
 export type RenderStandaloneButtonProps = {|
   fundingSource: FundingSources,
   preferences: HostedButtonPreferences,
   buttonContainerId: string,
   buttonOptions: HostedButtonOptions,
-  style: HostedButtonStyles,
 |};
 
 export type HostedButtonsComponentProps = {|

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -89,15 +89,17 @@ export const getButtonPreferences = ({
   button_preferences: buttonPreferences,
   eligible_funding_methods: eligibleFundingMethods,
 }: NcpResponsePreferences): HostedButtonPreferences => {
-  const filterByEligibility = (fundingMethod) =>
-    eligibleFundingMethods.includes(fundingMethod);
-
   return {
     // Remove any buttons that are not included in eligibleFundingMethods
-    buttonPreferences: buttonPreferences.filter(filterByEligibility),
+    buttonPreferences: buttonPreferences.filter(
+      (fundingMethod) =>
+        eligibleFundingMethods.includes(fundingMethod) ||
+        fundingMethod === "default"
+    ),
     // Sort the eligible funding methods returned from /ncp/api/form-fields in the order that they would appear in the smart stack.
-    eligibleFundingMethods:
-      SUPPORTED_FUNDING_SOURCES.filter(filterByEligibility),
+    eligibleFundingMethods: SUPPORTED_FUNDING_SOURCES.filter((fundingMethod) =>
+      eligibleFundingMethods.includes(fundingMethod)
+    ),
   };
 };
 

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -1,11 +1,8 @@
 /* @flow */
 
-import { getLogger } from "@paypal/sdk-client/src";
 import { request, memoize } from "@krakenjs/belter/src";
-
-import { getButtonsComponent } from "../zoid/buttons";
-
 import {
+  getLogger,
   buildDPoPHeaders,
   getSDKHost,
   getClientID,
@@ -13,6 +10,9 @@ import {
 } from "@paypal/sdk-client/src";
 import { FUNDING } from "@paypal/sdk-constants/src";
 import { SUPPORTED_FUNDING_SOURCES } from "@paypal/funding-components/src";
+import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
+
+import { getButtonsComponent } from "../zoid/buttons";
 
 import type {
   ButtonVariables,
@@ -24,14 +24,11 @@ import type {
   RenderForm,
   GetFlexDirectionArgs,
   GetFlexDirection,
-  BuildButtonContainerArgs,
   Color,
   FundingSources,
   RenderStandaloneButtonProps,
   ApplyButtonStylesProps,
 } from "./types";
-
-import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 
 const entryPoint = "SDK";
 const baseUrl = `https://${getSDKHost()}`;

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -345,10 +345,11 @@ export const applyContainerStyles = ({
   const buttonContainer = document.querySelector(`#${buttonContainerId}`);
 
   if (!buttonContainer) {
-    getLogger().error("ncps_button_container_id_missing", {
+    getLogger().error("ncps_button_container_missing", {
       buttonContainerId,
     });
-    throw new Error(`Button container with id ${buttonContainerId} not found.`);
+
+    throw new Error(`Element with id ${buttonContainerId} not found.`);
   }
 
   buttonContainer.style.flexDirection = flexDirection;

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -316,7 +316,7 @@ export const applyContainerStyles = ({
   flexDirection,
   buttonContainerId,
 }: ApplyButtonStylesProps): void | Error => {
-  const buttonContainer = document.querySelector(buttonContainerId);
+  const buttonContainer = document.querySelector(`#${buttonContainerId}`);
 
   if (!buttonContainer) {
     throw new Error(`Button container with id ${buttonContainerId} not found.`);

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -344,7 +344,7 @@ export const getButtonColor = (
 export const applyContainerStyles = ({
   flexDirection,
   buttonContainerId,
-}: ApplyButtonStylesProps): void | Error => {
+}: ApplyButtonStylesProps): void => {
   const buttonContainer = document.querySelector(`#${buttonContainerId}`);
 
   if (!buttonContainer) {

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -91,7 +91,7 @@ export const getButtonPreferences = ({
 }: NcpResponsePreferences): HostedButtonPreferences => {
   if (!buttonPreferences?.length || !eligibleFundingMethods?.length) {
     throw new Error(
-      `Expected preferences to be populated, recieved: ${JSON.stringify({
+      `Expected preferences to be populated, received: ${JSON.stringify({
         buttonPreferences,
         eligibleFundingMethods,
       })}`
@@ -99,7 +99,9 @@ export const getButtonPreferences = ({
   }
 
   return {
-    // Remove any buttons that are not included in eligibleFundingMethods
+    // Remove any buttons that are not included in eligibleFundingMethods.
+    // If the funding method is "default", we want to keep it in the preferences, and decide which
+    // button should be rendered in its place in renderStandaloneButton()
     buttonPreferences: buttonPreferences.filter(
       (fundingMethod) =>
         eligibleFundingMethods.includes(fundingMethod) ||
@@ -290,9 +292,9 @@ export const buildHostedButtonOnApprove = ({
 
 export const getFlexDirection = ({
   layout,
-}: GetFlexDirectionArgs): GetFlexDirection => {
-  return { flexDirection: layout === "horizontal" ? "row" : "column" };
-};
+}: GetFlexDirectionArgs): GetFlexDirection => ({
+  flexDirection: layout === "horizontal" ? "row" : "column",
+});
 
 export const getButtonColor = (
   color: Color,
@@ -339,7 +341,7 @@ export const applyContainerStyles = ({
     throw new Error(`Button container with id ${buttonContainerId} not found.`);
   }
 
-  buttonContainer.style.cssText = `display: flex; flex-wrap: nowrap; gap: 16px; max-width: 750px; flex-direction: ${flexDirection}`;
+  buttonContainer.style.flexDirection = flexDirection;
 };
 
 export const getDefaultButton = ({

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -49,6 +49,7 @@ export const getMerchantID = (): string | void => {
   // https://developer.paypal.com/docs/multiparty/checkout/multiseller-payments/
   const merchantIds = getSDKMerchantID();
   if (merchantIds.length > 1) {
+    getLogger().error("ncps_multiple_merchant_ids", { merchantIds });
     throw new Error("Multiple merchant-ids are not supported.");
   }
   return merchantIds[0];
@@ -90,10 +91,16 @@ export const getButtonPreferences = ({
   eligible_funding_methods: eligibleFundingMethods,
 }: NcpResponsePreferences): HostedButtonPreferences => {
   if (!buttonPreferences?.length || !eligibleFundingMethods?.length) {
+    const preferences = {
+      buttonPreferences,
+      eligibleFundingMethods,
+    };
+
+    getLogger().error("ncps_missing_preferences", { preferences });
+
     throw new Error(
       `Expected preferences to be populated, received: ${JSON.stringify({
-        buttonPreferences,
-        eligibleFundingMethods,
+        preferences,
       })}`
     );
   }
@@ -338,6 +345,9 @@ export const applyContainerStyles = ({
   const buttonContainer = document.querySelector(`#${buttonContainerId}`);
 
   if (!buttonContainer) {
+    getLogger().error("ncps_button_container_id_missing", {
+      buttonContainerId,
+    });
     throw new Error(`Button container with id ${buttonContainerId} not found.`);
   }
 

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -83,23 +83,19 @@ export const createAccessToken: CreateAccessToken = memoize<CreateAccessToken>(
   }
 );
 
-const getButtonPreferences = ({
+export const getButtonPreferences = ({
   button_preferences: buttonPreferences,
   eligible_funding_methods: eligibleFundingMethods,
 }) => {
   const filterByEligibility = (fundingMethod) =>
     eligibleFundingMethods.includes(fundingMethod);
 
-  // Remove any buttons that are not included in eligibleFundingMethods
-  const filteredButtonPreferences =
-    buttonPreferences.filter(filterByEligibility);
-  // Sort the eligible funding methods returned from /ncp/api/form-fields in the order that they would appear in the smart stack.
-  const sortedEligibleFundingMethods =
-    SUPPORTED_FUNDING_SOURCES.filter(filterByEligibility);
-
   return {
-    buttonPreferences: filteredButtonPreferences,
-    eligibleFundingMethods: sortedEligibleFundingMethods,
+    // Remove any buttons that are not included in eligibleFundingMethods
+    buttonPreferences: buttonPreferences.filter(filterByEligibility),
+    // Sort the eligible funding methods returned from /ncp/api/form-fields in the order that they would appear in the smart stack.
+    eligibleFundingMethods:
+      SUPPORTED_FUNDING_SOURCES.filter(filterByEligibility),
   };
 };
 
@@ -330,7 +326,10 @@ export const applyContainerStyles = ({
   );
 };
 
-const getDefaultButton = ({ buttonPreferences, eligibleFundingMethods }) => {
+export const getDefaultButton = ({
+  buttonPreferences,
+  eligibleFundingMethods,
+}) => {
   // Return first eligible funding method that is not specified in button preferences
   return eligibleFundingMethods.find(
     (fundingMethod) => !buttonPreferences.includes(fundingMethod)

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -116,7 +116,13 @@ export const getHostedButtonDetails: HostedButtonDetailsParams = async ({
 
   // $FlowIssue request returns ZalgoPromise
   const { body } = response;
-  const { link_variables: variables, preferences } = body.button_details;
+  const {
+    link_variables: variables,
+    preferences,
+    js_sdk_container_id: buttonContainerId,
+  } = body.button_details;
+
+  const shouldIncludePreferences = preferences && body.version === "2";
 
   return {
     style: {
@@ -128,10 +134,10 @@ export const getHostedButtonDetails: HostedButtonDetailsParams = async ({
       height: parseInt(getButtonVariable(variables, "height"), 10) || undefined,
     },
     version: body.version,
-    buttonContainerId: body.button_container_id || "#spb-container",
+    buttonContainerId: buttonContainerId || "spb-container",
     html: body.html,
     htmlScript: body.html_script,
-    ...(preferences && {
+    ...(shouldIncludePreferences && {
       preferences: getButtonPreferences(preferences),
     }),
   };
@@ -324,10 +330,7 @@ export const applyContainerStyles = ({
     throw new Error(`Button container with id ${buttonContainerId} not found.`);
   }
 
-  buttonContainer?.setAttribute(
-    "style",
-    `display: flex; flex-wrap: nowrap; gap: 16px; max-width: 750px; flex-direction: ${flexDirection}`
-  );
+  buttonContainer.style.cssText = `display: flex; flex-wrap: nowrap; gap: 16px; max-width: 750px; flex-direction: ${flexDirection}`;
 };
 
 export const getDefaultButton = ({
@@ -374,7 +377,7 @@ export const renderStandaloneButton = ({
   });
 
   if (standaloneButton.isEligible()) {
-    return standaloneButton.render(buttonContainerId);
+    return standaloneButton.render(`#${buttonContainerId}`);
   }
 
   getLogger().error(`ncps_standalone_${fundingSourceName}_ineligible`);

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -89,6 +89,15 @@ export const getButtonPreferences = ({
   button_preferences: buttonPreferences,
   eligible_funding_methods: eligibleFundingMethods,
 }: NcpResponsePreferences): HostedButtonPreferences => {
+  if (!buttonPreferences?.length || !eligibleFundingMethods?.length) {
+    throw new Error(
+      `Expected preferences to be populated, recieved: ${JSON.stringify({
+        buttonPreferences,
+        eligibleFundingMethods,
+      })}`
+    );
+  }
+
   return {
     // Remove any buttons that are not included in eligibleFundingMethods
     buttonPreferences: buttonPreferences.filter(
@@ -118,8 +127,8 @@ export const getHostedButtonDetails: HostedButtonDetailsParams = async ({
   const { body } = response;
   const {
     link_variables: variables,
-    preferences,
     js_sdk_container_id: buttonContainerId,
+    preferences,
   } = body.button_details;
 
   const shouldIncludePreferences = preferences && body.version === "2";

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -17,6 +17,7 @@ import {
   getButtonPreferences,
   getDefaultButton,
   renderStandaloneButton,
+  applyContainerStyles,
 } from "./utils";
 
 vi.mock("@krakenjs/belter/src", async () => {
@@ -643,6 +644,28 @@ describe("getDefaultButton", () => {
     const defaultButton = getDefaultButton(params);
 
     expect(defaultButton).toBeUndefined();
+  });
+});
+
+describe("applyContainerStyles", () => {
+  const buttonContainerId = "button-container";
+  const params = { flexDirection: "vertical", buttonContainerId };
+
+  test("successfully applies styles to container", () => {
+    const buttonContainer = document.createElement("div");
+    buttonContainer.id = buttonContainerId;
+    vi.spyOn(document, "querySelector").mockReturnValueOnce(buttonContainer);
+
+    applyContainerStyles(params);
+
+    expect(buttonContainer?.style.length).toBeTruthy();
+  });
+
+  test("throws error if button container cannot be found", () => {
+    const shouldThrowError = () => applyContainerStyles(params);
+    expect(shouldThrowError).toThrowError(
+      `Button container with id ${buttonContainerId} not found.`
+    );
   });
 });
 

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -110,6 +110,7 @@ describe("getHostedButtonDetails", () => {
             button_preferences: ["paypal", "paylater"],
             eligible_funding_methods: ["paypal", "venmo", "paylater"],
           },
+          js_sdk_container_id: "spb-container",
         },
         version: "2",
       },

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -571,7 +571,7 @@ test("getButtonColor", () => {
 });
 
 test("getElementFromSelector", () => {
-  const containerId = "#container-id";
+  const containerId = "container-id";
   const selector = document.createElement("div");
 
   selector.setAttribute("id", containerId.slice(1));
@@ -682,7 +682,8 @@ describe("applyContainerStyles", () => {
 });
 
 describe("renderStandaloneButton", () => {
-  const containerId = "#container-id";
+  const containerId = "container-id";
+  const expectedContainerId = `#${containerId}`;
   const renderMock = vi.fn();
   const errorMock = vi.fn();
   const baseParams = {
@@ -729,7 +730,7 @@ describe("renderStandaloneButton", () => {
     });
 
     expect(renderMock).toHaveBeenCalledTimes(1);
-    expect(renderMock).toHaveBeenCalledWith(containerId);
+    expect(renderMock).toHaveBeenCalledWith(expectedContainerId);
     expect(Buttons).toHaveBeenCalledWith(
       expect.objectContaining({
         fundingSource: "paypal",
@@ -779,7 +780,7 @@ describe("renderStandaloneButton", () => {
     });
 
     expect(renderMock).toHaveBeenCalledTimes(1);
-    expect(renderMock).toHaveBeenCalledWith(containerId);
+    expect(renderMock).toHaveBeenCalledWith(expectedContainerId);
     expect(Buttons).toHaveBeenCalledWith(
       expect.objectContaining({
         fundingSource: "venmo",
@@ -819,7 +820,7 @@ describe("renderStandaloneButton", () => {
       })
     );
     expect(renderMock).toHaveBeenCalledTimes(1);
-    expect(renderMock).toHaveBeenCalledWith(containerId);
+    expect(renderMock).toHaveBeenCalledWith(expectedContainerId);
   });
 
   test("does not render any button if fundingSource is 'default' and there are no eligible buttons", () => {

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -33,7 +33,9 @@ vi.mock("@paypal/sdk-client/src", async () => {
     getSDKHost: () => "example.com",
     getClientID: () => "client_id_123",
     getMerchantID: () => ["merchant_id_123"],
-    getLogger: vi.fn(),
+    getLogger: vi.fn(() => ({
+      error: vi.fn(),
+    })),
   };
 });
 
@@ -674,9 +676,10 @@ describe("applyContainerStyles", () => {
   });
 
   test("throws error if button container cannot be found", () => {
+    // Intentionally not setting up the button container to throw the error
     const shouldThrowError = () => applyContainerStyles(params);
     expect(shouldThrowError).toThrowError(
-      `Button container with id ${buttonContainerId} not found.`
+      `Element with id ${buttonContainerId} not found.`
     );
   });
 });

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -10,8 +10,6 @@ import {
   getHostedButtonDetails,
   getFlexDirection,
   getButtonColor,
-  shouldRenderSDKButtons,
-  appendButtonContainer,
   getElementFromSelector,
 } from "./utils";
 
@@ -554,36 +552,6 @@ test("getButtonColor", () => {
       );
     });
   });
-});
-
-test("shouldRenderSDKButtons", () => {
-  expect(shouldRenderSDKButtons([])).toBe(false);
-  expect(shouldRenderSDKButtons(["paypal"])).toBe(true);
-  expect(shouldRenderSDKButtons(["paypal", "venmo"])).toBe(true);
-});
-
-test("buildButtonContainer", () => {
-  const containerId = "#container-id";
-  const selector = document.createElement("div");
-
-  selector.setAttribute("id", containerId.slice(1));
-
-  vi.spyOn(document, "querySelector").mockReturnValueOnce(selector);
-
-  expect(() =>
-    appendButtonContainer({ flexDirection: "row", selector: containerId })
-  ).not.toThrow();
-
-  expect(() =>
-    appendButtonContainer({ flexDirection: "row", selector })
-  ).not.toThrow();
-
-  expect(() =>
-    appendButtonContainer({
-      flexDirection: "row",
-      selector: `${containerId}-not-found`,
-    })
-  ).toThrow("PayPal button container selector was not found");
 });
 
 test("getElementFromSelector", () => {

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -621,6 +621,17 @@ describe("getButtonPreferences", () => {
       "paylater",
     ]);
   });
+
+  test("doesn't filter out 'default' in button preferences", () => {
+    const params = {
+      button_preferences: ["paypal", "default"],
+      eligible_funding_methods: ["paylater", "venmo", "paypal"],
+    };
+
+    const preferences = getButtonPreferences(params);
+
+    expect(preferences.buttonPreferences).toEqual(["paypal", "default"]);
+  });
 });
 
 describe("getDefaultButton", () => {

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -638,6 +638,8 @@ describe("getButtonPreferences", () => {
 
   test("logs & throws error if the input is bad", () => {
     const errorMock = vi.fn();
+
+    // $FlowIssue
     getLogger.mockImplementation(() => ({ error: errorMock }));
 
     const params = {


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->
> [!NOTE]  
> Very sorry this PR became a bit larger than originally expected.  I'll try to leave some comments around to point out some of the main parts.

- 🤝 _**Support for NCP form fields API v2**_ - Support for v2 without losing support for v1.
- 📝 _**Extensive testing**_ - Added / adjusted a ton of unit tests to account for the new API.
-  🙅‍♂️ _**Removal for .setAttribute()**_ - We had merchants concerned with `.setAttribute()` as it violates some CSP's.  
- 🦆 _**Updated some syntax in utils.js to make it slightly more consistent **_ - I noticed sometimes we were using `function name() {}` and sometimes we were using `const name = () => {}`... TBH, I'd rather use `function`, but it seems like we use `const` more, so I went with that. Would love some opinions here 😄 

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
**JIRA:** [DTPPCPSDK-2228](https://paypal.atlassian.net/browse/DTPPCPSDK-2228) & [DTPPCPSDK-2229](https://paypal.atlassian.net/browse/DTPPCPSDK-2229)

### Reproduction Steps (if applicable)
<details><summary>Setup</summary>
<ul>
<li>Pull this branch to local</li>
<li>In clientsdknodeweb's package.json, under `proxy`, change `/ncp` to `"https://www.te-ncp-js-sdk.qa.paypal.com"` (this will give you the v2 NCP Form Fields API)</li>
<li>Run CSNW & SCNW using `npm run debug`. </li>
</ul>
</details> 

<details><summary>Creating a local no-code integration</summary>
<li>Navigate to https://www.msmaster.qa.paypal.com/buttons/smart</li>
<li>Sign in using an msmaster developer account</li>
<li>Build any integration you'd like and copy the code</li>
<li>Add that code to an html file and launch it in your browser.</li>
</details> 

### Screenshots (if applicable)
> [!Important]  
> The styles are a bit off in these screenshots since the NCP team has not included finalized styles in their API response.  So ignore the lack of margin between our buttons & their "checkout" button. 😄

#### Click through to see the different cases:
<details><summary>Prefers only PayPal button</summary>
<pre>
preferences: {  
    button_preferences: [ "paypal" ], 
    eligible_funding_methods: ["paypal",  "paylater" ]
}
</pre>
<img width="661" alt="image" src="https://github.com/paypal/paypal-checkout-components/assets/60204385/4529997b-744d-4cf1-9d5b-7c1ce76b4acc">
</details> 

<details><summary>Prefers PayPal & Venmo, both are eligible.</summary>
<pre>
preferences: {  
    button_preferences: [ "paypal", "venmo" ], 
    eligible_funding_methods: ["paypal", "venmo", "paylater" ]
}
</pre>
<img width="661" alt="image" src="https://github.com/paypal/paypal-checkout-components/assets/60204385/7f556922-07fe-418f-adaf-ee9c49a4c2d1">
</details> 

<details><summary>Prefers PayPal & PayLater, both are eligible.</summary>
<pre>
preferences: {  
    button_preferences: [ "paypal", "paylater" ], 
    eligible_funding_methods: ["paypal", "venmo", "paylater" ]
}
</pre>
<img width="661" alt="image" src="https://github.com/paypal/paypal-checkout-components/assets/60204385/0a9cfd80-a5d9-40d0-aa4d-0c1470378f48">
</details> 

<details><summary>Prefers PayPal & Venmo, Venmo not eligible. (Shows only PayPal)</summary>
<pre>
preferences: {  
    button_preferences: [ "paypal", "venmo" ], 
    eligible_funding_methods: ["paypal",  "paylater" ]
}
</pre>
<img width="661" alt="image" src="https://github.com/paypal/paypal-checkout-components/assets/60204385/4529997b-744d-4cf1-9d5b-7c1ce76b4acc">
</details> 

<details><summary>Prefers PayPal & default second button.</summary>
<pre>
preferences: {  
    button_preferences: [ "paypal", "venmo" ], 
    eligible_funding_methods: ["paypal",  "venmo", "paylater" ]
}
</pre>
<img width="661" alt="image" src="https://github.com/paypal/paypal-checkout-components/assets/60204385/7f556922-07fe-418f-adaf-ee9c49a4c2d1">
</details> 

<details><summary>Prefers PayPal & default second button, but all second buttons fail <code>Buttons().isEligible()</code> check. (Shows only PayPal)</summary>
<pre>
preferences: {  
    button_preferences: [ "paypal", "default" ], 
    eligible_funding_methods: ["paypal",  "paylater" ]
}
... 

Buttons({ fundingSource: "paylater" }).isEligible() -> false 😱</pre>
<img width="661" alt="image" src="https://github.com/paypal/paypal-checkout-components/assets/60204385/4529997b-744d-4cf1-9d5b-7c1ce76b4acc">
</details> 

<details><summary>Horizontal layout example (S/O @nikrom17 )</summary>
<pre>
preferences: {  
    button_preferences: [ "paypal", "venmo" ], 
    eligible_funding_methods: ["paypal",  "venmo", "paylater" ]
}
</pre>
<img width="661" alt="image" src="https://github.com/paypal/paypal-checkout-components/assets/60204385/2f935a2d-ac00-4a16-8a01-98d4ff71e28a">
</details> 


❤️ Thank you!
