### PR TITLE
use query param for atomics waiting state

### DIFF
--- a/src/zoid/checkout/component.jsx
+++ b/src/zoid/checkout/component.jsx
@@ -123,7 +123,9 @@ export function getCheckoutComponent(): CheckoutComponent {
         atomicsWaitingState: {
           type: "object",
           required: false,
-          queryParam: false,
+          queryParam: ({ value }) =>
+            value?.searchParameter || "atomicsWaitingState",
+          queryValue: ({ value }) => value?.encodedState || "",
         },
         clientID: {
           type: "string",

--- a/src/zoid/checkout/props.js
+++ b/src/zoid/checkout/props.js
@@ -39,4 +39,8 @@ export type CheckoutPropsType = {|
   csp: {|
     nonce: string,
   |},
+  atomicsWaitingState: {|
+    searchParameter: string,
+    encodedState: string,
+  |},
 |};


### PR DESCRIPTION
Checkout window is already setup to interact with a query param sent from the instrumentation library