### PR TITLE
do not validate token usage in shopper insights

### DIFF
--- a/src/shopper-insights/interface.js
+++ b/src/shopper-insights/interface.js
@@ -1,8 +1,6 @@
 /* @flow */
 import {
-  getUserIDToken,
   getPageType,
-  getClientToken,
   getSDKToken,
   getLogger,
   getPayPalAPIDomain,
@@ -46,8 +44,6 @@ export const ShopperInsights: LazyExport<ShopperInsightsInterface> = {
       sdkConfig: {
         sdkToken: getSDKToken(),
         pageType: getPageType(),
-        userIDToken: getUserIDToken(),
-        clientToken: getClientToken(),
         paypalApiDomain: getPayPalAPIDomain(),
         environment: getEnv(),
         buyerCountry: getBuyerCountry() || "US",

--- a/src/shopper-insights/shopperSession.js
+++ b/src/shopper-insights/shopperSession.js
@@ -60,8 +60,6 @@ type RecommendedPaymentMethodsResponse = {|
 type SdkConfig = {|
   sdkToken: ?string,
   pageType: ?string,
-  userIDToken: ?string,
-  clientToken: ?string,
   paypalApiDomain: string,
   environment: ?string,
   buyerCountry: string,
@@ -212,29 +210,6 @@ const parseSdkConfig = ({
     throw new ValidationError(
       `script data attribute page-type is required but was not passed`
     );
-  }
-
-  if (sdkConfig.userIDToken) {
-    logger.metricCounter({
-      namespace: shopperInsightsMetricNamespace,
-      event: "error",
-      dimensions: {
-        errorType: "merchant_configuration_validation_error",
-        validationDetails: "sdk_token_and_id_token_present",
-      },
-    });
-
-    throw new ValidationError(
-      `use script data attribute sdk-client-token instead of user-id-token`
-    );
-  }
-
-  // Client token has widely adopted integrations in the SDK that we do not want
-  // to support anymore. For now, we will be only enforcing a warning. We should
-  // expand on this warning with upgrade guides when we have them.
-  if (sdkConfig.clientToken) {
-    // eslint-disable-next-line no-console
-    console.warn(`script data attribute client-token is not recommended`);
   }
 
   return sdkConfig;

--- a/src/shopper-insights/shopperSession.test.js
+++ b/src/shopper-insights/shopperSession.test.js
@@ -32,8 +32,6 @@ const mockFindEligiblePaymentsRequest = (
 const defaultSdkConfig = {
   sdkToken: "sdk client token",
   pageType: "checkout",
-  clientToken: "",
-  userIDToken: "",
   paypalApiDomain: "https://api.paypal.com",
   environment: "test",
   buyerCountry: "US",
@@ -68,13 +66,14 @@ afterEach(() => {
 describe("shopper insights component - isEligibleInPaypalNetwork()", () => {
   test("should get is member using the shopper insights API", async () => {
     const shopperSession = createShopperSession();
-    const recommendedPaymentMethods = await shopperSession.isEligibleInPaypalNetwork({
-      email: "email@test.com",
-      phone: {
-        countryCode: "1",
-        nationalNumber: "2345678901",
-      },
-    });
+    const recommendedPaymentMethods =
+      await shopperSession.isEligibleInPaypalNetwork({
+        email: "email@test.com",
+        phone: {
+          countryCode: "1",
+          nationalNumber: "2345678901",
+        },
+      });
 
     expect.assertions(1);
     expect(recommendedPaymentMethods).toEqual(true);
@@ -95,13 +94,14 @@ describe("shopper insights component - isEligibleInPaypalNetwork()", () => {
         }),
     });
 
-    const recommendedPaymentMethods = await shopperSession.isEligibleInPaypalNetwork({
-      email: "email@test.com",
-      phone: {
-        countryCode: "1",
-        nationalNumber: "2345678901",
-      },
-    });
+    const recommendedPaymentMethods =
+      await shopperSession.isEligibleInPaypalNetwork({
+        email: "email@test.com",
+        phone: {
+          countryCode: "1",
+          nationalNumber: "2345678901",
+        },
+      });
 
     expect.assertions(1);
     expect(recommendedPaymentMethods).toEqual(true);
@@ -122,13 +122,14 @@ describe("shopper insights component - isEligibleInPaypalNetwork()", () => {
         }),
     });
 
-    const recommendedPaymentMethods = await shopperSession.isEligibleInPaypalNetwork({
-      email: "email@test.com",
-      phone: {
-        countryCode: "1",
-        nationalNumber: "2345678901",
-      },
-    });
+    const recommendedPaymentMethods =
+      await shopperSession.isEligibleInPaypalNetwork({
+        email: "email@test.com",
+        phone: {
+          countryCode: "1",
+          nationalNumber: "2345678901",
+        },
+      });
 
     expect.assertions(1);
     expect(recommendedPaymentMethods).toEqual(false);
@@ -142,13 +143,14 @@ describe("shopper insights component - isEligibleInPaypalNetwork()", () => {
         }),
     });
 
-    const recommendedPaymentMethods = await shopperSession.isEligibleInPaypalNetwork({
-      email: "email@test.com",
-      phone: {
-        countryCode: "1",
-        nationalNumber: "2345678901",
-      },
-    });
+    const recommendedPaymentMethods =
+      await shopperSession.isEligibleInPaypalNetwork({
+        email: "email@test.com",
+        phone: {
+          countryCode: "1",
+          nationalNumber: "2345678901",
+        },
+      });
 
     expect.assertions(1);
     expect(recommendedPaymentMethods).toEqual(false);
@@ -424,8 +426,6 @@ describe("shopper insights component - validateSdkConfig()", () => {
           ...defaultSdkConfig,
           sdkToken: "",
           pageType: "",
-          userIDToken: "",
-          clientToken: "",
         },
       })
     ).toThrowError(
@@ -440,28 +440,10 @@ describe("shopper insights component - validateSdkConfig()", () => {
           ...defaultSdkConfig,
           sdkToken: "sdk-token",
           pageType: "",
-          userIDToken: "",
-          clientToken: "",
         },
       })
     ).toThrowError(
       "script data attribute page-type is required but was not passed"
-    );
-  });
-
-  test("should throw if ID token is passed", () => {
-    expect(() =>
-      createShopperSession({
-        sdkConfig: {
-          ...defaultSdkConfig,
-          sdkToken: "sdk-token",
-          pageType: "product-listing",
-          userIDToken: "id-token",
-          clientToken: "",
-        },
-      })
-    ).toThrowError(
-      "use script data attribute sdk-client-token instead of user-id-token"
     );
   });
 });


### PR DESCRIPTION
We will validate tokens passed to the SDK in `@paypal/sdk-client`. Features like ShopperInsights should not care about what tokens are passed, it should only validate that it received the token it expects.