### PR TITLE
Add isButtonColorABTestMerchant to style prop

### DIFF
--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -330,6 +330,7 @@ export type ButtonStyle = {|
   disableMaxHeight?: boolean,
   borderRadius?: number,
   shouldApplyRebrandedStyles: boolean,
+  isButtonColorABTestMerchant: boolean,
 |};
 
 export type ButtonStyleInputs = {|
@@ -516,6 +517,7 @@ type HidePayPalAppSwitchOverlay = {|
 type ButtonColor = {|
   shouldApplyRebrandedStyles: boolean,
   color: $Values<typeof BUTTON_COLOR>,
+  isButtonColorABTestMerchant: boolean,
 |};
 
 type ColorABTestStorage = {|
@@ -738,6 +740,7 @@ export function determineRandomButtonColor({
   return {
     shouldApplyRebrandedStyles,
     color: buttonColor,
+    isButtonColorABTestMerchant: true,
   };
 }
 
@@ -876,6 +879,7 @@ export function getColorForFullRedesign({
   return {
     color: buttonColor,
     shouldApplyRebrandedStyles: true,
+    isButtonColorABTestMerchant: false,
   };
 }
 
@@ -953,6 +957,7 @@ export function getButtonColor({
           fundingSource,
           style,
         }),
+        isButtonColorABTestMerchant: false,
       };
   }
 }
@@ -971,7 +976,8 @@ export function normalizeButtonStyle(
 
   props = props || getDefaultButtonPropsInput();
   const { fundingSource, buttonColor } = props;
-  const { color, shouldApplyRebrandedStyles } = buttonColor || {};
+  const { color, shouldApplyRebrandedStyles, isButtonColorABTestMerchant } =
+    buttonColor || {};
 
   const FUNDING_CONFIG = getFundingConfig();
   const fundingConfig =
@@ -1118,6 +1124,7 @@ export function normalizeButtonStyle(
     disableMaxHeight,
     borderRadius,
     shouldApplyRebrandedStyles,
+    isButtonColorABTestMerchant,
   };
 }
 


### PR DESCRIPTION
### Description

This will allows us to track conversion and CTR for merchants enrolled in the button color A/B test
https://paypal.atlassian.net/browse/DTPPCPSDK-3184

We will then be able to create CTR and Conversion DD Charts for the merchants enrolled in the A/B test per button color

[CTR example Dashboard](https://paypal-prod.datadoghq.com/dashboard/5ut-fm5-pu4/paypal-web-sdk?fromUser=false&refresh_mode=paused&from_ts=1748408400000&to_ts=1748977080000&live=false&tile_focus=4189356090688772)
[Conversion Example Dashboard](https://paypal-prod.datadoghq.com/dashboard/5ut-fm5-pu4/paypal-web-sdk?fromUser=false&refresh_mode=paused&from_ts=1748408400000&to_ts=1748977080000&live=false&tile_focus=3392417976944362)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
