### PR TITLE
feat(Venmo): adding support for vault setup token creation

### DIFF
--- a/src/zoid/venmo/component.jsx
+++ b/src/zoid/venmo/component.jsx
@@ -176,6 +176,16 @@ export function getVenmoCheckoutComponent(): VenmoCheckoutComponent {
           type: "function",
           queryParam: "token",
           alias: "payment",
+          required: false,
+          // $FlowIgnore
+          queryValue: ({ value }) => ZalgoPromise.try(value),
+          decorate: ({ value }) => memoize(value),
+        },
+
+        createVaultSetupToken: {
+          type: "function",
+          queryParam: "vault_token",
+          required: false,
           // $FlowFixMe
           queryValue: ({ value }) => ZalgoPromise.try(value),
           decorate: ({ value }) => memoize(value),


### PR DESCRIPTION
### Description

Adds a `createVaultSetupToken` prop to the Venmo zoid component, enabling merchants to vault a customer's Venmo payment method without requiring an accompanying purchase.

### Changes
  - Adds createVaultSetupToken as an optional function prop on the Venmo component, surfaced to the iframe via the vault_token query param
  - Makes createOrder explicitly optional (required: false) so either prop can be used independently — vault-only or purchase-only flows are both valid

### Why
  Previously, the Venmo component only supported createOrder, which couples vaulting to an active purchase. This change decouples them, allowing merchants to implement a "save payment method" flow (e.g., during account setup or subscription enrollment) without initiating a
  transaction.

Jira: DTPPCPSDK-6367

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

### Groups who should review (if applicable)

❤️ Thank you!
