### PR TITLE
fix(hosted-buttons): fix an issue where shipping callbacks would not throw

### DIFF
--- a/src/hosted-buttons/utils.js
+++ b/src/hosted-buttons/utils.js
@@ -352,7 +352,7 @@ export const buildHostedButtonOnShippingAddressChange = ({
 
       // $FlowIssue zalgoPromis is type mixed
       if (response.status !== 200) {
-        actions.reject(errors?.ADDRESS_ERROR);
+        return actions.reject(errors?.ADDRESS_ERROR);
       }
     };
   }
@@ -384,7 +384,7 @@ export const buildHostedButtonOnShippingOptionsChange = ({
 
       // $FlowIssue zalgoPromis is type mixed
       if (response.status !== 200) {
-        actions.reject(errors?.METHOD_UNAVAILABLE);
+        return actions.reject(errors?.METHOD_UNAVAILABLE);
       }
     };
   }

--- a/src/hosted-buttons/utils.test.js
+++ b/src/hosted-buttons/utils.test.js
@@ -636,10 +636,20 @@ describe("buildHostedButtonOnShippingAddressChange", () => {
         status: 500,
       })
     );
-    // $FlowIssue
-    await onShippingAddressChange(data, actions);
-    expect(actions.reject).toHaveBeenCalledWith(errors.ADDRESS_ERROR);
-    expect.assertions(1);
+
+    const localActions = {
+      // eslint-disable-next-line compat/compat
+      reject: vi.fn((message) => Promise.reject(message)),
+    };
+
+    // $FlowIssueeslint-disable-next-line compat/compat
+    await expect(onShippingAddressChange(data, localActions)).rejects.toThrow(
+      errors.ADDRESS_ERROR
+    );
+
+    expect(localActions.reject).toHaveBeenCalledWith(errors.ADDRESS_ERROR);
+
+    expect.assertions(2);
   });
 
   test("return undefined when shouldIncludeShippingCallbacks is false", () => {


### PR DESCRIPTION
The result of calling actions.reject was not being returned, causing the callback to not reject when the consumer passed an action.reject that rejects.

### Description
The existing onShippingChange and onShippingOptionsChange callbacks used by hosted buttons do not return the result of calling the client application supplied action.reject method. This allows execution to continue and the callback resolves as if it were successful.

This causes the need for unsightly and hard to test error handling scenarios in the client application.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
(ticket incoming) Supporting NCPS shipping callbacks.

### Reproduction Steps (if applicable)
Passing `{ reject: message => Promise.reject(message) }` when calling either callback from the client application and the callback will not reject. See original test and changes for confirmation.

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
