### PR TITLE
fix: normalize malformed app switch cancel URL query strings

### DIFF
--- a/src/lib/appSwitchResume.js
+++ b/src/lib/appSwitchResume.js
@@ -44,7 +44,10 @@ function parseHashFragment(): {| hash: string, queryString: string |} {
     ) {
       return {
         hash: possibleAction,
-        queryString: hashString.slice(ampersandIndex + 1),
+        // Normalize embedded ? → & so parseQuery can extract all params.
+        // XOOS bug appends ?token=... inside a fragment, producing
+        // "merchantHash?token=EC-123" instead of "merchantHash&token=EC-123".
+        queryString: hashString.slice(ampersandIndex + 1).replace("?", "&"),
       };
     }
   }

--- a/src/lib/appSwithResume.test.js
+++ b/src/lib/appSwithResume.test.js
@@ -424,6 +424,25 @@ describe("app switch resume flow", () => {
       expect(isAppSwitchResumeFlow()).toEqual(true);
     });
 
+    test("#onCancel&hash?token=... - XOOS malformed URL with token after merchant hash", () => {
+      // DTXOOS-3741: XOOS appends ?token=... after the merchant's hash fragment,
+      // producing hash?token=EC-123. The embedded ? must be normalized to & so that
+      // parseQuery can extract the token correctly.
+      vi.spyOn(window, "location", "get").mockReturnValue({
+        hash: `#onCancel&hash?token=${orderID}&button_session_id=${buttonSessionID}`,
+        search: "",
+      });
+
+      const params = getAppSwitchResumeParams();
+
+      expect(params).toEqual({
+        buttonSessionID,
+        checkoutState: "onCancel",
+        orderID,
+      });
+      expect(isAppSwitchResumeFlow()).toEqual(true);
+    });
+
     test("#onApprove?token=...&hash?param=value - native app return with ? delimiter and merchant hash containing ?", () => {
       // Native app uses ? delimiter, and merchant hash also contains ?.
       // The first ? splits action from params; the second ? is just part of param values.


### PR DESCRIPTION


When a merchant's return_url contains a hash fragment, XOOS appends ?token=... after the hash, producing query strings like "hash?token=EC-123". parseQuery() only splits on &, so the token was never extracted.

Add .replace("?", "&") to normalize the query string after extracting the action from the hash fragment, allowing parseQuery to correctly extract all parameters.

### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
