### PR TITLE
feat: allows button message amount type to be string

### DIFF
--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -440,7 +440,7 @@ export type ButtonMessage = {|
 |};
 
 export type ButtonMessageInputs = {|
-  amount?: number | void,
+  amount?: number | string | void,
   offer?: $ReadOnlyArray<$Values<typeof MESSAGE_OFFER>> | void,
   color?: $Values<typeof MESSAGE_COLOR> | void,
   position?: $Values<typeof MESSAGE_POSITION> | void,
@@ -787,15 +787,20 @@ export function normalizeButtonMessage(
     align = MESSAGE_ALIGN.CENTER,
   } = message;
   let offer = message.offer;
-  if (typeof amount !== "undefined") {
-    if (typeof amount !== "number") {
+
+  var numericAmount = amount;
+  if (typeof numericAmount !== "undefined") {
+    if (typeof numericAmount === "string") {
+      numericAmount = Number(amount);
+    }
+    if (typeof numericAmount !== "number" || isNaN(numericAmount)) {
       throw new TypeError(
         `Expected message.amount to be a number, got: ${amount}`
       );
     }
-    if (amount < 0) {
+    if (numericAmount < 0) {
       throw new Error(
-        `Expected message.amount to be a positive number, got: ${amount}`
+        `Expected message.amount to be a positive number, got: ${numericAmount}`
       );
     }
   }
@@ -836,7 +841,7 @@ export function normalizeButtonMessage(
   }
 
   return {
-    amount,
+    amount: numericAmount,
     offer,
     color,
     position: calculateMessagePosition(fundingSources, layout, position),

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -781,26 +781,25 @@ export function normalizeButtonMessage(
   fundingSources: $ReadOnlyArray<$Values<typeof FUNDING>>
 ): ButtonMessage {
   const {
-    amount,
     color = MESSAGE_COLOR.BLACK,
     position,
     align = MESSAGE_ALIGN.CENTER,
   } = message;
   let offer = message.offer;
+  let amount = message.amount;
 
-  var numericAmount = amount;
-  if (typeof numericAmount !== "undefined") {
-    if (typeof numericAmount === "string") {
-      numericAmount = Number(amount);
+  if (typeof amount !== "undefined") {
+    if (typeof amount === "string") {
+      amount = Number(amount);
     }
-    if (typeof numericAmount !== "number" || isNaN(numericAmount)) {
+    if (typeof amount !== "number" || isNaN(amount)) {
       throw new TypeError(
         `Expected message.amount to be a number, got: ${amount}`
       );
     }
-    if (numericAmount < 0) {
+    if (amount < 0) {
       throw new Error(
-        `Expected message.amount to be a positive number, got: ${numericAmount}`
+        `Expected message.amount to be a positive number, got: ${amount}`
       );
     }
   }
@@ -841,7 +840,7 @@ export function normalizeButtonMessage(
   }
 
   return {
-    amount: numericAmount,
+    amount,
     offer,
     color,
     position: calculateMessagePosition(fundingSources, layout, position),

--- a/test/integration/tests/button/message.js
+++ b/test/integration/tests/button/message.js
@@ -594,4 +594,24 @@ describe(`paypal button message`, () => {
         .render("#testContainer");
     });
   });
+
+  describe("property normalization", () => {
+    it("should convert string type amount to number", () => {
+      return wrapPromise(({ expect }) => {
+        window.paypal
+          .Buttons({
+            message: { amount: "100" },
+            test: {
+              onRender: expect("onRender", ({ xprops }) => {
+                const {
+                  message: { amount },
+                } = xprops;
+                assert.equal(amount, 100);
+              }),
+            },
+          })
+          .render("#testContainer");
+      });
+    });
+  });
 });

--- a/test/integration/tests/button/validation.js
+++ b/test/integration/tests/button/validation.js
@@ -1004,7 +1004,18 @@ const buttonConfigs = [
 
       {
         message: {
-          amount: "100", // invalid: should be num
+          amount: "100", // valid: is converted to num
+          offer: ["pay_later_long_term"],
+          color: "black",
+          position: "top",
+          align: "left",
+        },
+        valid: true,
+      },
+
+      {
+        message: {
+          amount: "one hundred", // invalid: string not convertible to number
           offer: ["pay_later_long_term"],
           color: "black",
           position: "top",


### PR DESCRIPTION
### Description

Allows button messages to support taking string values for the amount (ex: "100")

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
As a developer, I’d like the integration for passing the amount to buttons and messages to be the same.

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
