### PR TITLE
observe window name

### DIFF
--- a/src/zoid/checkout/component.jsx
+++ b/src/zoid/checkout/component.jsx
@@ -25,6 +25,7 @@ import {
   noop,
   supportsPopups,
   inlineMemoize,
+  stringifyError,
 } from "@krakenjs/belter/src";
 import { FUNDING } from "@paypal/sdk-constants/src";
 import {
@@ -41,6 +42,42 @@ import { fixCreditRedirect } from "./hacks";
 import { DEFAULT_POPUP_SIZE } from "./config";
 
 export type CheckoutComponent = ZoidComponent<CheckoutPropsType>;
+
+const WINDOW_NAME_LOG_TRUNCATION_LENGTH = 100;
+
+function spyOnWindowNameAssignment(): void {
+  try {
+    let currentWindowName = window.name;
+
+    Object.defineProperty(window, "name", {
+      configurable: true,
+      get(): string {
+        return currentWindowName;
+      },
+      set(value: string): void {
+        getLogger().error("checkout_window_name_overwritten", {
+          err: stringifyError(
+            new Error(
+              `window.name was overwritten: ${String(value).slice(
+                0,
+                WINDOW_NAME_LOG_TRUNCATION_LENGTH,
+              )}`,
+            ),
+          ),
+          originalValue: currentWindowName.slice(
+            0,
+            WINDOW_NAME_LOG_TRUNCATION_LENGTH,
+          ),
+        });
+        currentWindowName = value;
+      },
+    });
+  } catch (error) {
+    getLogger().error("checkout_window_name_spy_error", {
+      err: stringifyError(error),
+    });
+  }
+}
 
 export function getCheckoutComponent(): CheckoutComponent {
   return inlineMemoize(getCheckoutComponent, () => {
@@ -382,6 +419,8 @@ export function getCheckoutComponent(): CheckoutComponent {
     });
 
     if (component.isChild()) {
+      spyOnWindowNameAssignment();
+
       window.xchild = {
         props: component.xprops,
         show: noop,

--- a/src/zoid/checkout/component.jsx
+++ b/src/zoid/checkout/component.jsx
@@ -43,7 +43,10 @@ import { DEFAULT_POPUP_SIZE } from "./config";
 
 export type CheckoutComponent = ZoidComponent<CheckoutPropsType>;
 
-const WINDOW_NAME_LOG_TRUNCATION_LENGTH = 100;
+const WINDOW_NAME_LOG_TRUNCATION_LENGTH = 50;
+// Matches window names zoid itself writes, eg `__zoid__paypal_checkout__<payload>__`.
+// See buildChildWindowName in @krakenjs/zoid.
+const ZOID_WINDOW_NAME_PATTERN = /^__zoid__.+__$/;
 
 function spyOnWindowNameAssignment(): void {
   try {
@@ -55,6 +58,11 @@ function spyOnWindowNameAssignment(): void {
         return currentWindowName;
       },
       set(value: string): void {
+        if (ZOID_WINDOW_NAME_PATTERN.test(value)) {
+          currentWindowName = value;
+          return;
+        }
+
         getLogger().error("checkout_window_name_overwritten", {
           err: stringifyError(
             new Error(

--- a/src/zoid/checkout/component.jsx
+++ b/src/zoid/checkout/component.jsx
@@ -72,7 +72,7 @@ function spyOnWindowNameAssignment(): void {
               )}`,
             ),
           ),
-          originalValue: currentWindowName.slice(
+          originalValue: String(currentWindowName).slice(
             0,
             WINDOW_NAME_LOG_TRUNCATION_LENGTH,
           ),


### PR DESCRIPTION
### Description

Observes changes to `window.name` from within Checkout component when component is a child. Ignores changes from zoid components, as zoid will mutate this itself as part of the popup component lifecycle.

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
