### PR TITLE
refactor: update component name, match success state response

### DIFF
--- a/src/three-domain-secure/component.jsx
+++ b/src/three-domain-secure/component.jsx
@@ -17,7 +17,7 @@ import type {
   ThreeDSResponse,
   TDSProps,
 } from "./types";
-import { getFastlaneThreeDS } from "./utils";
+import { getThreeDS } from "./utils";
 import type { GraphQLClient, RestClient } from "./api";
 
 const parseSdkConfig = ({ sdkConfig, logger }): SdkConfig => {
@@ -110,7 +110,7 @@ export class ThreeDomainSecureComponent {
           (link) => link.rel === "payer-action"
         ).href;
         responseStatus = true;
-        this.threeDSIframe = getFastlaneThreeDS();
+        this.threeDSIframe = getThreeDS();
       }
       return responseStatus;
     } catch (error) {
@@ -151,7 +151,7 @@ export class ThreeDomainSecureComponent {
           // Helios returns a boolen parameter: "success"
           // It will be true for all cases where liability is shifted to merchant
           // and false for downstream failures and errors
-          authenticationState = success ? "success" : "errored";
+          authenticationState = success ? "succeeded" : "errored";
           liabilityShift = liability_shift ? liability_shift : "false";
 
           // call BT mutation to update fastlaneNonce with 3ds data

--- a/src/three-domain-secure/component.test.js
+++ b/src/three-domain-secure/component.test.js
@@ -12,7 +12,7 @@ const defaultSdkConfig = {
   authenticationToken: "sdk-client-token",
 };
 vi.mock("./utils", () => ({
-  getFastlaneThreeDS: vi.fn(() => {
+  getThreeDS: vi.fn(() => {
     return vi.fn(() => ({
       render: vi.fn().mockResolvedValue({}),
       close: vi.fn(),

--- a/src/three-domain-secure/interface.js
+++ b/src/three-domain-secure/interface.js
@@ -16,13 +16,13 @@ import {
   type ThreeDomainSecureComponentInterface,
 } from "./component";
 import { GraphQLClient, RestClient } from "./api";
-import { getFastlaneThreeDS } from "./utils";
+import { getThreeDS } from "./utils";
 
 const BRAINTREE_PROD = "https://payments.braintree-api.com";
 const BRAINTREE_SANDBOX = "https://payments.sandbox.braintree-api.com";
 
 export function setup() {
-  getFastlaneThreeDS();
+  getThreeDS();
 }
 export function destroy(err?: mixed) {
   zoidDestroy(err);

--- a/src/three-domain-secure/interface.test.js
+++ b/src/three-domain-secure/interface.test.js
@@ -11,7 +11,7 @@ import { destroy as zoidDestroy } from "@krakenjs/zoid/src";
 
 import { ThreeDomainSecureComponent } from "./component";
 import { GraphQLClient, RestClient } from "./api";
-import { getFastlaneThreeDS } from "./utils";
+import { getThreeDS } from "./utils";
 import { setup, destroy, ThreeDomainSecureClient } from "./interface";
 
 vi.mock("@paypal/sdk-client/src");
@@ -23,7 +23,7 @@ vi.mock("./utils");
 describe("ThreeDomainSecure interface", () => {
   it("should setup and destroy", () => {
     setup();
-    expect(getFastlaneThreeDS).toHaveBeenCalledTimes(1);
+    expect(getThreeDS).toHaveBeenCalledTimes(1);
 
     const err = new Error("test error");
     destroy(err);

--- a/src/three-domain-secure/utils.jsx
+++ b/src/three-domain-secure/utils.jsx
@@ -18,8 +18,8 @@ import type { TDSProps } from "./types";
 
 export type TDSComponent = ZoidComponent<TDSProps>;
 
-export function getFastlaneThreeDS(): TDSComponent {
-  return inlineMemoize(getFastlaneThreeDS, () => {
+export function getThreeDS(): TDSComponent {
+  return inlineMemoize(getThreeDS, () => {
     const component = create({
       tag: "fastlane-threeds",
       url: ({ props }) => props.payerActionUrl,

--- a/src/three-domain-secure/utils.test.js
+++ b/src/three-domain-secure/utils.test.js
@@ -6,7 +6,7 @@ import { noop } from "@krakenjs/belter/src";
 import { describe, expect, vi } from "vitest";
 import { getEnv } from "@paypal/sdk-client/src";
 
-import { getFastlaneThreeDS } from "./utils";
+import { getThreeDS } from "./utils";
 
 vi.mock("@paypal/sdk-client/src");
 
@@ -27,7 +27,7 @@ describe("Three Domain Secure Utils", () => {
       type: "zoidComponent",
     }));
 
-    const fastlaneComponent = getFastlaneThreeDS();
+    const fastlaneComponent = getThreeDS();
     expect(fastlaneComponent).toBeDefined();
     // expect(createMock).toHaveBeenCalledTimes(1);
   });
@@ -43,7 +43,7 @@ describe("Three Domain Secure Utils", () => {
       type: "zoidComponent",
     }));
 
-    getFastlaneThreeDS();
+    getThreeDS();
 
     expect(window.xchild).toBeDefined();
     expect(window.xchild).toEqual({


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
- The ThreeDS Zoid component does not have any fastlane related logic, so a generic name is more suitable.
- No breaking change
- Fixes the response state from ~`success`~ to `succeeded` to match the integration guide pattern
### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
