### PR TITLE
fix(buttons): replace PayPal Plain font with PayPalOpen-Regular [DTGPLUPBLR-523]

### DIFF
--- a/src/ui/buttons/poweredBy.jsx
+++ b/src/ui/buttons/poweredBy.jsx
@@ -83,7 +83,7 @@ export function PoweredByPayPal({
         text-align: center;
         margin: 10px auto;
         height: 12px;
-        font-family: PayPal Plain, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
+        font-family: PayPalOpen-Regular, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
         font-size: 10px;
         font-weight: 400;
         color: #000000;

--- a/src/ui/buttons/styles/labels.js
+++ b/src/ui/buttons/styles/labels.js
@@ -61,7 +61,7 @@ export const labelStyle = `
     }
 
     .${CLASS.BUTTON_REBRAND} .${CLASS.BUTTON_LABEL} {
-        font-family: PayPal Plain, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
+        font-family: PayPalOpen-Regular, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
         font-weight: 400;
     }
 

--- a/src/ui/buttons/styles/page.js
+++ b/src/ui/buttons/styles/page.js
@@ -4,7 +4,7 @@ import { CLASS } from "../../../constants";
 
 export const pageStyle = `
     html, body {
-        font-family: PayPal Plain, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
+        font-family: PayPalOpen-Regular, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
         padding: 0;
         margin: 0;
         width: 100%;

--- a/src/ui/overlay/paypal-app-switch/style.jsx
+++ b/src/ui/overlay/paypal-app-switch/style.jsx
@@ -91,7 +91,7 @@ export function getContainerStyle({ uid }: {| uid: string |}): string {
         }
 
         #${uid} .paypal-checkout-modal {
-            font-family: PayPal Plain, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
+            font-family: PayPalOpen-Regular, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
             font-size: 14px;
             text-align: center;
 

--- a/src/ui/overlay/three-domain-secure/style.jsx
+++ b/src/ui/overlay/three-domain-secure/style.jsx
@@ -113,7 +113,7 @@ export function getContainerStyle({ uid }: {| uid: string |}): string {
         }
 
         #${uid} .paypal-checkout-modal {
-            font-family: PayPal Plain, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
+            font-family: PayPalOpen-Regular, system-ui, -apple-system, Roboto, "Segoe UI", Helvetica-Neue, Helvetica, Arial, sans-serif;
             font-size: 14px;
             text-align: center;
 


### PR DESCRIPTION
## Summary
- The PayPal Plain font license expires Aug 31, 2026 (see [pp-react Font Migration Guide](https://paypal.atlassian.net/wiki/spaces/PPUI/pages/3019146040))
- 5 files hardcoded `font-family: PayPal Plain, ...`, used in the powered-by label, button labels, page style, and the App Switch / 3DS overlay modals
- Replaced with `PayPalOpen-Regular` per the approved font mapping in the migration guide:
  - `src/ui/buttons/poweredBy.jsx`
  - `src/ui/buttons/styles/labels.js`
  - `src/ui/buttons/styles/page.js`
  - `src/ui/overlay/paypal-app-switch/style.jsx`
  - `src/ui/overlay/three-domain-secure/style.jsx`

## Test plan
- [ ] Visual check of button labels, powered-by text, App Switch modal, and 3DS overlay after rebuild

Full audit trail: [PayPal Plain Font Migration — BNPL/Credit Repo Audit Proof](https://paypal.atlassian.net/wiki/spaces/PPUI/pages/3027490347)