### PR TITLE
Add background color to saved payment method PP logo

### DIFF
--- a/src/ui/saved-payment-methods/template.jsx
+++ b/src/ui/saved-payment-methods/template.jsx
@@ -126,6 +126,7 @@ export function SavedPaymentMethods(
               align-items: center;
               justify-content: center;
               border: 1.2px solid #CCCCCC;
+              background-color: #FFFFFF;
               border-radius: 2px;
             }
 


### PR DESCRIPTION
### Description

Adds background color to the PayPal logo in the Saved Payment Methods component. 

Before:
<img width="350" height="115" alt="Screenshot 2026-05-27 at 12 36 33 PM" src="https://github.com/user-attachments/assets/a3512808-b469-4327-948e-ecc445578098" />


After:
<img width="341" height="88" alt="Screenshot 2026-05-27 at 12 36 52 PM" src="https://github.com/user-attachments/assets/2f5e949f-2f9b-48a1-b459-9871eb98fc2d" />



<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
