### PR TITLE
chore(connect): update accelerated-checkout-loader to fastlane-sdk-lo…

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ coverage
 CHANGELOG.md
 .husky
 .playwright-mcp
+.claude

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@krakenjs/post-robot": "^11.0.0",
     "@krakenjs/zalgo-promise": "^2.0.0",
     "@krakenjs/zoid": "^10.3.1",
-    "@paypal/accelerated-checkout-loader": "^1.0.1",
+    "@paypal/fastlane-sdk-loader": "^1.2.1",
     "@paypal/common-components": "^1.0.35",
     "@paypal/funding-components": "^1.0.31",
     "@paypal/sdk-client": "^4.0.199",

--- a/src/connect/component.jsx
+++ b/src/connect/component.jsx
@@ -1,5 +1,5 @@
 /* @flow */
-import { loadAxo } from "@paypal/accelerated-checkout-loader";
+import { loadAxo } from "@paypal/fastlane-sdk-loader";
 import { stringifyError } from "@krakenjs/belter/src";
 import {
   getClientID,

--- a/src/connect/component.test.js
+++ b/src/connect/component.test.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { getUserIDToken, getSDKToken } from "@paypal/sdk-client/src";
-import { loadAxo } from "@paypal/accelerated-checkout-loader";
+import { loadAxo } from "@paypal/fastlane-sdk-loader";
 import { describe, expect, test, vi } from "vitest";
 
 import {
@@ -30,7 +30,7 @@ vi.mock("@paypal/sdk-client/src", () => {
   };
 });
 
-vi.mock("@paypal/accelerated-checkout-loader", () => {
+vi.mock("@paypal/fastlane-sdk-loader", () => {
   return {
     loadAxo: vi.fn(),
   };


### PR DESCRIPTION
### Description

With the GH EMU migration, we renamed `@paypal/accelerated-checkout-loader` npm pkg to `@paypal/fastlane-sdk-loader`.  This is updating the dep in `package.json` and it's usage.

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

Replace `@paypal/accelerated-checkout-loader` with `@paypal/fastlane-sdk-loader` package rename across package.json, component.jsx, and component.test.js. Also exclude .claude directory from prettier checks.

https://www.npmjs.com/package/@paypal/fastlane-sdk-loader is published ✅ 
DTXOUP-6890

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
