### PR TITLE
Button autoResize by button container

### DIFF
--- a/src/constants/class.js
+++ b/src/constants/class.js
@@ -2,6 +2,8 @@
 
 export const CLASS = {
   CONTAINER: ("paypal-button-container": "paypal-button-container"),
+  AUTORESIZE_CONTAINER:
+    ("paypal-autoresize-container": "paypal-autoresize-container"),
   BUTTON_ROW: ("paypal-button-row": "paypal-button-row"),
   BUTTON: ("paypal-button": "paypal-button"),
   BUTTON_LABEL:

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -259,6 +259,7 @@ export function Buttons(props: ButtonsProps): ElementNode {
     <div
       class={[
         CLASS.CONTAINER,
+        CLASS.AUTORESIZE_CONTAINER,
         `${CLASS.LAYOUT}-${layout}`,
         `${CLASS.SHAPE}-${shape}`,
         `${CLASS.NUMBER}-${

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -80,6 +80,7 @@ import {
   type ButtonProps,
 } from "../../ui/buttons/props";
 import { isFundingEligible } from "../../funding";
+import { CLASS } from "../../constants";
 
 import { containerTemplate } from "./container";
 import { PrerenderedButtons } from "./prerender";
@@ -107,7 +108,7 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
     autoResize: {
       width: false,
       height: true,
-      element: ".paypal-autoresize-container",
+      element: `.${CLASS.AUTORESIZE_CONTAINER}`,
     },
 
     containerTemplate,

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -107,6 +107,7 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
     autoResize: {
       width: false,
       height: true,
+      element: ".paypal-autoresize-container",
     },
 
     containerTemplate,

--- a/test/integration/tests/button/size.js
+++ b/test/integration/tests/button/size.js
@@ -810,6 +810,75 @@ describe(`paypal button component sizes`, () => {
       .render(container);
   });
 
+  it("should render a responsive button and resize the zoid container when the button resizes", (done) => {
+    done = once(done);
+
+    const container = createElement(
+      "div",
+      {
+        style: {
+          width: "162px",
+          height: "100px",
+        },
+      },
+      getElement("#testContainer")
+    );
+
+    const expectedWidth = 255;
+    const expectedHeight = 35;
+
+    window.paypal
+      .Buttons({
+        test: {},
+
+        style: {
+          layout: "horizontal",
+          label: "pay",
+          tagline: false,
+        },
+
+        createOrder() {
+          done(new Error("Expected createOrder() to not be called"));
+        },
+
+        onApprove() {
+          done(new Error("Expected onApprove() to not be called"));
+        },
+
+        onRendered() {
+          const frame = getElement("#testContainer iframe");
+
+          onElementResize(frame, {})
+            .then(() => {
+              const height = frame.offsetHeight;
+
+              if (height === 42) {
+                return onElementResize(frame, {
+                  height: expectedHeight,
+                  width: expectedWidth,
+                });
+              }
+            })
+            .then(() => {
+              const zoidContainer = container.querySelector(
+                ".paypal-buttons-context-iframe"
+              );
+              if (parseInt(zoidContainer.style.height, 10) !== expectedHeight) {
+                done(
+                  new Error(
+                    `Expected zoid container height to be ${expectedHeight}. Received: ${zoidContainer.style.height}`
+                  )
+                );
+              }
+            })
+            .then(done, done);
+
+          container.style.width = "255px";
+        },
+      })
+      .render(container);
+  });
+
   it("should render a responsive button in a hidden element then display it", (done) => {
     done = once(done);
 

--- a/test/integration/tests/button/size.js
+++ b/test/integration/tests/button/size.js
@@ -863,9 +863,13 @@ describe(`paypal button component sizes`, () => {
               const zoidContainer = container.querySelector(
                 ".paypal-buttons-context-iframe"
               );
-              if (parseInt(zoidContainer.style.height, 10) !== expectedHeight) {
+              if (
+                !zoidContainer ||
+                parseInt(zoidContainer.style.height, 10) !== expectedHeight
+              ) {
                 done(
                   new Error(
+                    // $FlowFixMe
                     `Expected zoid container height to be ${expectedHeight}. Received: ${zoidContainer.style.height}`
                   )
                 );


### PR DESCRIPTION
### Description

This change sets `autoResize.element` on the Button component to the button container. I'm introducing a new class to prevent reliance on an existing class with other uses.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

Unblocks DTPPCPSDK-1915 #2361 
Does not implement `disableMaxHeight`

Resolves autoResize issue introduced when adding the `disableMaxHeight` prop, which sets container heights within the iframe to 100%. This height prevented resize events, because zoid [observes](https://github.com/krakenjs/zoid/blob/main/docs/api/create.md#autoresize--height-boolean-width-boolean-element-string-) the `body` [by](https://github.com/krakenjs/zoid/blob/main/src/child/child.js#L272) [default](https://github.com/krakenjs/zoid/blob/main/src/parent/parent.js#L1149). A height of 100% prevented this resize from occurring, because it would always match the initial container height.

### Reproduction steps

The issue occurred when the window was resized after the second render.

### Screenshots (if applicable)

Test environment with this PR + current mainline first/second render: `te-button-autoresize`

[Storybook TE with this change and disable max height changes in SCNW](https://github.paypal.com/pages/Core-SDK/button-redesign-storybook/?path=/story/edge-cases-button-disablemaxheight--container-with-fixed-height) (does not include the changes from #2361 to fully support `disableMaxHeight`, but this change has been tested with #2361 locally)

### Dependent Changes (if applicable)

This adds a new class and sets button resize behavior based on this new class. Both first and second render need this version to resize properly.

This change has been tested against the current mainline branch for first/second render. It should be released ahead of the `disableMaxHeight` changes. The server-side `disableMaxHeight` changes can then be released, following by #2361 

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
