### PR TITLE
Add shipping callbacks to Hosted Buttons

### DIFF
--- a/src/hosted-buttons/index.js
+++ b/src/hosted-buttons/index.js
@@ -6,6 +6,7 @@ import {
   buildHostedButtonCreateOrder,
   buildHostedButtonOnApprove,
   buildHostedButtonOnShippingAddressChange,
+  buildHostedButtonOnShippingOptionsChange,
   getDefaultButtonOptions,
   getFlexDirection,
   getHostedButtonDetails,
@@ -63,7 +64,12 @@ export const getHostedButtonsComponent = (): HostedButtonsComponent => {
       const onShippingAddressChange = buildHostedButtonOnShippingAddressChange({
         enableDPoP,
         hostedButtonId,
-        merchantId,
+        shouldIncludeShippingCallbacks,
+      });
+
+      const onShippingOptionsChange = buildHostedButtonOnShippingOptionsChange({
+        enableDPoP,
+        hostedButtonId,
         shouldIncludeShippingCallbacks,
       });
 
@@ -74,6 +80,7 @@ export const getHostedButtonsComponent = (): HostedButtonsComponent => {
         onApprove,
         onClick,
         onShippingAddressChange,
+        onShippingOptionsChange,
         onInit,
         style,
       };

--- a/src/hosted-buttons/index.js
+++ b/src/hosted-buttons/index.js
@@ -2,16 +2,17 @@
 import { getButtonsComponent } from "../zoid/buttons";
 
 import {
+  applyContainerStyles,
   buildHostedButtonCreateOrder,
   buildHostedButtonOnApprove,
-  getHostedButtonDetails,
-  renderForm,
-  getMerchantID,
-  getFlexDirection,
-  applyContainerStyles,
-  renderStandaloneButton,
-  renderDefaultButton,
+  buildHostedButtonOnShippingAddressChange,
   getDefaultButtonOptions,
+  getFlexDirection,
+  getHostedButtonDetails,
+  getMerchantID,
+  renderDefaultButton,
+  renderForm,
+  renderStandaloneButton,
 } from "./utils";
 import type {
   HostedButtonsComponent,
@@ -35,6 +36,7 @@ export const getHostedButtonsComponent = (): HostedButtonsComponent => {
         preferences,
         buttonContainerId,
         enableDPoP,
+        shouldIncludeShippingCallbacks,
       } = await getHostedButtonDetails({
         hostedButtonId,
       });
@@ -58,12 +60,20 @@ export const getHostedButtonsComponent = (): HostedButtonsComponent => {
         merchantId,
       });
 
+      const onShippingAddressChange = buildHostedButtonOnShippingAddressChange({
+        enableDPoP,
+        hostedButtonId,
+        merchantId,
+        shouldIncludeShippingCallbacks,
+      });
+
       const buttonOptions: HostedButtonOptions = {
         createOrder,
         hostedButtonId,
         merchantId,
         onApprove,
         onClick,
+        onShippingAddressChange,
         onInit,
         style,
       };

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -17,6 +17,16 @@ export type OnApprove = (data: {|
 
 type OnInit = (data: mixed, actions: mixed) => void;
 type OnClick = (data: mixed, actions: mixed) => void;
+export type OnShippingAddressChange = (data: {|
+  errors: mixed,
+  orderID: string,
+  shippingAddress: {|
+    city: string,
+    state: string,
+    countryCode: string,
+    postalCode: string,
+  |},
+|}) => Promise<mixed>;
 
 export type FundingSources = string;
 export interface GetFlexDirection {
@@ -51,6 +61,7 @@ export type HostedButtonOptions = {|
   onApprove: OnApprove,
   onClick: OnClick,
   onInit: OnInit,
+  onShippingAddressChange: OnShippingAddressChange | typeof undefined,
   style: HostedButtonStyles,
   hostedButtonId: string,
   merchantId?: string,
@@ -96,6 +107,7 @@ export type GetCallbackProps = {|
   enableDPoP?: boolean,
   hostedButtonId: string,
   merchantId?: string,
+  shouldIncludeShippingCallbacks?: boolean,
 |};
 
 export type HostedButtonsInstance = {|
@@ -111,6 +123,7 @@ export type HostedButtonDetailsParams =
     buttonContainerId: string,
     preferences?: HostedButtonPreferences,
     enableDPoP: boolean,
+    shouldIncludeShippingCallbacks: boolean,
   |}>;
 
 export type ButtonVariables = $ReadOnlyArray<{|

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -17,24 +17,39 @@ export type OnApprove = (data: {|
 
 type OnInit = (data: mixed, actions: mixed) => void;
 type OnClick = (data: mixed, actions: mixed) => void;
-export type OnShippingAddressChange = (data: {|
-  errors: mixed,
-  orderID: string,
-  shippingAddress: {|
-    city: string,
-    state: string,
-    countryCode: string,
-    postalCode: string,
-  |},
-|}) => Promise<mixed>;
 
-export type OnShippingOptionsChange = (data: {|
-  errors: mixed,
-  orderID: string,
-  selectedShippingOption: {|
-    id: string,
+export type OnShippingAddressChange = (
+  data: {|
+    errors: {|
+      ADDRESS_ERROR: string,
+    |},
+    orderID: string,
+    shippingAddress: {|
+      city: string,
+      state: string,
+      countryCode: string,
+      postalCode: string,
+    |},
   |},
-|}) => Promise<mixed>;
+  actions: {|
+    reject: (arg: string) => void,
+  |}
+) => Promise<mixed>;
+
+export type OnShippingOptionsChange = (
+  data: {|
+    errors: {|
+      METHOD_UNAVAILABLE: string,
+    |},
+    orderID: string,
+    selectedShippingOption: {|
+      id: string,
+    |},
+  |},
+  actions: {|
+    reject: (arg: string) => void,
+  |}
+) => Promise<mixed>;
 
 export type FundingSources = string;
 export interface GetFlexDirection {

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -160,6 +160,17 @@ export type CreateAccessToken = ({|
   enableDPoP?: boolean,
 |}) => Promise<{| accessToken: string, nonce: string |}>;
 
+export type BuildRequestHeaders = ({|
+  enableDPoP?: boolean,
+  url: string,
+  method: string,
+|}) => Promise<{|
+  Authorization: string,
+  "Content-Type": string,
+  "PayPal-Entry-Point": string,
+  DPoP?: string,
+|}>;
+
 export type HostedButtonsComponent =
   (HostedButtonsComponentProps) => HostedButtonsInstance;
 

--- a/src/hosted-buttons/types.js
+++ b/src/hosted-buttons/types.js
@@ -28,6 +28,14 @@ export type OnShippingAddressChange = (data: {|
   |},
 |}) => Promise<mixed>;
 
+export type OnShippingOptionsChange = (data: {|
+  errors: mixed,
+  orderID: string,
+  selectedShippingOption: {|
+    id: string,
+  |},
+|}) => Promise<mixed>;
+
 export type FundingSources = string;
 export interface GetFlexDirection {
   flexDirection: FlexDirection;
@@ -61,7 +69,8 @@ export type HostedButtonOptions = {|
   onApprove: OnApprove,
   onClick: OnClick,
   onInit: OnInit,
-  onShippingAddressChange: OnShippingAddressChange | typeof undefined,
+  onShippingAddressChange?: OnShippingAddressChange,
+  onShippingOptionsChange?: OnShippingOptionsChange,
   style: HostedButtonStyles,
   hostedButtonId: string,
   merchantId?: string,

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -311,12 +311,11 @@ export const buildHostedButtonOnShippingAddressChange = ({
   shouldIncludeShippingCallbacks,
 }: GetCallbackProps): OnShippingAddressChange | typeof undefined => {
   if (shouldIncludeShippingCallbacks) {
-    return async (data) => {
-      // const url = `https://www.te-ncps-shiptax.qa.paypal.com/ncp/v1/checkout/links/${hostedButtonId}/shipping-options`;
+    return async (data, actions) => {
       const url = `${apiUrl}/v1/checkout/links/${hostedButtonId}/shipping-options`;
       const method = "POST";
       const headers = await buildRequestHeaders({ url, method, enableDPoP });
-      const { shippingAddress, orderID } = data;
+      const { shippingAddress, orderID, errors } = data;
       const body = {
         context_id: orderID,
         shipping_address: {},
@@ -333,13 +332,18 @@ export const buildHostedButtonOnShippingAddressChange = ({
         };
       }
 
-      await request({
+      const response = await request({
         url,
         // $FlowIssue optional properties are not compatible with [key: string]: string
         headers,
         method,
         body: JSON.stringify(body),
       });
+
+      // $FlowIssue zalgoPromis is type mixed
+      if (response.status !== 200) {
+        actions.reject(errors?.ADDRESS_ERROR);
+      }
     };
   }
 };
@@ -350,24 +354,28 @@ export const buildHostedButtonOnShippingOptionsChange = ({
   shouldIncludeShippingCallbacks,
 }: GetCallbackProps): OnShippingOptionsChange | typeof undefined => {
   if (shouldIncludeShippingCallbacks) {
-    return async (data) => {
-      const url = `https://www.te-ncps-shiptax.qa.paypal.com/ncp/v1/checkout/links/${hostedButtonId}/shipping-options`;
-      // const url = `${apiUrl}/v1/checkout/links/${hostedButtonId}/acquire-shipping-options`;
+    return async (data, actions) => {
+      const url = `${apiUrl}/v1/checkout/links/${hostedButtonId}/shipping-options`;
       const method = "POST";
       const headers = await buildRequestHeaders({ url, method, enableDPoP });
-      const { selectedShippingOption, orderID } = data;
+      const { selectedShippingOption, orderID, errors } = data;
       const body = {
         context_id: orderID,
-        selected_shipping_option_id: selectedShippingOption?.id,
+        shipping_option_id: selectedShippingOption?.id,
       };
 
-      await request({
+      const response = await request({
         url,
         // $FlowIssue optional properties are not compatible with [key: string]: string
         headers,
         method,
         body: JSON.stringify(body),
       });
+
+      // $FlowIssue zalgoPromis is type mixed
+      if (response.status !== 200) {
+        actions.reject(errors?.METHOD_UNAVAILABLE);
+      }
     };
   }
 };

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -267,10 +267,8 @@ export const buildHostedButtonCreateOrder = ({
       });
       // $FlowIssue request returns ZalgoPromise
       const { body } = response;
-      console.log(body);
       return body.context_id || onError(body.name);
     } catch (e) {
-      console.log(e);
       return onError("REQUEST_FAILED");
     }
   };

--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -16,6 +16,7 @@ import { getButtonsComponent, type ButtonsComponent } from "../zoid/buttons";
 
 import type {
   ButtonVariables,
+  BuildRequestHeaders,
   CreateAccessToken,
   CreateOrder,
   GetCallbackProps,
@@ -91,7 +92,11 @@ export const createAccessToken: CreateAccessToken = memoize<CreateAccessToken>(
   }
 );
 
-const buildRequestHeaders = async ({ enableDPoP, url, method }) => {
+export const buildRequestHeaders: BuildRequestHeaders = async ({
+  enableDPoP,
+  url,
+  method,
+}) => {
   const { accessToken, nonce } = await createAccessToken({
     clientId: getClientID(),
     enableDPoP,
@@ -106,6 +111,7 @@ const buildRequestHeaders = async ({ enableDPoP, url, method }) => {
       })
     : {};
 
+  // $FlowIssue
   return {
     ...getHeaders(accessToken),
     // $FlowIssue exponential-spread
@@ -261,8 +267,10 @@ export const buildHostedButtonCreateOrder = ({
       });
       // $FlowIssue request returns ZalgoPromise
       const { body } = response;
+      console.log(body);
       return body.context_id || onError(body.name);
     } catch (e) {
+      console.log(e);
       return onError("REQUEST_FAILED");
     }
   };

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -1,5 +1,5 @@
 /* @flow */
-/* eslint-disable no-restricted-globals, promise/no-native */
+/* eslint-disable no-restricted-globals, promise/no-native, max-lines */
 import { test, expect, vi } from "vitest";
 import { request } from "@krakenjs/belter/src";
 import { getLogger } from "@paypal/sdk-client/src";
@@ -716,7 +716,7 @@ describe("buildHostedButtonOnShippingOptionsChange", () => {
     expect.assertions(1);
   });
 
-  test("return undefined when shouldIncludeShippingCallbacks is false", async () => {
+  test("return undefined when shouldIncludeShippingCallbacks is false", () => {
     const onShippingOptionsChange = buildHostedButtonOnShippingOptionsChange({
       hostedButtonId,
       shouldIncludeShippingCallbacks: false,
@@ -1022,4 +1022,4 @@ describe("render buttons", () => {
   });
 });
 
-/* eslint-enable no-restricted-globals, promise/no-native */
+/* eslint-enable no-restricted-globals,promise/no-native, max-lines  */


### PR DESCRIPTION
### Description

In phase 2, the NCPS team would like to extend this functionality into a configurable shipping and tax grid that allows the merchant the ability to set custom shipping and tax rates per location (as well as shipping options such as 2-day shipping, priority shipping, etc). 

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues 
https://paypal.atlassian.net/browse/DTPPCPSDK-2155
### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
