### PR TITLE
Adding Installments and IC2B for Card Fields

### DIFF
--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -46,6 +46,14 @@ const CARD_FIELD_TYPE = {
   POSTAL: "postal",
 };
 
+type InstallmentsConfiguration = {|
+  financingCountryCode : string,
+  currencyCode : string,
+  billingCountryCode : string,
+  amount : string,
+  includeBuyerInstallments ? : boolean
+|};
+
 type CardFieldsProps = {|
   clientID: string,
   style?: {|
@@ -100,6 +108,11 @@ type CardFieldsProps = {|
   hcfSessionID: string,
   partnerAttributionID: string,
   merchantID: $ReadOnlyArray<string>,
+  installments? : {|
+    onInstallmentsRequested : () => InstallmentsConfiguration | ZalgoPromise<InstallmentsConfiguration>,
+    onInstallmentsAvailable : (Object) => void,
+    onInstallmentsError? : (Object) => void
+  |},
 |};
 
 type CardFieldProps = {|
@@ -423,6 +436,11 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
             default: getUserIDToken,
             required: false,
           },
+          installments: {
+            type: "object",
+            required: false,
+            value: ({ props }) => props.parent.props.installments
+          },
         },
       });
     };
@@ -699,6 +717,10 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
         userIDToken: {
           type: "string",
           default: getUserIDToken,
+          required: false,
+        },
+        installments: {
+          type: "object",
           required: false,
         },
       },


### PR DESCRIPTION
### Description
This change is to support Installments and IC2B (Installment Cost to Buyer) for SDK.

**HLD**: https://paypal.atlassian.net/wiki/spaces/NewInitiatives/pages/892253914/Installments+IC2B+in+PayPal+Card+Fields?focusedCommentId=911039343

**LLD**: 
https://paypal.atlassian.net/wiki/spaces/NewInitiatives/pages/937141479/MX+Installment+Cost+to+Buyer+IC2B+-+SDK+-+Checkout+LLD

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
Due to the high cost, only 40% of merchants enable installments, typically during promotions or seasonal campaigns. If a merchant does not enable installments, buyers do not get installment options, even if their credit card supports installments. This is addressed in IC2B (Installments Cost to Buyer), where the portion of the installments fee exceeding the maximum term selected by the merchant is shared with the buyer, allowing them to access all installment options.

https://paypal.atlassian.net/browse/DTTABASCO-2090

### Screenshots (if applicable)
![Screenshot 2024-09-16 at 12 13 49 PM](https://github.com/user-attachments/assets/c39f466c-17ed-4404-8eca-26a4fba6eaf0)

### Dependent Changes (if applicable)
Smart component node web: https://github.paypal.com/Checkout-R/smartcomponentnodeweb/pull/765/
Needs to be updated in clientsdknodeweb

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->
❤️ Thank you!
