### PR TITLE
Remove isPayPalDomain from subscriptions props

### DIFF
--- a/src/zoid/card-fields/component.jsx
+++ b/src/zoid/card-fields/component.jsx
@@ -249,23 +249,21 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
             value: ({ props }) => props.parent.props.createOrder,
           },
 
-          ...(isPayPalDomain() && {
-            createSubscription: {
-              type: "function",
-              required: false,
-              value: ({ props }) => {
-                if (
-                  props.parent.props.createSubscription &&
-                  !props.parent.props.sdkToken
-                ) {
-                  throw new ValidationError(
-                    `SDK Token must be passed in for createSubscription`
-                  );
-                }
-                return props.parent.props.createSubscription;
-              },
+          createSubscription: {
+            type: "function",
+            required: false,
+            value: ({ props }) => {
+              if (
+                props.parent.props.createSubscription &&
+                !props.parent.props.sdkToken
+              ) {
+                throw new ValidationError(
+                  `SDK Token must be passed in for createSubscription`
+                );
+              }
+              return props.parent.props.createSubscription;
             },
-          }),
+          },
 
           createVaultSetupToken: {
             type: "function",
@@ -601,20 +599,18 @@ export const getCardFieldsComponent: () => CardFieldsComponent = memoize(
           required: false,
         },
 
-        ...(isPayPalDomain() && {
-          createSubscription: {
-            type: "function",
-            required: false,
-            value: ({ props }) => {
-              if (props.createSubscription && !props.sdkToken) {
-                throw new ValidationError(
-                  `SDK Token must be passed in for createSubscription`
-                );
-              }
-              return props.createSubscription;
-            },
+        createSubscription: {
+          type: "function",
+          required: false,
+          value: ({ props }) => {
+            if (props.createSubscription && !props.sdkToken) {
+              throw new ValidationError(
+                `SDK Token must be passed in for createSubscription`
+              );
+            }
+            return props.createSubscription;
           },
-        }),
+        },
 
         createVaultSetupToken: {
           type: "function",


### PR DESCRIPTION
### Description
Original PR when adding subscriptions with paypal domain restriction: https://github.com/paypal/paypal-checkout-components/pull/2449/files

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
Full Stack Subscriptions JS SDK changes are ready to be released so we want to allow external domains to use the new subscriptions props.

JIRA: https://paypal.atlassian.net/browse/DTPRP-3083

### Reproduction Steps (if applicable)

### Screenshots (if applicable)
Before:
Props are not loaded for `127.0.0.1` domain. It only renders for `localhost` and `*.paypal.*` domains

Testing with locally hosted JS SDK test app:

<img width="1999" height="1025" alt="Screenshot 2025-09-25 at 4 34 12 PM" src="https://github.com/user-attachments/assets/b2ddcba3-f405-43ad-8b4c-2542968f48fb" />

After:
Props are loaded for any domains and card fields are rendered - tested with `127.0.0.1`

Testing with locally hosted JS SDK test app:

<img width="2002" height="1027" alt="Screenshot 2025-09-25 at 4 32 12 PM" src="https://github.com/user-attachments/assets/3ecad5e3-e604-4649-8906-68f1b8a45295" />

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)
@imbrian 

❤️ Thank you!
