### PR TITLE
Errors with strict CSP for inline styling, nonces added to <style>.

### DIFF
--- a/src/funding/paypal/template.jsx
+++ b/src/funding/paypal/template.jsx
@@ -7,6 +7,7 @@ import {
   Style,
   type ChildType,
 } from "@krakenjs/jsx-pragmatic/src";
+import { getCSPNonce } from "@paypal/sdk-client/src";
 import {
   PPLogoExternalImage,
   PPLogoInlineSVG,
@@ -271,8 +272,10 @@ export function WalletLabelOld(opts: WalletLabelOptions): ?ChildType {
     );
   }
 
+  const cspNonce = getCSPNonce();
+
   return (
-    <Style css={css}>
+    <Style nonce={cspNonce} css={css}>
       <div class="wallet-label">
         <div class="paypal-mark">
           {__WEB__ ? (
@@ -472,8 +475,10 @@ export function WalletLabel(opts: WalletLabelOptions): ?ChildType {
     attrs[ATTRIBUTE.PAY_NOW] = true;
   }
 
+  const cspNonce = getCSPNonce();
+
   return (
-    <Style css={css}>
+    <Style nonce={cspNonce} css={css}>
       <div class="wallet-label-new" {...attrs}>
         {branded ? (
           <div class="paypal-mark">

--- a/src/funding/venmo/template.jsx
+++ b/src/funding/venmo/template.jsx
@@ -1,6 +1,7 @@
 /* @flow */
 /** @jsx node */
 import { node, Style, type ChildType } from "@krakenjs/jsx-pragmatic/src";
+import { getCSPNonce } from "@paypal/sdk-client/src";
 import {
   VenmoLogoExternalImage,
   VenmoLogoInlineSVG,
@@ -32,8 +33,10 @@ export function WalletLabel({ ...props }: WalletLabelOptions): ChildType {
     label = instrument.label;
   }
 
+  const cspNonce = getCSPNonce();
+
   return (
-    <Style css={css}>
+    <Style nonce={cspNonce} css={css}>
       <div class="wallet-label-venmo">
         <div class="divider">|</div>
         {logo && (

--- a/src/ui/text/text.jsx
+++ b/src/ui/text/text.jsx
@@ -7,6 +7,7 @@ import {
   type ChildType,
   type NullableChildrenType,
 } from "@krakenjs/jsx-pragmatic/src";
+import { getCSPNonce } from "@paypal/sdk-client/src";
 
 import { CLASS, TEXT_COLOR } from "../../constants";
 
@@ -49,8 +50,10 @@ export function PlaceHolder({
   chars,
   color = TEXT_COLOR.WHITE,
 }: PlaceHolderProps): ChildType {
+  const cspNonce = getCSPNonce();
+
   return (
-    <Style css={css}>
+    <Style nonce={cspNonce} css={css}>
       <div class={["placeholder", `color-${color}`].join(" ")}>
         {new Array(chars).fill("x").join("")}
       </div>


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->
This PR is in response to a LI where a merchant was encountering inline-styling errors with their CSP and their CSP does not allow for the use of 'unsafe-inline'

To address these issues, a nonce was added to the <style> tags that were throwing these errors. 

LI: https://paypal.atlassian.net/browse/LI-84820

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
Ticket: https://paypal.atlassian.net/browse/DTPPCPSDK-3080

Not all styling had a nonce with it and it was causing errors with a merchant's Content Security Policy.

### Reproduction Steps (if applicable)
Test bed to reproduce error is provided in the comments under the LI link above.

Example error:  'Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'self' 'nonce-...'

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
