### PR TITLE
Add getSDKToken for card fields for IC2B

### DIFF
--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -23,6 +23,7 @@ import {
   getPartnerAttributionID,
   getMerchantID,
   getUserIDToken,
+  getSDKToken,
   getClientMetadataID,
 } from "@paypal/sdk-client/src";
 import { getRefinedFundingEligibility } from "@paypal/funding-components/src";
@@ -436,6 +437,11 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
             default: getUserIDToken,
             required: false,
           },
+          sdkToken: {
+            type: "string",
+            default: getSDKToken,
+            required: false,
+          },
           installments: {
             type: "object",
             required: false,
@@ -717,6 +723,11 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
         userIDToken: {
           type: "string",
           default: getUserIDToken,
+          required: false,
+        },
+        sdkToken: {
+          type: "string",
+          default: getSDKToken,
           required: false,
         },
         installments: {


### PR DESCRIPTION
### Description
As a part of Installment and IC2B, Adding sdkToken in Card Props for making Calculated Financing Options call for getting Installment options . 

### Description
This change is to support Installments and IC2B (Installment Cost to Buyer) for SDK.

**HLD**: https://paypal.atlassian.net/wiki/spaces/NewInitiatives/pages/892253914/Installments+IC2B+in+PayPal+Card+Fields?focusedCommentId=911039343

**LLD**: 
https://paypal.atlassian.net/wiki/spaces/NewInitiatives/pages/937141479/MX+Installment+Cost+to+Buyer+IC2B+-+SDK+-+Checkout+LLD

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
Due to the high cost, only 40% of merchants enable installments, typically during promotions or seasonal campaigns. If a merchant does not enable installments, buyers do not get installment options, even if their credit card supports installments. This is addressed in IC2B (Installments Cost to Buyer), where the portion of the installments fee exceeding the maximum term selected by the merchant is shared with the buyer, allowing them to access all installment options.

https://paypal.atlassian.net/browse/DTTABASCO-2090

Reference PR for IC2B: https://github.com/paypal/paypal-checkout-components/pull/2432

### Screenshots (if applicable)
![Screenshot 2024-09-16 at 12 13 49 PM](https://github.com/user-attachments/assets/c39f466c-17ed-4404-8eca-26a4fba6eaf0)

### Dependent Changes (if applicable)
Smart component node web: https://github.paypal.com/Checkout-R/smartcomponentnodeweb/pull/765/
Needs to be updated in clientsdknodeweb

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->
❤️ Thank you!