### PR TITLE
add validations for isEligible merchant payload

### DIFF
--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -4,7 +4,7 @@
 import { type LoggerType } from "@krakenjs/beaver-logger/src";
 import { type ZoidComponent } from "@krakenjs/zoid/src";
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
-import { FPTI_KEY } from "@paypal/sdk-constants/src";
+import { FPTI_KEY, CURRENCY } from "@paypal/sdk-constants/src";
 import { createAccessToken } from "@paypal/sdk-client/src";
 
 import { PAYMENT_3DS_VERIFICATION } from "../constants/api";
@@ -93,6 +93,8 @@ export class ThreeDomainSecureComponent {
   }
 
   async isEligible(merchantPayload: MerchantPayloadData): Promise<boolean> {
+    this.validateMerchantPayload(merchantPayload);
+
     const data = parseMerchantPayload({ merchantPayload });
     this.fastlaneNonce = merchantPayload.nonce;
 
@@ -201,6 +203,49 @@ export class ThreeDomainSecureComponent {
         instance.close();
       });
     });
+  }
+
+  validateMerchantPayload(merchantPayload: MerchantPayloadData): void {
+    // TODO we have a ticket to standardize client-side validations
+    // eslint-disable-next-line flowtype/no-weak-types
+    const isRequired = (value: any) => Boolean(value);
+    // eslint-disable-next-line flowtype/no-weak-types
+    const isString = (value: any) => typeof value === "string";
+
+    const validations = {
+      amount: {
+        test: [isString, isRequired],
+        message: (value) =>
+          `[amount] is required and must be a string. received: ${value}`,
+      },
+      currency: {
+        test: [(value) => value in CURRENCY, isRequired],
+        message: (value) =>
+          `[currency] is required and must be a valid currency. received: ${value}`,
+      },
+      nonce: {
+        test: [isString, isRequired],
+        message: (value) =>
+          `[nonce] is required and must be a string. received: ${value}`,
+      },
+    };
+
+    const errors = [];
+
+    Object.entries(merchantPayload).forEach(([key, value]) => {
+      if (key in validations) {
+        if (!validations[key]?.test?.every((validation) => validation(value))) {
+          errors.push(validations[key]?.message(value));
+        }
+      }
+    });
+
+    if (errors.length) {
+      const joinedErrors = errors.join("\n");
+
+      this.logger.warn(joinedErrors);
+      throw new ValidationError(joinedErrors);
+    }
   }
 
   updateNonceWith3dsData(threeDSRefID: string): Promise<GqlResponse> {


### PR DESCRIPTION
### Description

Adds validations for `amount`, `currency`, and `nonce` to 3DS component's `isEligible` method.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
