### PR TITLE
Updated interactive state colors for rebrand light blue hover and pre…

### DIFF
--- a/src/constants/class.js
+++ b/src/constants/class.js
@@ -6,6 +6,7 @@ export const CLASS = {
     ("paypal-autoresize-container": "paypal-autoresize-container"),
   BUTTON_ROW: ("paypal-button-row": "paypal-button-row"),
   BUTTON: ("paypal-button": "paypal-button"),
+  BUTTON_REBRAND: ("paypal-button-rebrand": "paypal-button-rebrand"),
   BUTTON_LABEL:
     ("paypal-button-label-container": "paypal-button-label-container"),
   LOGO_PP: ("paypal-logo-pp": "paypal-logo-pp"),

--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -302,6 +302,7 @@ export function Button({
         }}
         class={[
           CLASS.BUTTON,
+          `${shouldApplyRebrandedStyles ? CLASS.BUTTON_REBRAND : ""}`,
           `${showLoadingSpinner ? CLASS.LOADING : ""}`,
           `${CLASS.NUMBER}-${i}`,
           `${CLASS.LAYOUT}-${layout}`,

--- a/src/ui/buttons/styles/color.js
+++ b/src/ui/buttons/styles/color.js
@@ -32,14 +32,14 @@ export const buttonColorStyle = `
 
     @media (hover:hover) {
         .${CLASS.BUTTON}.${CLASS.COLOR}-${BUTTON_COLOR.REBRAND_BLUE}:hover {
-            background: #008CFF;
+            background: #54B4E0;
             overflow: inherit;
         }
     }
     
     @media (hover:hover) {
         .${CLASS.BUTTON}.${CLASS.COLOR}-${BUTTON_COLOR.REBRAND_BLUE}:active {
-            background: #E3F7FF;
+            background: #3DB5FF;
             overflow: inherit;
         }
     }

--- a/src/ui/buttons/styles/labels.js
+++ b/src/ui/buttons/styles/labels.js
@@ -57,11 +57,17 @@ export const labelStyle = `
     }
 
     .${CLASS.BUTTON_LABEL} {
-        font-family: PayPal Pro Book, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
+        font-family: system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
         font-weight: 500;
     }
 
-    div[data-funding-source=venmo] .${CLASS.BUTTON_LABEL} {
+    .${CLASS.BUTTON_REBRAND} .${CLASS.BUTTON_LABEL} {
+        font-family: PayPal Pro Book, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
+    }
+
+    .${CLASS.BUTTON_REBRAND} div[data-funding-source=venmo] .${
+  CLASS.BUTTON_LABEL
+} {
         font-family: Scto Grotesk A, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
     }
 `;


### PR DESCRIPTION
…ssed/active states. Updated label font family to system for legacy buttons

### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

Need to update the interactive state colors for the rebrand. 

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

Ticket: https://paypal.atlassian.net/browse/DTPPCPSDK-3119

### Reproduction Steps (if applicable)

### Screenshots (if applicable)
Hover:
![Screenshot 2025-05-20 at 5 12 11 PM](https://github.com/user-attachments/assets/7ca5e5f9-eaa9-4241-8b8e-ea38f2bb3589)

Active/Pressed:
![Screenshot 2025-05-20 at 5 12 25 PM](https://github.com/user-attachments/assets/ffeb24c7-a18a-4c76-be04-dd1288a83864)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
