### PR TITLE
Make one-click UI ineligible if any shipping callback is present 👾

### DIFF
--- a/src/funding/funding.js
+++ b/src/funding/funding.js
@@ -265,20 +265,16 @@ export function determineEligibleFunding({
 
 export function isWalletFundingEligible({
   wallet,
-  onShippingChange,
-  onShippingAddressChange,
-  onShippingOptionsChange,
+  hasShippingCallback,
 }: {|
   wallet: ?Wallet,
-  onShippingChange: ?OnShippingChange,
-  onShippingAddressChange: ?OnShippingAddressChange,
-  onShippingOptionsChange: ?OnShippingOptionsChange,
+  hasShippingCallback: boolean,
 |}): boolean {
   if (!wallet) {
     return false;
   }
 
-  if (onShippingChange || onShippingAddressChange || onShippingOptionsChange) {
+  if (hasShippingCallback) {
     return false;
   }
 

--- a/src/funding/funding.test.js
+++ b/src/funding/funding.test.js
@@ -4,7 +4,7 @@ import { describe, expect } from "vitest";
 
 import { BUTTON_FLOW } from "../constants";
 
-import { isFundingEligible } from "./funding";
+import { isFundingEligible, isWalletFundingEligible } from "./funding";
 
 const defaultMockFundingOptions = {
   platform: "desktop",
@@ -136,5 +136,33 @@ describe("Funding eligibility", () => {
     );
 
     expect(fundingEligible).toBe(false);
+  });
+});
+
+describe("isWalletFundingEligible", () => {
+  const mockWallet = { paypal: [] };
+
+  test("should not be eligible if a shipping callback is present", () => {
+    const result = isWalletFundingEligible({
+      wallet: mockWallet,
+      hasShippingCallback: true,
+    });
+    expect(result).toBe(false);
+  });
+
+  test("should not be eligible if wallet does not exist", () => {
+    const result = isWalletFundingEligible({
+      wallet: null,
+      hasShippingCallback: false,
+    });
+    expect(result).toBe(false);
+  });
+
+  test("should be eligible if a shipping callback is not present & wallet exists", () => {
+    const result = isWalletFundingEligible({
+      wallet: mockWallet,
+      hasShippingCallback: false,
+    });
+    expect(result).toBe(true);
   });
 });

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -41,24 +41,18 @@ import { calculateShowPoweredBy } from "./util";
 type GetWalletInstrumentOptions = {|
   wallet: ?Wallet,
   fundingSource: $Values<typeof FUNDING>,
-  onShippingChange: ?OnShippingChange,
-  onShippingAddressChange: ?OnShippingAddressChange,
-  onShippingOptionsChange: ?OnShippingOptionsChange,
+  hasShippingCallback: boolean,
 |};
 
 function getWalletInstrument({
   wallet,
   fundingSource,
-  onShippingChange,
-  onShippingAddressChange,
-  onShippingOptionsChange,
+  hasShippingCallback,
 }: GetWalletInstrumentOptions): ?WalletInstrument {
   if (
     !isWalletFundingEligible({
       wallet,
-      onShippingChange,
-      onShippingAddressChange,
-      onShippingOptionsChange,
+      hasShippingCallback,
     })
   ) {
     return;
@@ -81,9 +75,7 @@ const FUNDING_TO_INSTRUMENT = {
 type GetWalletInstrumentsOptions = {|
   wallet: ?Wallet,
   fundingSources: $ReadOnlyArray<$Values<typeof FUNDING>>,
-  onShippingChange: ?OnShippingChange,
-  onShippingAddressChange: ?OnShippingAddressChange,
-  onShippingOptionsChange: ?OnShippingOptionsChange,
+  hasShippingCallback: boolean,
   layout: $Values<typeof BUTTON_LAYOUT>,
 |};
 
@@ -91,9 +83,7 @@ function getWalletInstruments({
   wallet,
   layout,
   fundingSources,
-  onShippingChange,
-  onShippingAddressChange,
-  onShippingOptionsChange,
+  hasShippingCallback,
 }: GetWalletInstrumentsOptions): {|
   [$Values<typeof FUNDING>]: WalletInstrument,
 |} {
@@ -102,9 +92,7 @@ function getWalletInstruments({
     const instrument = getWalletInstrument({
       wallet,
       fundingSource: source,
-      onShippingChange,
-      onShippingAddressChange,
-      onShippingOptionsChange,
+      hasShippingCallback,
     });
 
     if (instrument) {
@@ -234,9 +222,7 @@ export function Buttons(props: ButtonsProps): ElementNode {
     wallet,
     fundingSources,
     layout,
-    onShippingChange,
-    onShippingAddressChange,
-    onShippingOptionsChange,
+    hasShippingCallback,
   });
 
   const isWallet =


### PR DESCRIPTION
### Description
**JIRA:** [DTPPCPSDK-2430](https://paypal.atlassian.net/browse/DTPPCPSDK-2430)

- _**🐞 Fixes bug with one-click button wrongly showing**_ - SCNW doesn't have access to our new shipping callbacks (`onShippingAddressChange` & `onShippingOptionsChange`). This created a bug where if you were to pass a new shipping callback into your buttons config, on second render, `isWalletFundingEligible()` would wrongly return _true_ since it wouldn't know about the new shipping callbacks.  To fix this, I used our new query param `hasShippingCallback`, which SCNW has access to for the second render.
- _**📝 Added some basic tests for `isWalletFundingEligible`**_ - Added a quick set of unit tests for this function just for fun since we have a test file for funding.js. 

### Reproduction Steps (if applicable)
Test with this PR: [Add shipping callbacks to id token page 👾 by ssablan · Pull Request #297 · Checkout-R/xotestbednodeweb](https://github.paypal.com/Checkout-R/xotestbednodeweb/pull/297)

### Screenshots (if applicable)
<details>
<summary><b>onShippingChange (one-click disabled)</b></summary>

![image](https://github.com/paypal/paypal-checkout-components/assets/60204385/152df4a8-70ab-4c67-a92a-c992771f9073)
</details>

<details>
<summary><b>onShippingAddressChange (one-click disabled)</b></summary>

![image](https://github.com/paypal/paypal-checkout-components/assets/60204385/3df88a04-c755-4215-a4ab-11c00a857526)
</details>

<details>
<summary><b>onShippingOptionsChange (one-click disabled)</b></summary>

![image](https://github.com/paypal/paypal-checkout-components/assets/60204385/1d53c11e-30d2-47c3-a7ef-df7bbe34b931)
</details>

<details>
<summary><b>No shipping callback (one-click enabled)</b></summary>

![image](https://github.com/paypal/paypal-checkout-components/assets/60204385/44c16a6f-54f4-4a2b-aee4-c8d705d0ddd0)
</details>

❤️ Thank you!
