### PR TITLE
Add sdkSource to button props

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -30,6 +30,7 @@ import {
   getAPIStageHost,
   getPayPalDomain,
   getUserIDToken,
+  getSDKIntegrationSource,
   getClientMetadataID,
   getAmount,
   getEnableFunding,
@@ -1297,6 +1298,17 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
         required: false,
         queryParam: getEnv() !== ENV.LOCAL && getEnv() !== ENV.STAGE,
         bodyParam: getEnv() === ENV.LOCAL || getEnv() === ENV.STAGE,
+      },
+
+      sdkSource: {
+        type: "string",
+        value: () => {
+          const sdkSourceValue = getSDKIntegrationSource();
+          return sdkSourceValue;
+        },
+        required: false,
+        queryParam: true,
+        bodyParam: true,
       },
 
       vault: {


### PR DESCRIPTION
What is the purpose of this PR?

To support observability for BT JS SDK app-switch integration, the following query parameters must be included in the app switch universal link:

source: bsdk
merchant: id of merchant
flow_type: va/ecs

Jira Ticket: https://paypal.atlassian.net/browse/DTNFSPEED-518

This change was based on the signoff provided as stated in this confluence ,
https://paypal.atlassian.net/wiki/spaces/~712020bf3722d704414ecfa7688c73d80a4e73/pages/2693601182/Proposed+solution+to+add+new+params+to+Universal+appswitch+link


Test Recording Video
https://github.com/user-attachments/assets/5483c41b-ef48-428a-98d2-7ab4ae16c141

