### PR TITLE
update logos/text showing

### DIFF
--- a/src/funding/credit/config.jsx
+++ b/src/funding/credit/config.jsx
@@ -12,7 +12,6 @@ import {
   PayPalLogoInlineSVG,
   LOGO_COLOR,
   PPRebrandLogoInlineSVG,
-  PPRebrandLogoExternalImage,
   CreditMarkRebrandExternalImage,
 } from "@paypal/sdk-logos/src";
 

--- a/src/funding/credit/config.jsx
+++ b/src/funding/credit/config.jsx
@@ -99,12 +99,12 @@ export function getCreditConfig(): FundingSourceConfig {
               fundingEligibility={fundingEligibility}
               locale={locale}
             />
-            {__WEB__ ? (
-              <PPRebrandLogoExternalImage logoColor={logoColorPP} />
-            ) : (
-              <PPRebrandLogoInlineSVG logoColor={logoColorPP} />
+            {!__WEB__ && <PPRebrandLogoInlineSVG logoColor={logoColorPP} />}
+            {!__WEB__ && (
+              <Text animate optional>
+                {"Später Bezahlen"}
+              </Text>
             )}
-            <Text>{"Später Bezahlen"}</Text>
           </Style>
         );
       }
@@ -119,12 +119,12 @@ export function getCreditConfig(): FundingSourceConfig {
             experiment={experiment}
             fundingEligibility={fundingEligibility}
           />
-          {__WEB__ ? (
-            <PPRebrandLogoExternalImage logoColor={logoColorPP} />
-          ) : (
-            <PPRebrandLogoInlineSVG logoColor={logoColorPP} />
+          {!__WEB__ && <PPRebrandLogoInlineSVG logoColor={logoColorPP} />}
+          {!__WEB__ && (
+            <Text animate optional>
+              {"Credit"}
+            </Text>
           )}
-          <Text>{"Credit"}</Text>
         </Style>
       );
     },

--- a/src/funding/paylater/config.jsx
+++ b/src/funding/paylater/config.jsx
@@ -9,7 +9,6 @@ import {
   PPLogoInlineSVG,
   LOGO_COLOR,
   PPRebrandLogoInlineSVG,
-  PPRebrandLogoExternalImage,
   PaylaterMarkRebrandExternalImage,
 } from "@paypal/sdk-logos/src";
 

--- a/src/funding/paylater/config.jsx
+++ b/src/funding/paylater/config.jsx
@@ -131,18 +131,16 @@ export function getPaylaterConfig(): FundingSourceConfig {
             fundingEligibility={fundingEligibility}
             locale={locale}
           />
-          {__WEB__ ? (
-            <PPRebrandLogoExternalImage logoColor={logoColorPP} />
-          ) : (
-            <PPRebrandLogoInlineSVG logoColor={logoColorPP} />
+          {!__WEB__ && <PPRebrandLogoInlineSVG logoColor={logoColorPP} />}
+          {!__WEB__ && (
+            <Text animate optional>
+              {getLabelText(
+                fundingEligibility,
+                locale,
+                shouldApplyRebrandedStyles
+              ) || "Pay Later"}
+            </Text>
           )}
-          <Text>
-            {getLabelText(
-              fundingEligibility,
-              locale,
-              shouldApplyRebrandedStyles
-            ) || "Pay Later"}
-          </Text>
         </Style>
       );
     },

--- a/src/ui/buttons/script.jsx
+++ b/src/ui/buttons/script.jsx
@@ -235,6 +235,12 @@ export function getComponentScript(): () => void {
         if (totalWidth > buttonWidth) {
           hideElement(paypalLogo);
           showElement(ppLogo);
+          const allTextElements = allElements.filter(
+            (el) =>
+              el.classList.contains("paypal-button-text") &&
+              !el.classList.contains("immediate")
+          );
+          allTextElements.forEach((el) => showElement(el));
         } else {
           showElement(paypalLogo);
           hideElement(ppLogo);


### PR DESCRIPTION
### Description

Summary
Adds PayPalRebrandLogo and label text to the rebrand paylater and credit button labels, mirroring the PayPal button label structure
toggleLogos determines at runtime whether the PayPal wordmark + text combo fits the button width, and swaps to the PP monogram when it does not

Why the text animation does not slide in (known open issue)
The show-text CSS animation in labels.js is:
```
.dom-ready .paypal-button .paypal-button-text:not(.immediate):not(.personalization-text):not(.hidden) {
    animation: show-text 1s 0s forwards;
}
```
This animation fires exactly once — when dom-ready is added to <body> — on any text element that is currently visible (not .hidden). For the PayPal button labels, this works because the text starts CSS-hidden, toggleOptionals decides it fits and never adds .hidden, and then dom-ready fires and the animation plays cleanly.

For paylater/credit, toggleLogos is called inside setDomReady's setTimeout callback — which runs after dom-ready is added to the body.
toggleLogos calls hideElement(paypalLogo) and hideElement(ppLogo) to temporarily pull both logos out of flow for measurement. These calls set position: absolute on the logo elements, which collapses the flex container width. This reflow happens while the show-text animation is in progress, causing the browser to recalculate the text element's max-width percentage mid-animation and visually snap/flash instead of slide.

Additionally, the toggleOptionals call in this same setTimeout calls showElement(text) unconditionally — classList.remove("hidden") — even when .hidden was never present. Any classList mutation on the text element triggers a style recalculation that resets the running CSS animation.

The root tension: toggleLogos needs DOM layout to be complete to measure widths accurately (requiring the setTimeout), but by the time layout is complete, dom-ready has already been added and the animation has started. Any DOM mutation that causes a reflow at this point interrupts the animation.

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

https://github.com/user-attachments/assets/9b1ae0af-7afa-4212-a84d-dce795b5d441

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
