### PR TITLE
added data-shopper-session-id as a prop so it can logged in scnw

### DIFF
--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -477,6 +477,7 @@ export type RenderButtonProps = {|
   personalization: ?Personalization,
   clientAccessToken: ?string,
   customerId: ?string,
+  shopperSessionId?: string,
   content?: ContentType,
   flow: $Values<typeof BUTTON_FLOW>,
   experiment: Experiment,
@@ -604,6 +605,7 @@ export type ButtonProps = {|
   sessionID: string,
   buttonLocation: string,
   buttonSessionID: string,
+  shopperSessionId?: string,
   onShippingChange: ?OnShippingChange,
   onShippingAddressChange: ?OnShippingAddressChange,
   onShippingOptionsChange: ?OnShippingOptionsChange,
@@ -650,6 +652,7 @@ export type ButtonPropsInputs = {
   remember?: $PropertyType<ButtonProps, "remember"> | void,
   sessionID?: $PropertyType<ButtonProps, "sessionID"> | void,
   buttonSessionID?: $PropertyType<ButtonProps, "buttonSessionID"> | void,
+  shopperSessionId?: string,
   nonce: string,
   enableFunding?: $ReadOnlyArray<?$Values<typeof FUNDING>>,
   components: $ReadOnlyArray<$Values<typeof COMPONENTS>>,
@@ -1267,6 +1270,7 @@ export function normalizeButtonProps(
     message,
     messageMarkup,
     renderedButtons,
+    shopperSessionId,
   } = props;
 
   const { country, lang } = locale;
@@ -1362,6 +1366,7 @@ export function normalizeButtonProps(
     vault,
     userIDToken,
     customerId,
+    shopperSessionId,
     applePay,
     applePaySupport,
     supportsPopups,

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -45,6 +45,7 @@ import {
   isPayPalTrustedUrl,
   getSDKInitTime,
   getSDKToken,
+  getShopperSessionId,
 } from "@paypal/sdk-client/src";
 import {
   rememberFunding,
@@ -1176,6 +1177,12 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
       sessionState: {
         type: "object",
         value: () => sessionState,
+      },
+
+      shopperSessionId: {
+        type: "string",
+        required: false,
+        value: getShopperSessionId,
       },
 
       getShopperInsightsUsed: {


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

SDK needs to pass the Merchant passed data-shopper-session-id to the FPTI logs for process_button_load event.

Ticket: https://paypal.atlassian.net/browse/DTPPCPSDK-3229

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
