### PR TITLE
Fix button styles when paypal button is not vaultable

### DIFF
--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -109,6 +109,7 @@ export function Button({
 
   let { color, period, label } = style;
 
+  // if no color option is passed in via style props, use the default color value from the funding source config
   if (color === "" || typeof color === "undefined") {
     color = colors[0];
   }

--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -107,7 +107,11 @@ export function Button({
   const colors = fundingConfig.colors;
   const secondaryColors = fundingConfig.secondaryColors || {};
 
-  let { color = colors[0], period, label } = style;
+  let { color, period, label } = style;
+
+  if (color === "" || typeof color === "undefined") {
+    color = colors[0];
+  }
 
   if (multiple && i > 0) {
     if (

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -317,7 +317,7 @@ export type OnClick = (OnClickData, OnClickActions) => void;
 
 export type ButtonStyle = {|
   label: $Values<typeof BUTTON_LABEL> | void,
-  color: $Values<typeof BUTTON_COLOR>,
+  color?: $Values<typeof BUTTON_COLOR>,
   shape: $Values<typeof BUTTON_SHAPE>,
   tagline: boolean,
   layout: $Values<typeof BUTTON_LAYOUT>,
@@ -644,6 +644,7 @@ export function normalizeButtonStyle(
   }
 
   let {
+    color,
     label,
     layout = fundingSource
       ? BUTTON_LAYOUT.HORIZONTAL
@@ -663,9 +664,6 @@ export function normalizeButtonStyle(
     // $FlowFixMe
     tagline = false;
   }
-
-  // if color is a falsy value, set it to the default color from the funding config
-  const color = style.color ? style.color : fundingConfig.colors[0];
 
   if (values(BUTTON_LAYOUT).indexOf(layout) === -1) {
     throw new Error(`Invalid layout: ${layout}`);

--- a/test/integration/tests/button/style.js
+++ b/test/integration/tests/button/style.js
@@ -3,6 +3,7 @@
 
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 import { once } from "@krakenjs/belter/src";
+import { FUNDING } from "@paypal/sdk-constants/src";
 
 import {
   generateOrderID,
@@ -11,6 +12,7 @@ import {
   getElementRecursive,
   assert,
   WEBVIEW_USER_AGENT,
+  mockProp,
 } from "../common";
 
 for (const flow of ["popup", "iframe"]) {
@@ -58,7 +60,7 @@ for (const flow of ["popup", "iframe"]) {
   });
 }
 
-describe("paypal button color", () => {
+describe.only("paypal button color", () => {
   beforeEach(() => {
     createTestContainer();
   });
@@ -67,13 +69,22 @@ describe("paypal button color", () => {
     destroyTestContainer();
   });
 
-  it("should render a button with gold background when no color is specified", () => {
+  it("should render a button with gold background when empty string is passed in for color", () => {
     return window.paypal
       .Buttons({
         style: {
           color: "",
         },
       })
+      .render("#testContainer")
+      .then(() => {
+        assert.ok(getElementRecursive(".paypal-button-color-gold"));
+      });
+  });
+
+  it("should render a button with gold background when no color is specified", () => {
+    return window.paypal
+      .Buttons()
       .render("#testContainer")
       .then(() => {
         assert.ok(getElementRecursive(".paypal-button-color-gold"));
@@ -97,7 +108,7 @@ describe("paypal button color", () => {
     return window.paypal
       .Buttons({
         style: {
-          color: "",
+          color: "gold",
         },
       })
       .render("#testContainer")

--- a/test/integration/tests/button/style.js
+++ b/test/integration/tests/button/style.js
@@ -3,7 +3,6 @@
 
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 import { once } from "@krakenjs/belter/src";
-import { FUNDING } from "@paypal/sdk-constants/src";
 
 import {
   generateOrderID,
@@ -12,7 +11,6 @@ import {
   getElementRecursive,
   assert,
   WEBVIEW_USER_AGENT,
-  mockProp,
 } from "../common";
 
 for (const flow of ["popup", "iframe"]) {

--- a/test/integration/tests/button/style.js
+++ b/test/integration/tests/button/style.js
@@ -60,7 +60,7 @@ for (const flow of ["popup", "iframe"]) {
   });
 }
 
-describe.only("paypal button color", () => {
+describe("paypal button color", () => {
   beforeEach(() => {
     createTestContainer();
   });


### PR DESCRIPTION
### Description

We had a styling bug where the gold color was being applied to the venmo and card buttons. This was due to the nomalizeButtonStyle function using the paypal funding source config to determine the default if no funding source was passed in as a prop. This was an issue for the smart stack use case when the paypal button was not eligible. Instead of using the default color for the funding source in the Button component, it was using the gold value set as a default fallback.

The paypal button was not eligible for vaulting when passing `displayOnly: ["vaultable"]`

Where we pull in the default button color based on the eligible funding source for the smart stack.
https://github.com/paypal/paypal-checkout-components/blob/main/src/ui/buttons/button.jsx#L110

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
https://paypal.atlassian.net/browse/LI-46995

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

<img width="396" alt="Screenshot 2024-07-23 at 4 31 51 PM" src="https://github.com/user-attachments/assets/b1bf9a13-e360-4ff0-9212-78624059fef6">

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
