### PR TITLE
Fix button color styles being applied incorrectly

### DIFF
--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -111,9 +111,19 @@ export function Button({
 
   // if no color option is passed in via style props
   if (color === "" || typeof color === "undefined") {
-    // if multiple buttons are being rendered (smart stack), we set default color as gold
     // if a single button is rendered, we set color to first option in the fundingSource config
-    color = multiple ? "gold" : colors[0];
+    color = colors[0];
+
+    // if multiple buttons are being rendered (smart stack), we set default color as gold > first
+    if (multiple) {
+      color = "gold";
+    }
+  }
+
+  // validate the first button rendered has a valid color
+  // this check is needed to validate the first button in a smart stack gets the correct color
+  if (i === 0 && !colors.includes(color)) {
+    color = colors[0];
   }
 
   // The secondary colors are used to render the smart stack (multiple buttons)
@@ -137,6 +147,8 @@ export function Button({
     logoColors[color] || logoColors[LOGO_COLOR.DEFAULT] || LOGO_COLOR.DEFAULT;
   const textColor =
     textColors[color] || textColors[TEXT_COLOR.DEFAULT] || TEXT_COLOR.DEFAULT;
+
+  console.log({ fundingSource, logoColor, textColor, color });
 
   const { Label, WalletLabel, Logo, showWalletMenu } = fundingConfig;
 

--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -148,8 +148,6 @@ export function Button({
   const textColor =
     textColors[color] || textColors[TEXT_COLOR.DEFAULT] || TEXT_COLOR.DEFAULT;
 
-  console.log({ fundingSource, logoColor, textColor, color });
-
   const { Label, WalletLabel, Logo, showWalletMenu } = fundingConfig;
 
   const clickHandler = (event, opts) => {


### PR DESCRIPTION
### Description

When the PayPal button is not eligible in a vaulting flow our logic for applying the button color was incorrect.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
[LI-46995](https://paypal.atlassian.net/browse/LI-46995)

Relavant PRs
1. https://github.com/paypal/paypal-checkout-components/pull/2420
1. https://github.com/paypal/paypal-checkout-components/pull/2424

### Reproduction Steps
JS SDK script 
```html
<script src="https://www.paypal.com/sdk/js?client-id=B_AxqJZnX9Fg6HifHgzGWffqQhnRxsdiXR2eGsIS50nBpG8IPJXi7-bZA4zgvlDGaEs0QwxlTGbuGdRmo&merchant-id=NY9D8KUEC8W54&enable-funding=venmo"></script>
```

button configuraton
```js
paypal.Buttons({
    displayOnly: ["vaultable"],
    style: {
        color: ''
    },
  }).render('#paypal-container-id');`);
```

### Screenshots (if applicable)
1. First relevant PR fixed the issue with the colors being applied incorrectly, but failed to account for the effects to the default colors on the smart stack (secondary colors)
<img width="375" alt="image-20240808-185002" src="https://github.com/user-attachments/assets/d9a05978-0e09-453e-8326-3bf1835f574f">


3. The second relevant PR attempted to fix the issue with the default colors but was unsuccessful and reintroduced the bug this LI pointed out
![smart stack](https://github.com/user-attachments/assets/105a1ffe-9883-407b-b6ba-31038c4e61af)

5. This PR contains a solution for both of these issues 
<img width="626" alt="Screenshot 2024-08-21 at 7 21 19 AM" src="https://github.com/user-attachments/assets/8c61537a-e9bf-4dc8-86e8-1fe84a7deefd">
<img width="630" alt="Screenshot 2024-08-21 at 7 36 15 AM" src="https://github.com/user-attachments/assets/8e0ff699-7b9a-4b38-b606-6e18d6dd0632">



### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
