### PR TITLE
[DTGPLUPBLR-357] Add UK Pi30 GB paylater button tests and demo page

### DIFF
--- a/demo/dev/button-paylater-gb.htm
+++ b/demo/dev/button-paylater-gb.htm
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link
+    rel="stylesheet"
+    href="https://www.paypalobjects.com/paypal-sdk-fonts/PayPal-Plain/PayPal-Plain.css"
+  />
+  <link
+    rel="stylesheet"
+    href="https://www.paypalobjects.com/paypal-sdk-fonts/PayPalPro-Book/PayPalPro-Book.css"
+  />
+  <link
+    rel="stylesheet"
+    href="https://www.paypalobjects.com/paypal-sdk-fonts/Scto-Grotesk-A/Scto-Grotesk-A.css"
+  />
+  <script src="https://localhost.paypal.com:9001/sdk.js?client-id=alc_client1"></script>
+  <script src="https://localhost.paypal.com:9001/button.js"></script>
+  <script src="https://localhost.paypal.com:9001/jsx-pragmatic.js"></script>
+</head>
+
+<body>
+  <script>
+    const server = xprops.server || {};
+
+    const props = {
+      ...xprops,
+      locale: { country: "GB", lang: "en" },
+      fundingEligibility: {
+        paypal: { eligible: true },
+        paylater: {
+          eligible: true,
+          products: {
+            paylater: {
+              eligible: true,
+              variant: "GB",
+            },
+          },
+        },
+        card: {
+          eligible: true,
+          isPayPalBranded: true,
+          vendors: {
+            visa: { eligible: true },
+            mastercard: { eligible: true },
+            amex: { eligible: true },
+          },
+        },
+      },
+      content: {
+        payWithDebitOrCreditCard: "Debit or Credit Card",
+        payNow: "Pay Now",
+        payWith: "Pay with",
+        credit: "Credit",
+        balance: "Balance",
+      },
+      wallet: server.wallet || xprops.wallet,
+    };
+
+    document.write(button.Buttons(props).render(jsx.html()));
+
+    document.querySelectorAll("[data-funding-source]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const instance = paypal.Checkout({
+          createOrder: () => {
+            return "EC-XXXXXXXXXX";
+          },
+          onApprove: () => {
+            console.log("Approved");
+            instance.close();
+          },
+        });
+        instance.renderTo(window.parent.document.body);
+      });
+    });
+  </script>
+</body>

--- a/src/funding/paylater/config.jsx
+++ b/src/funding/paylater/config.jsx
@@ -37,6 +37,13 @@ function getLabelText(
   }
 
   if (
+    paylater?.products?.paylater?.eligible &&
+    paylater?.products?.paylater?.variant === "GB"
+  ) {
+    labelText = "Pay Later";
+  }
+
+  if (
     (paylater?.products?.payIn3?.eligible &&
       paylater?.products?.payIn3?.variant === "ES") ||
     (paylater?.products?.paylater?.eligible &&

--- a/test/integration/tests/funding/paylater/index.js
+++ b/test/integration/tests/funding/paylater/index.js
@@ -319,7 +319,7 @@ describe(`paylater button text`, () => {
       );
       assert.equal(
         getElementRecursive(".paypal-button").getAttribute("aria-label"),
-        "paypal paylater"
+        "Pay Later"
       );
     });
   });

--- a/test/integration/tests/funding/paylater/index.js
+++ b/test/integration/tests/funding/paylater/index.js
@@ -290,6 +290,40 @@ describe(`paylater button text`, () => {
     });
   });
 
+  it(`should display Pay Later label when paylater product is eligible and variant is GB`, () => {
+    const fundingSource = FUNDING.PAYLATER;
+    mockProp(
+      window.__TEST_FUNDING_ELIGIBILITY__[fundingSource],
+      "eligible",
+      true
+    );
+    mockProp(window.__TEST_FUNDING_ELIGIBILITY__[fundingSource], "products", {
+      paylater: {
+        eligible: true,
+        variant: "GB",
+      },
+    });
+
+    const button = window.paypal.Buttons({
+      fundingSource,
+    });
+
+    if (!button.isEligible()) {
+      throw new Error(`Expected paylater to be eligible`);
+    }
+
+    return button.render("#testContainer").then(() => {
+      assert.equal(
+        getElementRecursive(".paypal-button-text").innerHTML,
+        "Pay Later"
+      );
+      assert.equal(
+        getElementRecursive(".paypal-button").getAttribute("aria-label"),
+        "paypal paylater"
+      );
+    });
+  });
+
   it(`should fallback to Pay Later button text if unable to retrieve products`, () => {
     const fundingSource = FUNDING.PAYLATER;
     mockProp(

--- a/test/percy/config.js
+++ b/test/percy/config.js
@@ -1113,6 +1113,111 @@ buttonConfigs.push({
   },
 });
 
+// UK (GB) Pi30 variant button tests.
+buttonConfigs.push({
+  button: {
+    style: {
+      layout: "horizontal",
+      label: "pay",
+    },
+  },
+  container: {
+    width: 330,
+  },
+  fundingEligibility: {
+    [FUNDING.PAYPAL]: {
+      eligible: true,
+    },
+    [FUNDING.PAYLATER]: {
+      eligible: true,
+      products: {
+        paylater: {
+          eligible: true,
+          variant: "GB",
+        },
+      },
+    },
+  },
+});
+
+buttonConfigs.push({
+  button: {
+    style: {
+      layout: "horizontal",
+      label: "pay",
+    },
+  },
+  container: {
+    width: 320,
+  },
+  fundingEligibility: {
+    [FUNDING.PAYPAL]: {
+      eligible: true,
+    },
+    [FUNDING.PAYLATER]: {
+      eligible: true,
+      products: {
+        paylater: {
+          eligible: true,
+          variant: "GB",
+        },
+      },
+    },
+  },
+});
+
+buttonConfigs.push({
+  button: {
+    style: {
+      layout: "horizontal",
+      label: "pay",
+    },
+  },
+  container: {
+    width: 300,
+  },
+  fundingEligibility: {
+    [FUNDING.PAYPAL]: {
+      eligible: true,
+    },
+    [FUNDING.PAYLATER]: {
+      eligible: true,
+      products: {
+        paylater: {
+          eligible: true,
+          variant: "GB",
+        },
+      },
+    },
+  },
+});
+
+buttonConfigs.push({
+  button: {
+    style: {
+      layout: "horizontal",
+      label: "pay",
+    },
+  },
+  container: {
+    width: 290,
+  },
+  fundingEligibility: {
+    [FUNDING.PAYPAL]: {
+      eligible: true,
+    },
+    [FUNDING.PAYLATER]: {
+      eligible: true,
+      products: {
+        paylater: {
+          eligible: true,
+          variant: "GB",
+        },
+      },
+    },
+  },
+});
+
 buttonConfigs.push({
   diffThreshold: 1000,
   container: {

--- a/test/screenshot/config.js
+++ b/test/screenshot/config.js
@@ -1150,6 +1150,111 @@ buttonConfigs.push({
   },
 });
 
+// UK (GB) Pi30 variant button tests.
+buttonConfigs.push({
+  button: {
+    style: {
+      layout: "horizontal",
+      label: "pay",
+    },
+  },
+  container: {
+    width: 330,
+  },
+  fundingEligibility: {
+    [FUNDING.PAYPAL]: {
+      eligible: true,
+    },
+    [FUNDING.PAYLATER]: {
+      eligible: true,
+      products: {
+        paylater: {
+          eligible: true,
+          variant: "GB",
+        },
+      },
+    },
+  },
+});
+
+buttonConfigs.push({
+  button: {
+    style: {
+      layout: "horizontal",
+      label: "pay",
+    },
+  },
+  container: {
+    width: 320,
+  },
+  fundingEligibility: {
+    [FUNDING.PAYPAL]: {
+      eligible: true,
+    },
+    [FUNDING.PAYLATER]: {
+      eligible: true,
+      products: {
+        paylater: {
+          eligible: true,
+          variant: "GB",
+        },
+      },
+    },
+  },
+});
+
+buttonConfigs.push({
+  button: {
+    style: {
+      layout: "horizontal",
+      label: "pay",
+    },
+  },
+  container: {
+    width: 300,
+  },
+  fundingEligibility: {
+    [FUNDING.PAYPAL]: {
+      eligible: true,
+    },
+    [FUNDING.PAYLATER]: {
+      eligible: true,
+      products: {
+        paylater: {
+          eligible: true,
+          variant: "GB",
+        },
+      },
+    },
+  },
+});
+
+buttonConfigs.push({
+  button: {
+    style: {
+      layout: "horizontal",
+      label: "pay",
+    },
+  },
+  container: {
+    width: 290,
+  },
+  fundingEligibility: {
+    [FUNDING.PAYPAL]: {
+      eligible: true,
+    },
+    [FUNDING.PAYLATER]: {
+      eligible: true,
+      products: {
+        paylater: {
+          eligible: true,
+          variant: "GB",
+        },
+      },
+    },
+  },
+});
+
 buttonConfigs.push({
   diffThreshold: 1000,
   container: {

--- a/test/ssr/ssr.test.js
+++ b/test/ssr/ssr.test.js
@@ -189,6 +189,51 @@ test(`Button should render with ssr, with en_HK locale option`, async () => {
   }
 });
 
+test(`Button should render with ssr, with GB locale and paylater variant`, async () => {
+  const { Buttons } = await getButtonScript();
+
+  const buttonHTML = Buttons({
+    locale: { country: "GB", lang: "en" },
+    platform: "desktop",
+    sessionID: "xyz",
+    buttonSessionID: "abc",
+    fundingEligibility: {
+      paypal: {
+        eligible: true,
+      },
+      paylater: {
+        eligible: true,
+        products: {
+          paylater: {
+            eligible: true,
+            variant: "GB",
+          },
+        },
+      },
+      card: {
+        eligible: true,
+        isPayPalBranded: true,
+        vendors: {
+          visa: { eligible: true },
+          mastercard: { eligible: true },
+          amex: { eligible: true },
+          discover: { eligible: true },
+        },
+      },
+    },
+  }).render(html());
+
+  if (!buttonHTML || typeof buttonHTML !== "string") {
+    throw new Error(`Expected html to be a non-empty string`);
+  }
+
+  if (!buttonHTML.includes("Pay Later")) {
+    throw new Error(
+      `Expected SSR HTML to contain "Pay Later" label for GB variant`
+    );
+  }
+});
+
 // This is failing since validation of the color prop moved
 // This condition is tested in vitest
 test.skip(`Button should fail to render with ssr, with invalid style option`, async () => {


### PR DESCRIPTION
- Add integration test: GB variant renders 'Pay Later' label
- Add Percy and screenshot configs for GB paylater button
- Add SSR test for GB locale with paylater variant
- Add demo page button-paylater-gb.htm for local testing

### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
