### PR TITLE
Update pre-render template to take the height of the input selector

### DIFF
--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -128,9 +128,10 @@ const url = () =>
   `${getPayPalDomain()}${__PAYPAL_CHECKOUT__.__URI__.__CARD_FIELD__}`;
 
 const prerenderTemplate = ({ props, doc }) => {
-  return (
-    <CardPrerender nonce={props.nonce} height={props.style?.height} />
-  ).render(dom({ doc }));
+  const height = props.style?.height || props.style?.input?.height || null;
+  return (<CardPrerender nonce={props.nonce} height={height} />).render(
+    dom({ doc })
+  );
 };
 
 export type CardFieldsComponent = ZoidComponent<

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -129,7 +129,7 @@ const url = () =>
   `${getPayPalDomain()}${__PAYPAL_CHECKOUT__.__URI__.__CARD_FIELD__}`;
 
 const prerenderTemplate = ({ props, doc }) => {
-  const height = props.style?.height || props.style?.input?.height || null;
+  const height = props.style?.height ?? props.style?.input?.height ?? null;
   return (<CardPrerender nonce={props.nonce} height={height} />).render(
     dom({ doc })
   );

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -50,6 +50,7 @@ type CardFieldsProps = {|
   clientID: string,
   style?: {|
     height: number,
+    input: {| height: number |},
   |},
   env?: string,
   locale?: string,


### PR DESCRIPTION
### Description

Currently, the pre-render template will only look for a height property to be passed at the top level of the custom style object. Passing the height in this way introduced a bug where the CSS properties of the rendered Card Fields would not be applied. 

This PR is to allow the pre-render template to check for a height property to be passed to the input selector and to utilize that height.

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

scnw PR #707 introduced a bug where passing height at the top level would break the CSS of the rendered input field
Jira ticket - DTPPCPSDK-2442

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

**Top level height with input height**
Pre-render template at 100px and rendered input fields at 50px
```
      style: {
        height: "100px",
        input: {
          height: "50px",
          background: "#E79482",
        },
      },
```
![image](https://github.com/paypal/paypal-checkout-components/assets/38122192/13d0ab6d-4396-4c3c-a793-b791dcd01115)

**Only input height**
Pre-render template and rendered input fields at 50px
```
      style: {
        input: {
          height: "50px",
          background: "#E79482",
        },
      },
```
![image](https://github.com/paypal/paypal-checkout-components/assets/38122192/4a969437-c63d-4587-bca5-b4a42458e4ac)


### Dependent Changes (if applicable)

scnw PR #717

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
