### PR TITLE
Fix duplicate PayPal announcement for screen readers via distinct iframe aria-label

### DIFF
--- a/src/zoid/buttons/component.jsx
+++ b/src/zoid/buttons/component.jsx
@@ -241,6 +241,7 @@ export const getButtonsComponent: () => ButtonsComponent = memoize(() => {
           allowpaymentrequest: "allowpaymentrequest",
           scrolling: "no",
           title: `${FUNDING_BRAND_LABEL.PAYPAL}${fundingSource}`,
+          "aria-label": "Payment Button",
           role: "presentation",
         },
       };


### PR DESCRIPTION
JIRA - https://paypal.atlassian.net/browse/LI-185959

### Description
Adds a distinct aria-label="Payment Button" to the smart button iframe, keeping the existing title logic unchanged. This resolves the duplicate "PayPal, PayPal" screen reader announcement (LI-185959) reported by Shopify, since the frame and the inner button no longer share the same accessible name.

Note: the exact announcement order can vary slightly by browser/screen reader combination, but in all cases the name is no longer duplicated. Examples:

- Standalone PayPal button: `link, PayPal, Payment Button, group`
- Smart button stack (PayPal first): `link, PayPal, Payment Button, group`, then subsequent buttons in the same group announce just their own name: `link, Venmo`, `link, paypal paylater`, `link, Debit or Credit Card`