### PR TITLE
refactor: update fr pay later btn label

### DIFF
--- a/src/funding/paylater/config.jsx
+++ b/src/funding/paylater/config.jsx
@@ -137,13 +137,7 @@ export function getPaylaterConfig(): FundingSourceConfig {
           ) : (
             <PPRebrandLogoInlineSVG logoColor={logoColorPP} />
           )}
-          <Text>
-            {getLabelText(
-              fundingEligibility,
-              locale,
-              shouldApplyRebrandedStyles
-            ) || "Pay Later"}
-          </Text>
+          <Text>{getLabelText(fundingEligibility, locale) || "Pay Later"}</Text>
         </Style>
       );
     },

--- a/src/funding/paylater/config.jsx
+++ b/src/funding/paylater/config.jsx
@@ -22,8 +22,7 @@ import css from "./style.scoped.scss";
 
 function getLabelText(
   fundingEligibility: FundingEligibilityType,
-  locale?: LocaleType,
-  shouldApplyRebrandedStyles?: boolean
+  locale?: LocaleType
 ): ?string {
   const { paylater } = fundingEligibility;
   const { lang } = locale || {};

--- a/src/funding/paylater/config.jsx
+++ b/src/funding/paylater/config.jsx
@@ -68,10 +68,12 @@ function getLabelText(
   }
 
   if (
-    paylater?.products?.payIn4?.eligible &&
-    paylater?.products?.payIn4?.variant === "FR"
+    (paylater?.products?.payIn4?.eligible &&
+      paylater?.products?.payIn4?.variant === "FR") ||
+    (paylater?.products?.paylater?.eligible &&
+      paylater?.products?.paylater?.variant === "FR")
   ) {
-    labelText = shouldApplyRebrandedStyles ? "4X" : "4X PayPal";
+    labelText = "Payer en plusieurs fois";
   }
 
   return labelText;

--- a/test/integration/tests/funding/paylater/index.js
+++ b/test/integration/tests/funding/paylater/index.js
@@ -120,7 +120,7 @@ describe(`paylater button text`, () => {
     });
   });
 
-  it(`should display 4X PayPal label when payIn4 product is eligible and variant is FR`, () => {
+  it(`should display Payer en plusieurs fois label when payIn4 product is eligible and variant is FR`, () => {
     const fundingSource = FUNDING.PAYLATER;
     mockProp(
       window.__TEST_FUNDING_ELIGIBILITY__[fundingSource],
@@ -145,11 +145,11 @@ describe(`paylater button text`, () => {
     return button.render("#testContainer").then(() => {
       assert.equal(
         getElementRecursive(".paypal-button-text").innerHTML,
-        "4X PayPal"
+        "Payer en plusieurs fois"
       );
       assert.equal(
         getElementRecursive(".paypal-button").getAttribute("aria-label"),
-        "4X PayPal"
+        "Payer en plusieurs fois"
       );
     });
   });


### PR DESCRIPTION
### Description
update french pay later button label to read “Payer en plusieurs fois”

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
label update to support both pi4 and pay monthly products

### Reproduction Steps (if applicable)
N/A

### Screenshots (if applicable)
<img width="767" height="81" alt="Screenshot 2026-05-05 at 12 23 21 PM" src="https://github.com/user-attachments/assets/38cd841b-6f53-418a-9acc-8d3bce4fdd6a" />

### Dependent Changes (if applicable)
xobuyernodeserv

### Groups who should review (if applicable)
upstream - @opercy

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
