### PR TITLE
feat(buttons): add button disability changes

### DIFF
--- a/src/constants/class.js
+++ b/src/constants/class.js
@@ -28,6 +28,7 @@ export const CLASS = {
 
   LOADING: ("paypal-button-loading": "paypal-button-loading"),
   SPINNER: ("paypal-button-spinner": "paypal-button-spinner"),
+  DISABLED: ("paypal-button-disabled": "paypal-button-disabled"),
 
   TAGLINE: ("paypal-button-tagline": "paypal-button-tagline"),
   POWERED_BY: ("paypal-powered-by": "paypal-powered-by"),

--- a/src/ui/buttons/button.jsx
+++ b/src/ui/buttons/button.jsx
@@ -72,6 +72,7 @@ type IndividualButtonProps = {|
   instrument: ?WalletInstrument,
   showPayLabel: boolean,
   showLoadingSpinner?: boolean,
+  disabled?: boolean,
 |};
 
 export function Button({
@@ -97,6 +98,7 @@ export function Button({
   userIDToken,
   vault,
   showLoadingSpinner = false,
+  disabled = false,
 }: IndividualButtonProps): ElementNode {
   const { layout, shape, borderRadius } = style;
 
@@ -311,6 +313,7 @@ export function Button({
           CLASS.BUTTON,
           `${shouldApplyRebrandedStyles ? CLASS.BUTTON_REBRAND : ""}`,
           `${showLoadingSpinner ? CLASS.LOADING : ""}`,
+          `${disabled ? CLASS.DISABLED : ""}`,
           `${CLASS.NUMBER}-${i}`,
           `${CLASS.LAYOUT}-${layout}`,
           `${CLASS.NUMBER}-${
@@ -326,7 +329,8 @@ export function Button({
         onClick={clickHandler}
         onRender={onButtonRender}
         onKeyPress={keypressHandler}
-        tabindex="0"
+        tabindex={showLoadingSpinner || disabled ? "-1" : "0"}
+        aria-disabled={showLoadingSpinner || disabled ? "true" : "false"}
         aria-label={labelText}
       >
         <div class={CLASS.BUTTON_LABEL} aria-hidden="true">

--- a/src/ui/buttons/buttons.jsx
+++ b/src/ui/buttons/buttons.jsx
@@ -128,6 +128,7 @@ type ButtonsProps = ButtonPropsInputs & {|
   onClick?: Function,
   wallet?: ?Wallet,
   showLoadingSpinner?: boolean,
+  disabled?: boolean,
 |};
 
 export function validateButtonProps(props: ButtonPropsInputs) {
@@ -135,7 +136,11 @@ export function validateButtonProps(props: ButtonPropsInputs) {
 }
 
 export function Buttons(props: ButtonsProps): ElementNode {
-  const { onClick = noop, showLoadingSpinner = false } = props;
+  const {
+    onClick = noop,
+    showLoadingSpinner = false,
+    disabled = false,
+  } = props;
   const {
     applePaySupport,
     buyerCountry,
@@ -296,6 +301,7 @@ export function Buttons(props: ButtonsProps): ElementNode {
           instrument={instruments[source]}
           showPayLabel={showPayLabel}
           showLoadingSpinner={showLoadingSpinner}
+          disabled={disabled}
         />
       ))}
 

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -639,6 +639,14 @@ export type ButtonProps = {|
   messageMarkup?: string,
   hideSubmitButtonForCardForm?: boolean,
   userAgent: string,
+  disabled?: boolean,
+  onInit?: (
+    data: {||},
+    actions: {|
+      disable: () => void,
+      enable: () => void,
+    |}
+  ) => void,
 |};
 
 // eslint-disable-next-line flowtype/require-exact-type

--- a/src/ui/buttons/styles/button.js
+++ b/src/ui/buttons/styles/button.js
@@ -39,6 +39,12 @@ export const buttonStyle = `
         cursor: pointer;
     }
 
+    .${CLASS.BUTTON}.${CLASS.DISABLED} {
+        pointer-events: none !important;
+        cursor: not-allowed !important;
+        opacity: 0.6 !important;
+    }
+
     .${CLASS.CONTAINER}.${CLASS.ENV}-${ENV.TEST} .${CLASS.TEXT} {
         background: rgba(0, 0, 0, 0.5) !important;
         color: transparent  !important;

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -1370,6 +1370,12 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
         queryParam: true,
         value: getUserAgent,
       },
+
+      disabled: {
+        type: "boolean",
+        queryParam: true,
+        required: false,
+      },
     },
 
     exports: {

--- a/src/zoid/buttons/prerender.jsx
+++ b/src/zoid/buttons/prerender.jsx
@@ -111,6 +111,7 @@ export function PrerenderedButtons({
           {...props}
           onClick={handleClick}
           showLoadingSpinner={eagerOrderCreation}
+          disabled={props.disabled}
         />
       </body>
     </html>


### PR DESCRIPTION
### Description

This PR addresses the accessibility issue reported by TPG/Vodafone, where focus navigation was still moving to the PayPal button even when it was disabled. The fix ensures that when the PayPal button is disabled, it is no longer focusable via keyboard navigation, improving accessibility compliance.

Implement disabled button functionality with onInit callback for dynamic enable/disable control.

Add disabled prop to ButtonProps type with onInit callback
Add disabled state management in Button component
Add disabled CSS class and ARIA attributes for accessibility
Implement onInit callback in prerender with disable/enable actions
Add DISABLED class constant for styling


Jira Ticket:
(https://paypal.atlassian.net/browse/LI-134276)


Reproduction Steps

Build both csnw and scnw packages to ensure all dependencies are up to date:

Run the build commands for both csnw and scnw in your local environment.

Alias the paypal-checkout components to point to your local changes:

Run npm run storybook to test in local and verify all button stories render correctly
Navigate to react-paypal-js/Buttons/DisabledButtons - verify checkbox enables button
Navigate to testing/onInit/DisabledButtons - verify vanilla JS disabled button works

we can verify these changes in testing environment-points to local
(https://www.te-sdktestingnodeweb.qa.paypal.com/sdktestingnodeweb/storybook?path=/story/react-paypal-js-buttons--disabled-buttons&globals=sdkEnvironment:local)

Vanilla JS SDk

https://github.com/user-attachments/assets/96d79643-d4fa-4fab-a1c2-a2bcf2bfa057

React SDk


https://github.com/user-attachments/assets/0192a28f-1b8f-469f-9afd-c4e019b14d83











