### PR TITLE
refactor: update CA pay later button label

### DIFF
--- a/src/funding/paylater/config.jsx
+++ b/src/funding/paylater/config.jsx
@@ -59,7 +59,7 @@ function getLabelText(
     paylater?.products?.paylater?.variant === "CA" &&
     lang === "fr"
   ) {
-    labelText = "Payer en 4";
+    labelText = "Payer plus tard";
   }
 
   if (paylater?.products?.payIn4?.eligible) {


### PR DESCRIPTION
### Description

update CA pay later button to now read "Payer plus tard" when locale is `fr`

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

updating label to support both pi4 and pay monthly products
### Reproduction Steps (if applicable)
N/A
### Screenshots (if applicable)
<img width="791" height="101" alt="Screenshot 2026-09-16 at 10 09 33 AM" src="https://github.com/user-attachments/assets/1bf7bd6c-7daa-449e-aafa-b761f693a02f" />


### Dependent Changes (if applicable)

xobuyernodeserv

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-smart-payment-buttons). -->
<!-- Are there any additional considerations when deploying this change to production? -->

### Groups who should review (if applicable)

upstream - @surekhaw  @opercy 

<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️ Thank you!
