### PR TITLE
[DO NOT MERGE] Increase minimum label height to 20px

### DIFF
--- a/src/ui/buttons/styles/responsive.js
+++ b/src/ui/buttons/styles/responsive.js
@@ -60,7 +60,9 @@ export function buttonResponsiveStyle({
         12
       );
 
-      const labelHeight = max(roundUp(perc(buttonHeight, 35) + 5, 2), 12);
+      // A PayPal logo with min height 20px is what we need to achieve the desired look when the button is small
+      // A small button rendered by us is approximately 100px width by 42px height
+      const labelHeight = max(roundUp(perc(buttonHeight, 35) + 5, 2), 20);
 
       const pillBorderRadius = Math.ceil(buttonHeight / 2);
 


### PR DESCRIPTION
### Description

Co-authored by @gcaven

Hello PayPal SDK team 👋 We are trying to render a PayPal button using the `disableMaxHeight: true` and `disableMaxWidth: true` params so the PayPal button sizes according to the container.

We noticed the PayPal logo scales proportionately to the container size, but at small container sizes, the PayPal logo gets very small such that it looks inconsistent to other branded buttons on the page- please see screenshots below.

@westeezy helped us and pointed us out to where the `.paypal-button-label-container` CSS is generated. However, `labelHeight` is dynamic and used in a lot of places, so we were curious if you could help us make sense of whether this fits in your product requirements and move this forward. Many thanks in advance 🙏 

### Reproduction Steps (if applicable)

1. In the `style` param, set `disableMaxHeight: true` and `disableMaxWidth: true`
2. Render the PayPal button in a small container, eg. 100px width x 42px height

### Screenshots (if applicable)

#### Current state
<img width="1463" alt="Screenshot 2024-07-24 at 14 25 47" src="https://github.com/user-attachments/assets/243c2284-781e-4e0b-a919-dd16e5847d40">

#### Desired state

<img width="1693" alt="Screenshot 2024-07-24 at 14 28 47" src="https://github.com/user-attachments/assets/7a0b2a17-e66a-44a9-8e23-ee80b7cc61ff">

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
