### PR TITLE
Make getShopperInsightsUsed prop not required 👾

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -952,6 +952,7 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
       getShopperInsightsUsed: {
         type: "function",
         value: () => wasShopperInsightsUsed,
+        required: false,
       },
 
       stageHost: {


### PR DESCRIPTION
### Description

**JIRA:** [DTPPCPSDK-2369](https://paypal.atlassian.net/browse/DTPPCPSDK-2369)

_**🐞 Fixes local error saying getShopperInsightsUsed is missing**_ - noticed this in my local env.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->d
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
