### PR TITLE
Pin jsx-pragmatic to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@krakenjs/beaver-logger": "^5.7.0",
     "@krakenjs/belter": "^2.0.0",
     "@krakenjs/cross-domain-utils": "^3.0.0",
-    "@krakenjs/jsx-pragmatic": "^3",
+    "@krakenjs/jsx-pragmatic": "3.0.0",
     "@krakenjs/post-robot": "^11.0.0",
     "@krakenjs/zalgo-promise": "^2.0.0",
     "@krakenjs/zoid": "^10.3.1",


### PR DESCRIPTION
### Description

We are observing karma tests failures with latest version of jsx-pragmatic.
Pin down the version to last stable version 3.0.0 

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
