### PR TITLE
feat: updates message position logic to allow a bottom selection with 'Powered By'

### DIFF
--- a/src/ui/buttons/util.js
+++ b/src/ui/buttons/util.js
@@ -2,7 +2,6 @@
 import { FUNDING } from "@paypal/sdk-constants/src";
 
 import { BUTTON_LAYOUT, MESSAGE_POSITION } from "../../constants";
-import { ValidationError } from "../../lib";
 
 export function isBorderRadiusNumber(borderRadius?: number): boolean {
   return typeof borderRadius === "number";
@@ -25,8 +24,9 @@ export function calculateMessagePosition(
   const showPoweredBy = calculateShowPoweredBy(layout, fundingSources);
 
   if (showPoweredBy && position === MESSAGE_POSITION.BOTTOM) {
-    throw new ValidationError(
-      "Message position must be 'top' when Debit and/or Credit Card button is present"
+    // eslint-disable-next-line no-console
+    console.warn(
+      "PayPal Button Message cannot be positioned at bottom when displaying the Debit or Credit Card button."
     );
   }
 

--- a/test/integration/tests/button/message.js
+++ b/test/integration/tests/button/message.js
@@ -386,6 +386,35 @@ describe(`paypal button message`, () => {
           })
           .render("#testContainer");
       });
+      it("should place message on top when position is bottom and credit/debit IS a funding source", (done) => {
+        window.paypal
+          .Buttons({
+            style: {
+              layout: "vertical",
+            },
+            message: {
+              position: "bottom",
+            },
+            fundingEligibility: {
+              credit: {
+                eligible: true,
+              },
+              paypal: {
+                eligible: true,
+              },
+              card: {
+                eligible: true,
+              },
+            },
+            test: {
+              onRender() {
+                assert.ok(getElementRecursive(".paypal-button-message-top"));
+                done();
+              },
+            },
+          })
+          .render("#testContainer");
+      });
     });
     describe("standalone layout", () => {
       it("should place message on bottom by default", (done) => {

--- a/test/integration/tests/button/validation.js
+++ b/test/integration/tests/button/validation.js
@@ -1009,10 +1009,10 @@ const buttonConfigs = [
           amount: 100,
           offer: ["pay_later_long_term"],
           color: "black",
-          position: "bottom", // Message position must be 'top' when Debit and/or Credit Card button is present
+          position: "bottom", // Used to be invalid, now just throws a console.warn
           align: "left",
         },
-        valid: false,
+        valid: true,
       },
 
       {


### PR DESCRIPTION
Changes message placement logic to allow a bottom selection (then overwrites it with top) for vertical button stack.

### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
