### PR TITLE
Enable eager order creation and render buttons in disabled state

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -67,6 +67,7 @@ export type Experiment = {|
   isPaypalRebrandEnabled?: boolean,
   defaultBlueButtonColor?: $Values<typeof BUTTON_COLOR>,
   venmoEnableWebOnNonNativeBrowser?: boolean,
+  spbEagerOrderCreation?: boolean,
 |};
 
 export type Requires = {|

--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -71,6 +71,7 @@ type IndividualButtonProps = {|
   merchantFundingSource: ?$Values<typeof FUNDING>,
   instrument: ?WalletInstrument,
   showPayLabel: boolean,
+  showLoadingSpinner?: boolean,
 |};
 
 export function Button({
@@ -95,6 +96,7 @@ export function Button({
   tagline,
   userIDToken,
   vault,
+  showLoadingSpinner = false,
 }: IndividualButtonProps): ElementNode {
   const { layout, shape, borderRadius } = style;
   const { isPaypalRebrandEnabled, defaultBlueButtonColor } = experiment;
@@ -307,6 +309,7 @@ export function Button({
         }}
         class={[
           CLASS.BUTTON,
+          `${showLoadingSpinner ? CLASS.LOADING : ""}`,
           `${CLASS.NUMBER}-${i}`,
           `${CLASS.LAYOUT}-${layout}`,
           `${CLASS.NUMBER}-${

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -127,6 +127,7 @@ function getWalletInstruments({
 type ButtonsProps = ButtonPropsInputs & {|
   onClick?: Function,
   wallet?: ?Wallet,
+  showLoadingSpinner?: boolean,
 |};
 
 export function validateButtonProps(props: ButtonPropsInputs) {
@@ -134,7 +135,7 @@ export function validateButtonProps(props: ButtonPropsInputs) {
 }
 
 export function Buttons(props: ButtonsProps): ElementNode {
-  const { onClick = noop } = props;
+  const { onClick = noop, showLoadingSpinner = false } = props;
   const {
     applePaySupport,
     buyerCountry,
@@ -289,6 +290,7 @@ export function Buttons(props: ButtonsProps): ElementNode {
           vault={vault}
           instrument={instruments[source]}
           showPayLabel={showPayLabel}
+          showLoadingSpinner={showLoadingSpinner}
         />
       ))}
 

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -512,7 +512,7 @@ type HidePayPalAppSwitchOverlay = {|
 
 export type ButtonProps = {|
   // app switch properties
-  appSwitchWhenAvailable: string,
+  appSwitchWhenAvailable: boolean,
   listenForHashChanges: () => void,
   removeListenerForHashChanges: () => void,
   // Not passed to child iframe

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -102,6 +102,7 @@ import {
   getButtonExperiments,
   getModal,
   sendPostRobotMessageToButtonIframe,
+  isEagerOrderCreationEnabled,
 } from "./util";
 
 export type ButtonsComponent = ZoidComponent<
@@ -611,6 +612,12 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
         value: ({ props }) => {
           return props?.displayOnly || [];
         },
+      },
+
+      eagerOrderCreation: {
+        type: "boolean",
+        queryParam: true,
+        value: ({ props }) => isEagerOrderCreationEnabled(props),
       },
 
       enableFunding: {

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -617,7 +617,8 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
       eagerOrderCreation: {
         type: "boolean",
         queryParam: true,
-        value: ({ props }) => isEagerOrderCreationEnabled(props),
+        value: ({ props }) =>
+          isEagerOrderCreationEnabled(props.appSwitchWhenAvailable),
       },
 
       enableFunding: {

--- a/src/zoid/buttons/prerender.jsx
+++ b/src/zoid/buttons/prerender.jsx
@@ -19,14 +19,12 @@ import type { ZoidProps } from "@krakenjs/zoid/src";
 import { DEFAULT_POPUP_SIZE } from "../checkout";
 import { Buttons } from "../../ui";
 import { type ButtonProps } from "../../ui/buttons/props";
-import type { Experiment } from "../../types";
 
 import { isEagerOrderCreationEnabled } from "./util";
 
 type PrerenderedButtonsProps = {|
   nonce: ?string,
   props: ZoidProps<ButtonProps>,
-  experiment: Experiment,
   onRenderCheckout: ({|
     win?: CrossDomainWindowType,
     fundingSource: $Values<typeof FUNDING>,
@@ -40,7 +38,9 @@ export function PrerenderedButtons({
   onRenderCheckout,
   props,
 }: PrerenderedButtonsProps): ChildType {
-  const eagerOrderCreation = isEagerOrderCreationEnabled(props);
+  const eagerOrderCreation = isEagerOrderCreationEnabled(
+    props.appSwitchWhenAvailable
+  );
   let win;
   const handleClick = (
     // eslint-disable-next-line no-undef

--- a/src/zoid/buttons/prerender.jsx
+++ b/src/zoid/buttons/prerender.jsx
@@ -19,10 +19,14 @@ import type { ZoidProps } from "@krakenjs/zoid/src";
 import { DEFAULT_POPUP_SIZE } from "../checkout";
 import { Buttons } from "../../ui";
 import { type ButtonProps } from "../../ui/buttons/props";
+import type { Experiment } from "../../types";
+
+import { isEagerOrderCreationEnabled } from "./util";
 
 type PrerenderedButtonsProps = {|
   nonce: ?string,
   props: ZoidProps<ButtonProps>,
+  experiment: Experiment,
   onRenderCheckout: ({|
     win?: CrossDomainWindowType,
     fundingSource: $Values<typeof FUNDING>,
@@ -35,7 +39,9 @@ export function PrerenderedButtons({
   nonce,
   onRenderCheckout,
   props,
+  experiment,
 }: PrerenderedButtonsProps): ChildType {
+  const eagerOrderCreation = isEagerOrderCreationEnabled(props, experiment);
   let win;
   const handleClick = (
     // eslint-disable-next-line no-undef
@@ -62,7 +68,11 @@ export function PrerenderedButtons({
         [FPTI_KEY.CHOSEN_FUNDING]: fundingSource,
       });
 
-    if (fundingSource === FUNDING.VENMO || fundingSource === FUNDING.APPLEPAY) {
+    if (
+      eagerOrderCreation ||
+      fundingSource === FUNDING.VENMO ||
+      fundingSource === FUNDING.APPLEPAY
+    ) {
       // wait for button to load
     } else if (supportsPopups() && !props.merchantRequestedPopupsDisabled) {
       // remember the popup window to prevent showing a new popup window on every click in the prerender state

--- a/src/zoid/buttons/prerender.jsx
+++ b/src/zoid/buttons/prerender.jsx
@@ -41,7 +41,7 @@ export function PrerenderedButtons({
   props,
   experiment,
 }: PrerenderedButtonsProps): ChildType {
-  const eagerOrderCreation = isEagerOrderCreationEnabled(props, experiment);
+  const eagerOrderCreation = isEagerOrderCreationEnabled({ props, experiment });
   let win;
   const handleClick = (
     // eslint-disable-next-line no-undef

--- a/src/zoid/buttons/prerender.jsx
+++ b/src/zoid/buttons/prerender.jsx
@@ -39,9 +39,8 @@ export function PrerenderedButtons({
   nonce,
   onRenderCheckout,
   props,
-  experiment,
 }: PrerenderedButtonsProps): ChildType {
-  const eagerOrderCreation = isEagerOrderCreationEnabled({ props, experiment });
+  const eagerOrderCreation = isEagerOrderCreationEnabled(props);
   let win;
   const handleClick = (
     // eslint-disable-next-line no-undef
@@ -58,6 +57,7 @@ export function PrerenderedButtons({
       .info("paypal_js_sdk_v5_button_prerender_click", {
         fundingSource,
         card,
+        eagerOrderCreation: String(eagerOrderCreation),
         buttonsSessionID: props.buttonSessionID,
       })
       .track({
@@ -68,11 +68,12 @@ export function PrerenderedButtons({
         [FPTI_KEY.CHOSEN_FUNDING]: fundingSource,
       });
 
-    if (
-      eagerOrderCreation ||
-      fundingSource === FUNDING.VENMO ||
-      fundingSource === FUNDING.APPLEPAY
-    ) {
+    if (eagerOrderCreation) {
+      // Pass this click. The buttons are rendered in disabled state
+      return;
+    }
+
+    if (fundingSource === FUNDING.VENMO || fundingSource === FUNDING.APPLEPAY) {
       // wait for button to load
     } else if (supportsPopups() && !props.merchantRequestedPopupsDisabled) {
       // remember the popup window to prevent showing a new popup window on every click in the prerender state

--- a/src/zoid/buttons/prerender.jsx
+++ b/src/zoid/buttons/prerender.jsx
@@ -107,7 +107,11 @@ export function PrerenderedButtons({
     <html>
       <body>
         {/* $FlowFixMe */}
-        <Buttons {...props} onClick={handleClick} />
+        <Buttons
+          {...props}
+          onClick={handleClick}
+          showLoadingSpinner={eagerOrderCreation}
+        />
       </body>
     </html>
   );

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -44,7 +44,6 @@ import type {
 } from "../../ui/buttons/props";
 import { determineEligibleFunding } from "../../funding";
 import { BUTTON_SIZE_STYLE } from "../../ui/buttons/config";
-import type { ZoidProps } from "@krakenjs/zoid/src";
 
 type DetermineFlowOptions = {|
   createBillingAgreement: CreateBillingAgreement,
@@ -459,13 +458,13 @@ export const sendPostRobotMessageToButtonIframe = ({
 };
 
 export const isEagerOrderCreationEnabled = (
-  props: ZoidProps<ButtonProps>
+  appSwitchWhenAvailable: boolean
 ): boolean => {
   const experiment = getButtonExperiments();
   return Boolean(
     !isWebView() &&
       isDevice() &&
-      props.appSwitchWhenAvailable &&
+      appSwitchWhenAvailable &&
       experiment.spbEagerOrderCreation
   );
 };

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -457,30 +457,15 @@ export const sendPostRobotMessageToButtonIframe = ({
     }
   }
 };
-type EagerOrderCreationEligibilityInput = {|
-  props: ZoidProps<ButtonProps>,
-  experiment: Experiment,
-|};
 
-export const isEagerOrderCreationEnabled = ({
-  props,
-  experiment,
-}: EagerOrderCreationEligibilityInput): boolean =>
-  memoize(() => {
-    const result =
-      !isWebView() &&
+export const isEagerOrderCreationEnabled = (
+  props: ZoidProps<ButtonProps>
+): boolean => {
+  const experiment = getButtonExperiments();
+  return Boolean(
+    !isWebView() &&
       isDevice() &&
       props.appSwitchWhenAvailable &&
-      experiment.spbEagerOrderCreation;
-
-    getLogger().info("button_eager_order_creation_enabled", {
-      buttonSessionID: props.buttonSessionID,
-      eagerOrderEnabled: result,
-      webview: isWebView(),
-      device: isDevice(),
-      appSwitchWhenAvailable: props.appSwitchWhenAvailable,
-      spbEagerOrderCreationExperiment: experiment.spbEagerOrderCreation,
-    });
-
-    return result;
-  });
+      experiment.spbEagerOrderCreation
+  );
+};

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -8,6 +8,7 @@ import {
   isSafari,
   type Experiment,
   isDevice,
+  isWebView,
   isTablet,
   getElement,
   isStandAlone,
@@ -43,6 +44,7 @@ import type {
 } from "../../ui/buttons/props";
 import { determineEligibleFunding } from "../../funding";
 import { BUTTON_SIZE_STYLE } from "../../ui/buttons/config";
+import type { ZoidProps } from "@krakenjs/zoid/src";
 
 type DetermineFlowOptions = {|
   createBillingAgreement: CreateBillingAgreement,
@@ -455,3 +457,30 @@ export const sendPostRobotMessageToButtonIframe = ({
     }
   }
 };
+type EagerOrderCreationEligibilityInput = {|
+  props: ZoidProps<ButtonProps>,
+  experiment: Experiment,
+|};
+
+export const isEagerOrderCreationEnabled = ({
+  props,
+  experiment,
+}: EagerOrderCreationEligibilityInput): boolean =>
+  memoize(() => {
+    const result =
+      !isWebView() &&
+      isDevice() &&
+      props.appSwitchWhenAvailable &&
+      experiment.spbEagerOrderCreation;
+
+    getLogger().info("button_eager_order_creation_enabled", {
+      buttonSessionID: props.buttonSessionID,
+      eagerOrderEnabled: result,
+      webview: isWebView(),
+      device: isDevice(),
+      appSwitchWhenAvailable: props.appSwitchWhenAvailable,
+      spbEagerOrderCreationExperiment: experiment.spbEagerOrderCreation,
+    });
+
+    return result;
+  });


### PR DESCRIPTION
### Description

* Render buttons in a disabled state during first render if the experiment returns eager order creation is enabled.
* We will be sending a separate PR for test cases. 

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
