### PR TITLE
clean up use of globalSessionID

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -47,7 +47,6 @@ import {
   getSDKInitTime,
   getSDKToken,
   getShopperSessionId,
-  getGlobalSessionID,
 } from "@paypal/sdk-client/src";
 import {
   rememberFunding,
@@ -812,12 +811,6 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
         value: () => {
           return () => queriedEligibleFunding;
         },
-      },
-
-      globalSessionID: {
-        type: "string",
-        required: false,
-        value: getGlobalSessionID,
       },
 
       hostedButtonId: {


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

We need to clean up use the of globalSessionID as we are now leveraging getPayPalSessionID for logging global_session_id in scnw.

https://paypal.atlassian.net/browse/DTPPCPSDK-3702

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

1. Open a button test page. 
2. In button iframe in the console, window.xprops should not contain a globalSessionID prop.

### Screenshots (if applicable)
Before: 
<img width="1214" height="839" alt="Screenshot 2025-10-03 at 12 23 55 PM" src="https://github.com/user-attachments/assets/2b2e18a2-7efe-4ede-98dd-41537d93152b" />

After:
<img width="357" height="78" alt="Screenshot 2025-10-03 at 12 27 18 PM" src="https://github.com/user-attachments/assets/859a8eb2-0671-4242-ab5c-93e3b4baa4ce" />


### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
