### PR TITLE
height should be set if it is user provided

### DIFF
--- a/src/ui/buttons/styles/button.js
+++ b/src/ui/buttons/styles/button.js
@@ -189,7 +189,6 @@ export const buttonRebrandStyle = `
         display: flex;
         align-items: center;
         line-height: 1.1;
-        flex-shrink: 1;
         min-width: 0;
     }
 

--- a/src/ui/buttons/styles/responsive.js
+++ b/src/ui/buttons/styles/responsive.js
@@ -520,7 +520,7 @@ const generateRebrandedButtonSizeStyles = ({
           }
 
           .${CLASS.BUTTON_ROW} {
-              height: ${defaultHeight}px;
+              height: ${height || defaultHeight}px;
               vertical-align: top;
               max-height: ${height || maxHeight}px;
           }

--- a/src/ui/buttons/styles/responsive.js
+++ b/src/ui/buttons/styles/responsive.js
@@ -520,9 +520,9 @@ const generateRebrandedButtonSizeStyles = ({
           }
 
           .${CLASS.BUTTON_ROW} {
-              height: ${height || defaultHeight}px;
+              ${disableMaxHeight ? "" : `height: ${height || defaultHeight}px;`}
               vertical-align: top;
-              max-height: ${height || maxHeight}px;
+              ${disableMaxHeight ? "" : `max-height: ${height || maxHeight}px;`}
           }
 
           .${CLASS.BUTTON_REBRAND} > .${CLASS.BUTTON_LABEL} {


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

https://paypal.atlassian.net/browse/DTPPCPSDK-3125

Fix: If user sets height, button should render at that height.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)
<img width="835" height="436" alt="Screenshot 2025-09-04 at 4 35 16 PM" src="https://github.com/user-attachments/assets/0f316342-0155-454c-bc55-89ffc22e20a5" />

<img width="857" height="432" alt="Screenshot 2025-09-04 at 4 35 42 PM" src="https://github.com/user-attachments/assets/233c6792-d89c-4d89-8454-9f43dc5e7b1d" />

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
