### PR TITLE
Reland: Pass bfcache events via post-robot

### DIFF
--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -598,9 +598,7 @@ export type ButtonProps = {|
   hashChangeHandler: (event: any) => void,
   listenForVisibilityChange: () => void,
   removeListenerForVisibilityChanges: () => void,
-  // Not passed to child iframe
   visibilityChangeHandler: () => void,
-
   showPayPalAppSwitchOverlay: (args: ShowPayPalAppSwitchOverlay) => void,
   hidePayPalAppSwitchOverlay: (args: HidePayPalAppSwitchOverlay) => void,
 

--- a/src/ui/buttons/props.js
+++ b/src/ui/buttons/props.js
@@ -598,7 +598,9 @@ export type ButtonProps = {|
   hashChangeHandler: (event: any) => void,
   listenForVisibilityChange: () => void,
   removeListenerForVisibilityChanges: () => void,
+  // Not passed to child iframe
   visibilityChangeHandler: () => void,
+
   showPayPalAppSwitchOverlay: (args: ShowPayPalAppSwitchOverlay) => void,
   hidePayPalAppSwitchOverlay: (args: HidePayPalAppSwitchOverlay) => void,
 

--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -107,9 +107,9 @@ import {
   getButtonSize,
   getButtonExperiments,
   getModal,
-  sendPostRobotMessageToButtonIframe,
   isEagerOrderCreationEnabled,
   resolveMerchantDomain,
+  sendPostRobotMessageToButtonIframe,
 } from "./util";
 
 export type ButtonsComponent = ZoidComponent<
@@ -469,6 +469,20 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
               "visibilitychange",
               props.visibilityChangeHandler
             );
+          },
+      },
+
+      onBfcacheRestore: {
+        type: "function",
+        sendToChild: false,
+        queryParam: false,
+        value:
+          () =>
+          ({ cachedDurationMs } = {}) => {
+            sendPostRobotMessageToButtonIframe({
+              eventName: "bfcache_restore",
+              payload: { cachedDurationMs },
+            });
           },
       },
 

--- a/src/zoid/buttons/util.js
+++ b/src/zoid/buttons/util.js
@@ -411,6 +411,7 @@ export const sendPostRobotMessageToButtonIframe = ({
     if (iframes[i].name.includes("zoid__paypal_buttons")) {
       postRobotSend(iframes[i].contentWindow, eventName, payload, {
         domain: getPayPalDomain(),
+        fireAndForget: true,
       });
     }
   }


### PR DESCRIPTION
### Description

Relands #2608, which was reverted by #2616. This is a clean revert-of-the-revert: `git revert` of #2616's merge commit, with one merge conflict resolved (an unrelated `resolveMerchantDomain` import was added to `main` after #2616 merged; both imports now coexist). Diff verified to match #2608's original changes exactly (same 3 files, same +16/-3 line counts), aside from that import reordering.

Adds an `onBfcacheRestore` prop to the Buttons component that forwards a `bfcache_restore` post-robot message (with `cachedDurationMs`) to the child iframe when the parent page is restored from bfcache, and sets `fireAndForget: true` on the underlying post-robot send to avoid "window closed before ack" errors if the child doesn't respond in time.

### Why are we making these changes?

DTPPCPSDK-5875 (bfcache epic). This is the sender half of SCNW's `postRobot.on("bfcache_restore")` listener (#1237, already merged and live), which has had no sender since #2608 was reverted.

### Dependent Changes

Part of the same chain as zoid #479/#485 and paypal-checkout-components #2615.