### PR TITLE
Add disableDefaultStyle prop for Card Fields

### DIFF
--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -127,7 +127,14 @@ type CardFieldsChildren = {|
 const url = () =>
   `${getPayPalDomain()}${__PAYPAL_CHECKOUT__.__URI__.__CARD_FIELD__}`;
 
+const DEFAULT_HEIGHT = "78px";
+
 const prerenderTemplate = ({ props, doc }) => {
+  if (props.parent.props.disableDefaultStyle) {
+    props.style.height = "100%";
+    console.log("it's true, baby!");
+  }
+  console.log("mervin", props);
   return (
     <CardPrerender nonce={props.nonce} height={props.style?.height} />
   ).render(dom({ doc }));
@@ -147,7 +154,7 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
         url,
 
         dimensions: {
-          height: "30px",
+          height: DEFAULT_HEIGHT,
           width: "100%",
         },
 
@@ -158,7 +165,7 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
         },
 
         autoResize: {
-          height: true,
+          height: false,
           width: false,
         },
 
@@ -420,7 +427,7 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
       url,
 
       dimensions: {
-        height: "30px",
+        height: "100%",
         width: "100%",
       },
 
@@ -431,7 +438,7 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
       },
 
       autoResize: {
-        height: true,
+        height: false,
         width: false,
       },
 
@@ -587,6 +594,12 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
           queryParam: true,
         },
 
+        disableDefaultStyle: {
+          type: "boolean",
+          required: true,
+          queryParam: true,
+        },
+
         onChange: {
           type: "function",
           required: false,
@@ -685,3 +698,5 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
     return CardFields;
   }
 );
+// window.paypal.cardFields(someObject)
+// Zoid is passing someObject into the props object

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -124,7 +124,7 @@ type CardFieldsChildren = {|
   NameField: CardFieldComponent,
 |};
 
-function isDefaultStyleDisabled(props) {
+function isDefaultStyleDisabled(props): boolean {
   return Boolean(props?.parent?.props?.disableDefaultStyle);
 }
 

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -127,14 +127,10 @@ type CardFieldsChildren = {|
 const url = () =>
   `${getPayPalDomain()}${__PAYPAL_CHECKOUT__.__URI__.__CARD_FIELD__}`;
 
-const DEFAULT_HEIGHT = "78px";
-
 const prerenderTemplate = ({ props, doc }) => {
   if (props.parent.props.disableDefaultStyle) {
-    props.style.height = "100%";
-    console.log("it's true, baby!");
+    props.style.height = "100vh";
   }
-  console.log("mervin", props);
   return (
     <CardPrerender nonce={props.nonce} height={props.style?.height} />
   ).render(dom({ doc }));
@@ -149,12 +145,27 @@ export type CardFieldsComponent = ZoidComponent<
 export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
   (): CardFieldsComponent => {
     const genericCardField = (type) => {
+      console.log("mervin: inside checkout-comp, xprops", window.xprops);
+
+      let DEFAULT_AUTORESIZE = {
+        height: true,
+        width: false,
+      };
+
+      // if (window.xprops?.parent.props.disableDefaultStyle) {
+      //   console.log("mervin - inside conditional");
+      //   DEFAULT_AUTORESIZE = {
+      //     height: false,
+      //     width: false,
+      //   };
+      // }
+
       return create({
         tag: `paypal-card-${type}-field`,
         url,
 
         dimensions: {
-          height: DEFAULT_HEIGHT,
+          height: "100%",
           width: "100%",
         },
 
@@ -164,10 +175,7 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
           },
         },
 
-        autoResize: {
-          height: false,
-          width: false,
-        },
+        autoResize: DEFAULT_AUTORESIZE,
 
         prerenderTemplate,
 
@@ -596,7 +604,7 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
 
         disableDefaultStyle: {
           type: "boolean",
-          required: true,
+          required: false,
           queryParam: true,
         },
 

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -153,8 +153,6 @@ export type CardFieldsComponent = ZoidComponent<
 export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
   (): CardFieldsComponent => {
     const genericCardField = (type) => {
-      console.log("mervin: inside checkout-comp, xprops", window.xprops);
-
       return create({
         tag: `paypal-card-${type}-field`,
         url,

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -148,7 +148,7 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
       console.log("mervin: inside checkout-comp, xprops", window.xprops);
 
       let DEFAULT_AUTORESIZE = {
-        height: true,
+        height: false,
         width: false,
       };
 

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -49,7 +49,7 @@ const CARD_FIELD_TYPE = {
 type CardFieldsProps = {|
   clientID: string,
   style?: {|
-    height: number,
+    height: number | string,
   |},
   env?: string,
   locale?: string,
@@ -102,7 +102,10 @@ type CardFieldProps = {|
   ...CardFieldsProps,
 
   parent: {|
-    props: CardFieldsProps,
+    props: {|
+      ...CardFieldsProps,
+      disableDefaultStyle?: boolean,
+    |},
   |},
 |};
 
@@ -125,6 +128,7 @@ type CardFieldsChildren = {|
 |};
 
 function isDefaultStyleDisabled(props): boolean {
+  // $FlowFixMe
   return Boolean(props?.parent?.props?.disableDefaultStyle);
 }
 
@@ -133,6 +137,11 @@ const url = () =>
 
 const prerenderTemplate = ({ props, doc }) => {
   if (isDefaultStyleDisabled(props)) {
+    if (props.style === undefined) {
+      props.style = {
+        height: "",
+      };
+    }
     props.style.height = "100vh";
   }
   return (

--- a/src/zoid/card-fields/prerender.jsx
+++ b/src/zoid/card-fields/prerender.jsx
@@ -14,53 +14,93 @@ export function CardPrerender({
   nonce,
   height,
 }: PrerenderedCardProps): ChildType {
+  const newCssString = `
+html, body {
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+body {
+    background: #e9ebee;
+    position: absolute;
+    overflow: hidden;
+    height: ${height ?? DEFAULT_HEIGHT};
+}
+
+body::after {
+    content: "";
+    display: block;
+    background-color: #fff;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    height: ${height ?? DEFAULT_HEIGHT};
+    transform: translateX(0);
+    box-shadow: 0px 0px 107px 60px #dddfe2;
+    animation: 1.5s loading-placeholder ease-in-out infinite;
+}
+
+@keyframes loading-placeholder {
+    0% {
+        opacity: 0.1;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0.1;
+    }
+}
+`;
+
+  const defaultCssString = `
+html, body {
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+body {
+    background: #e9ebee;
+    position: relative;
+    overflow: hidden;
+    height: ${height ?? DEFAULT_HEIGHT};
+}
+
+body::after {
+    content: "";
+    display: block;
+    background-color: #fff;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    height: ${height ?? DEFAULT_HEIGHT};
+    transform: translateX(0);
+    box-shadow: 0px 0px 107px 60px #dddfe2;
+    animation: 1.5s loading-placeholder ease-in-out infinite;
+}
+
+@keyframes loading-placeholder {
+    0% {
+        opacity: 0.1;
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0.1;
+    }
+}
+`;
   return (
     <html>
       <body>
-        <style
-          nonce={nonce}
-          innerHTML={`
-                        html, body {
-                            padding: 0;
-                            margin: 0;
-                            width: 100%;
-                            height: 100%;
-                        }
-
-                        body {
-                            background: #e9ebee;
-                            position: relative;
-                            overflow: hidden;
-                            height: ${height ?? DEFAULT_HEIGHT};
-                        }
-
-                        body::after {
-                            content: "";
-                            display: block;
-                            background-color: #fff;
-                            position: absolute;
-                            top: 0;
-                            bottom: 0;
-                            width: 100%;
-                            height: ${height ?? DEFAULT_HEIGHT};
-                            transform: translateX(0);
-                            box-shadow: 0px 0px 107px 60px #dddfe2;
-                            animation: 1.5s loading-placeholder ease-in-out infinite;
-                        }
-
-                        @keyframes loading-placeholder {
-                            0% {
-                                opacity: 0.1;
-                            }
-                            50% {
-                                opacity: 1;
-                            }
-                            100% {
-                                opacity: 0.1;
-                            }
-                        }
-                    `}
-        />
+        <style nonce={nonce} innerHTML={``} />
       </body>
     </html>
   );

--- a/src/zoid/card-fields/prerender.jsx
+++ b/src/zoid/card-fields/prerender.jsx
@@ -24,45 +24,45 @@ export function CardPrerender({
             disableDefaultStyle
               ? ""
               : `
-html, body {
-    padding: 0;
-    margin: 0;
-    width: 100%;
-    height: 100%;
-}
+                  html, body {
+                      padding: 0;
+                      margin: 0;
+                      width: 100%;
+                      height: 100%;
+                  }
 
-body {
-    background: #e9ebee;
-    position: relative;
-    overflow: hidden;
-    height: ${height ?? DEFAULT_HEIGHT};
-}
+                  body {
+                      background: #e9ebee;
+                      position: relative;
+                      overflow: hidden;
+                      height: ${height ?? DEFAULT_HEIGHT};
+                  }
 
-body::after {
-    content: "";
-    display: block;
-    background-color: #fff;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 100%;
-    height: ${height ?? DEFAULT_HEIGHT};
-    transform: translateX(0);
-    box-shadow: 0px 0px 107px 60px #dddfe2;
-    animation: 1.5s loading-placeholder ease-in-out infinite;
-}
+                  body::after {
+                      content: "";
+                      display: block;
+                      background-color: #fff;
+                      position: absolute;
+                      top: 0;
+                      bottom: 0;
+                      width: 100%;
+                      height: ${height ?? DEFAULT_HEIGHT};
+                      transform: translateX(0);
+                      box-shadow: 0px 0px 107px 60px #dddfe2;
+                      animation: 1.5s loading-placeholder ease-in-out infinite;
+                  }
 
-@keyframes loading-placeholder {
-    0% {
-        opacity: 0.1;
-    }
-    50% {
-        opacity: 1;
-    }
-    100% {
-        opacity: 0.1;
-    }
-}
+                  @keyframes loading-placeholder {
+                      0% {
+                          opacity: 0.1;
+                      }
+                      50% {
+                          opacity: 1;
+                      }
+                      100% {
+                          opacity: 0.1;
+                      }
+                  }
 `
           }
         />

--- a/src/zoid/card-fields/prerender.jsx
+++ b/src/zoid/card-fields/prerender.jsx
@@ -6,6 +6,7 @@ import { node, type ChildType } from "@krakenjs/jsx-pragmatic/src";
 type PrerenderedCardProps = {|
   nonce: ?string,
   height: ?number | ?string,
+  disableDefaultStyle?: boolean,
 |};
 
 export const DEFAULT_HEIGHT = 78;

--- a/src/zoid/card-fields/prerender.jsx
+++ b/src/zoid/card-fields/prerender.jsx
@@ -5,7 +5,7 @@ import { node, type ChildType } from "@krakenjs/jsx-pragmatic/src";
 
 type PrerenderedCardProps = {|
   nonce: ?string,
-  height: ?number,
+  height: ?number | ?string,
 |};
 
 const DEFAULT_HEIGHT = 78;

--- a/src/zoid/card-fields/prerender.jsx
+++ b/src/zoid/card-fields/prerender.jsx
@@ -8,55 +8,22 @@ type PrerenderedCardProps = {|
   height: ?number | ?string,
 |};
 
-const DEFAULT_HEIGHT = 78;
+export const DEFAULT_HEIGHT = 78;
 
 export function CardPrerender({
   nonce,
   height,
+  disableDefaultStyle,
 }: PrerenderedCardProps): ChildType {
-  const newCssString = `
-html, body {
-    padding: 0;
-    margin: 0;
-    width: 100%;
-    height: 100%;
-}
-
-body {
-    background: #e9ebee;
-    position: absolute;
-    overflow: hidden;
-    height: ${height ?? DEFAULT_HEIGHT};
-}
-
-body::after {
-    content: "";
-    display: block;
-    background-color: #fff;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 100%;
-    height: ${height ?? DEFAULT_HEIGHT};
-    transform: translateX(0);
-    box-shadow: 0px 0px 107px 60px #dddfe2;
-    animation: 1.5s loading-placeholder ease-in-out infinite;
-}
-
-@keyframes loading-placeholder {
-    0% {
-        opacity: 0.1;
-    }
-    50% {
-        opacity: 1;
-    }
-    100% {
-        opacity: 0.1;
-    }
-}
-`;
-
-  const defaultCssString = `
+  return (
+    <html>
+      <body>
+        <style
+          nonce={nonce}
+          innerHTML={
+            disableDefaultStyle
+              ? ""
+              : `
 html, body {
     padding: 0;
     margin: 0;
@@ -96,11 +63,9 @@ body::after {
         opacity: 0.1;
     }
 }
-`;
-  return (
-    <html>
-      <body>
-        <style nonce={nonce} innerHTML={``} />
+`
+          }
+        />
       </body>
     </html>
   );


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

Currently, the Card Fields are constrained by the allowed styling props and does not allow a height to be passed. Adding this prop will pass the flag to the Card Fields component in `scnw`, modify the prerender template to fit the merchant's parent container, and conditionally change the dimensions passed to the zoid component. 

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

We are making these changes to facilitate more custom styling of the Card Fields. 

Jira Ticket - DTPPCPSDK-2203

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

*Default styling*
![image](https://github.com/paypal/paypal-checkout-components/assets/38122192/6c0939e9-2c8c-4e6b-97fb-8d5f55bf110a)

*Disabled Default Styling*
![image](https://github.com/paypal/paypal-checkout-components/assets/38122192/1cc15854-bd97-4c76-8b6e-f09e527433c7)

![image](https://github.com/paypal/paypal-checkout-components/assets/38122192/cc30e7b3-5a52-4bff-b582-ab289787e382)



### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

`scnw` PR - #682

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
