### PR TITLE
Add performance prop 👾

### DIFF
--- a/src/lib/perceived-latency-instrumentation.js
+++ b/src/lib/perceived-latency-instrumentation.js
@@ -51,11 +51,6 @@ export const logLatencyInstrumentationPhase = ({
   buttonSessionID,
   phase,
 }: LogLatencyInstrumentationPhaseParams) => {
-  console.log({
-    fn: "logLatency",
-    buttonSessionID,
-    phase,
-  });
   if (window.performance && window.performance.mark) {
     window.performance.mark(`${buttonSessionID}_${phase}`);
   }

--- a/src/lib/perceived-latency-instrumentation.js
+++ b/src/lib/perceived-latency-instrumentation.js
@@ -25,13 +25,13 @@ function getNavigationTimeOrigin(): number {
   }
 }
 
-function getStartTimeFromMark({
+export function getStartTimeFromMark({
   buttonSessionID,
   phase,
 }: LogLatencyInstrumentationPhaseParams): number {
   if (window.performance) {
     return performance.getEntriesByName(`${buttonSessionID}_${phase}`).pop()
-      .startTime;
+      ?.startTime;
   } else {
     throw new Error("window.performance not supported");
   }
@@ -51,6 +51,11 @@ export const logLatencyInstrumentationPhase = ({
   buttonSessionID,
   phase,
 }: LogLatencyInstrumentationPhaseParams) => {
+  console.log({
+    fn: "logLatency",
+    buttonSessionID,
+    phase,
+  });
   if (window.performance && window.performance.mark) {
     window.performance.mark(`${buttonSessionID}_${phase}`);
   }

--- a/src/lib/perceived-latency-instrumentation.test.js
+++ b/src/lib/perceived-latency-instrumentation.test.js
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, vi } from "vitest";
+import { getStartTimeFromMark } from "./perceived-latency-instrumentation";
+
+describe("getStartTimeFromMark", () => {
+  const buttonSessionID = "button-session-id";
+  const phase = "phase";
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    performance.clearMarks();
+  });
+
+  test("should throw error if window.perfomance doesn't exist", () => {
+    vi.spyOn(window, "performance", "get").mockReturnValueOnce(null);
+
+    const startTimeFn = () => getStartTimeFromMark(buttonSessionID, phase);
+    expect(startTimeFn).toThrowError();
+  });
+
+  test("should return undefined if performance entry is not found", () => {
+    const startTime = getStartTimeFromMark(buttonSessionID, phase);
+
+    expect(startTime).toBeUndefined();
+  });
+
+  test("should get the start time from a performance mark", () => {
+    const expectedStartTime = 1;
+    const entryName = `${buttonSessionID}_${phase}`;
+
+    window.performance.mark(entryName, { startTime: expectedStartTime });
+
+    const startTime = getStartTimeFromMark({ buttonSessionID, phase });
+
+    expect(startTime).toBe(expectedStartTime);
+  });
+});

--- a/src/lib/perceived-latency-instrumentation.test.js
+++ b/src/lib/perceived-latency-instrumentation.test.js
@@ -1,4 +1,7 @@
+/* @flow */
+/* eslint-disable compat/compat */
 import { beforeEach, describe, expect, vi } from "vitest";
+
 import { getStartTimeFromMark } from "./perceived-latency-instrumentation";
 
 describe("getStartTimeFromMark", () => {
@@ -34,3 +37,5 @@ describe("getStartTimeFromMark", () => {
     expect(startTime).toBe(expectedStartTime);
   });
 });
+
+/* eslint-enable compat/compat */

--- a/src/types.js
+++ b/src/types.js
@@ -77,3 +77,7 @@ export type LazyExport<T> = {|
 export type LazyProtectedExport<T> = {|
   __get__: () => ?T,
 |};
+
+export type PerformanceProp = {|
+  firstRenderStartTime: number,
+|};

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -93,6 +93,7 @@ import {
   getButtonSize,
   getButtonExperiments,
   getModal,
+  getPerformanceProp,
 } from "./util";
 
 export type ButtonsComponent = ZoidComponent<ButtonProps>;
@@ -875,6 +876,12 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
         type: "object",
         queryParam: false,
         required: false,
+      },
+
+      performance: {
+        type: "object",
+        queryParam: true,
+        value: ({ props }) => getPerformanceProp(props.buttonSessionID),
       },
 
       platform: {

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -28,7 +28,10 @@ import {
 import { FUNDING, FPTI_KEY } from "@paypal/sdk-constants/src";
 import { getRefinedFundingEligibility } from "@paypal/funding-components/src";
 
-import type { Experiment as EligibilityExperiment } from "../../types";
+import type {
+  Experiment as EligibilityExperiment,
+  PerformanceProp,
+} from "../../types";
 import { BUTTON_FLOW, BUTTON_SIZE, BUTTON_LAYOUT } from "../../constants";
 import type {
   ApplePaySessionConfigRequest,
@@ -39,6 +42,7 @@ import type {
 } from "../../ui/buttons/props";
 import { determineEligibleFunding } from "../../funding";
 import { BUTTON_SIZE_STYLE } from "../../ui/buttons/config";
+import { getStartTimeFromMark } from "../../lib/perceived-latency-instrumentation";
 
 type DetermineFlowOptions = {|
   createBillingAgreement: CreateBillingAgreement,
@@ -424,3 +428,15 @@ export const getModal: (
       });
   }
 });
+
+/**
+ * Creates an object containing any performance data we need to pass as a prop.
+ */
+export function getPerformanceProp(buttonSessionID: string): PerformanceProp {
+  return {
+    firstRenderStartTime: getStartTimeFromMark({
+      buttonSessionID,
+      phase: "buttons-first-render",
+    }),
+  };
+}

--- a/src/zoid/buttons/util.test.js
+++ b/src/zoid/buttons/util.test.js
@@ -1,6 +1,8 @@
 /* @flow */
+/* eslint-disable compat/compat */
 
-import { describe } from "vitest";
+import { describe, expect } from "vitest";
+
 import { getPerformanceProp } from "./util";
 
 describe("getPerformanceProp", () => {
@@ -28,3 +30,5 @@ describe("getPerformanceProp", () => {
     expect(performanceProp).toEqual({});
   });
 });
+
+/* eslint-enable compat/compat */

--- a/src/zoid/buttons/util.test.js
+++ b/src/zoid/buttons/util.test.js
@@ -1,0 +1,30 @@
+/* @flow */
+
+import { describe } from "vitest";
+import { getPerformanceProp } from "./util";
+
+describe("getPerformanceProp", () => {
+  const buttonSessionID = "button-session-id";
+
+  beforeEach(() => {
+    performance.clearMarks();
+  });
+
+  test("should create object containing performance data", () => {
+    const startTime = 1;
+    const performanceEntryName = `${buttonSessionID}_buttons-first-render`;
+
+    performance.mark(performanceEntryName, { startTime });
+
+    const perfomanceProp = getPerformanceProp(buttonSessionID);
+
+    expect(perfomanceProp).toEqual({
+      firstRenderStartTime: startTime,
+    });
+  });
+
+  test("firstRenderStartTime should be undefined if the performance entry name is not found", () => {
+    const performanceProp = getPerformanceProp(buttonSessionID);
+    expect(performanceProp).toEqual({});
+  });
+});

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -47,11 +47,11 @@ const CARD_FIELD_TYPE = {
 };
 
 type InstallmentsConfiguration = {|
-  financingCountryCode : string,
-  currencyCode : string,
-  billingCountryCode : string,
-  amount : string,
-  includeBuyerInstallments ? : boolean
+  financingCountryCode: string,
+  currencyCode: string,
+  billingCountryCode: string,
+  amount: string,
+  includeBuyerInstallments?: boolean,
 |};
 
 type CardFieldsProps = {|
@@ -108,10 +108,12 @@ type CardFieldsProps = {|
   hcfSessionID: string,
   partnerAttributionID: string,
   merchantID: $ReadOnlyArray<string>,
-  installments? : {|
-    onInstallmentsRequested : () => InstallmentsConfiguration | ZalgoPromise<InstallmentsConfiguration>,
-    onInstallmentsAvailable : (Object) => void,
-    onInstallmentsError? : (Object) => void
+  installments?: {|
+    onInstallmentsRequested: () =>
+      | InstallmentsConfiguration
+      | ZalgoPromise<InstallmentsConfiguration>,
+    onInstallmentsAvailable: (Object) => void,
+    onInstallmentsError?: (Object) => void,
   |},
 |};
 
@@ -439,7 +441,7 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
           installments: {
             type: "object",
             required: false,
-            value: ({ props }) => props.parent.props.installments
+            value: ({ props }) => props.parent.props.installments,
           },
         },
       });


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
**JIRA:** [DTPPCPSDK-2732](https://paypal.atlassian.net/browse/DTPPCPSDK-2732)

**_🆕  Added `performance` prop_** - This prop can be added to pass performance data from first render to second render.

**_😗 Added `firstRenderStartTime`_** - This will allow us to have better insight into the overall latency when loading the SDK.

### Reproduction Steps (if applicable)

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/40c3c8ba-21de-4164-ba8f-1b19bf1bfc54)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
