### PR TITLE
Get DPoP flag from NCP form fields API 👾

### DIFF
--- a/src/hosted-buttons/index.js
+++ b/src/hosted-buttons/index.js
@@ -22,7 +22,6 @@ import type {
 
 export const getHostedButtonsComponent = (): HostedButtonsComponent => {
   function HostedButtons({
-    enableDPoP = false,
     hostedButtonId,
   }: HostedButtonsComponentProps): HostedButtonsInstance {
     const Buttons = getButtonsComponent();
@@ -35,6 +34,7 @@ export const getHostedButtonsComponent = (): HostedButtonsComponent => {
         version,
         preferences,
         buttonContainerId,
+        enableDPoP,
       } = await getHostedButtonDetails({
         hostedButtonId,
       });

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -110,6 +110,7 @@ export type HostedButtonDetailsParams =
     version: ?string,
     buttonContainerId: string,
     preferences?: HostedButtonPreferences,
+    enableDPoP: boolean,
   |}>;
 
 export type ButtonVariables = $ReadOnlyArray<{|

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -154,6 +154,7 @@ export const getHostedButtonDetails: HostedButtonDetailsParams = async ({
       tagline: getButtonVariable(variables, "tagline") === "true",
       height: parseInt(getButtonVariable(variables, "height"), 10) || undefined,
     },
+    enableDPoP: getButtonVariable(variables, "enable_dpop") === "true",
     version: body.version,
     buttonContainerId: buttonContainerId || "spb-container",
     html: body.html,

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -107,6 +107,10 @@ describe("getHostedButtonDetails", () => {
               name: "tagline",
               value: "true",
             },
+            {
+              name: "enable_dpop",
+              value: "true",
+            },
           ],
           preferences: {
             button_preferences: ["paypal", "paylater"],
@@ -149,7 +153,7 @@ describe("getHostedButtonDetails", () => {
     await getHostedButtonDetails({
       hostedButtonId,
       fundingSources: [],
-    }).then(({ style, preferences, version }) => {
+    }).then(({ style, preferences, version, enableDPoP }) => {
       expect(style.height).toEqual(50);
       expect(style.tagline).toEqual(true);
       expect(preferences).toEqual({
@@ -157,8 +161,9 @@ describe("getHostedButtonDetails", () => {
         eligibleFundingMethods: ["paypal", "venmo", "paylater"],
       });
       expect(version).toEqual("2");
+      expect(enableDPoP).toEqual(true);
     });
-    expect.assertions(4);
+    expect.assertions(5);
   });
 
   test("handles false tagline values", async () => {


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->
**JIRA:** [DTPPCPSDK-2153](https://paypal.atlassian.net/browse/DTPPCPSDK-2153)

- _**🌽 Get enableDPoP from NCP form fields API**_ - Before, we were passing it into the HostedButtons component, but now we will get it straight from NCP's API.

### Screenshots (if applicable)
![image](https://github.com/paypal/paypal-checkout-components/assets/60204385/9bc356d7-c2d8-4d5b-8a37-2d0f6a50516a)
![image](https://github.com/paypal/paypal-checkout-components/assets/60204385/28635683-f038-4707-a9bb-87f01f83362a)

❤️ Thank you!
