### PR TITLE
Feat: Add Amount to Card Fields for Improved BIN API Requests

### DIFF
--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -16,6 +16,7 @@ import {
   getClientID,
   getDebug,
   getCurrency,
+  getAmount,
   getIntent,
   getCommit,
   getVault,
@@ -712,6 +713,12 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
           type: "string",
           queryParam: true,
           value: getCurrency,
+        },
+
+        amount: {
+          type: "string",
+          queryParam: true,
+          value: getAmount,
         },
 
         intent: {

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -717,7 +717,7 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
 
         amount: {
           type: "string",
-          queryParam: true,
+          queryParam: false,
           value: getAmount,
         },
 

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -16,7 +16,6 @@ import {
   getClientID,
   getDebug,
   getCurrency,
-  getAmount,
   getIntent,
   getCommit,
   getVault,
@@ -296,6 +295,12 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
             queryParam: true,
             allowDelegate: true,
             value: ({ props }) => props.parent.props.locale,
+          },
+
+          amount: {
+            type: "object",
+            value: ({ props }) => props.parent.props.amount,
+            required: false,
           },
 
           onApprove: {
@@ -713,12 +718,6 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
           type: "string",
           queryParam: true,
           value: getCurrency,
-        },
-
-        amount: {
-          type: "string",
-          queryParam: false,
-          value: getAmount,
         },
 
         intent: {

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -645,6 +645,12 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
           value: getLocale,
         },
 
+        amount: {
+          type: "object",
+          queryParam: false,
+          required: false,
+        },
+
         onApprove: {
           type: "function",
           required: false,

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -77,6 +77,7 @@ type CardFieldsProps = {|
   fundingEligibility: FundingEligibilityType,
   disableCard?: $ReadOnlyArray<$Values<typeof CARD>>,
   currency: $Values<typeof CURRENCY>,
+  amount: string,
   intent: $Values<typeof INTENT>,
   commit: boolean,
   vault: boolean,

--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -647,7 +647,6 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
 
         amount: {
           type: "object",
-          queryParam: false,
           required: false,
         },
 


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

This change adds support for an amount prop in the Card Fields component, enabling more accurate BIN API requests. The amount object, containing currency and value, is passed to the card-fields component and subsequently used in the BIN API request data. When unavailable, the value defaults to 0. This enhancement eliminates the use of dummy values, improving the precision of BIN lookups.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

https://paypal.atlassian.net/browse/DTPPCPSDK-2863

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
